### PR TITLE
break: Rename onRef prop to wrappedRef.

### DIFF
--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -658,7 +658,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
             onClick={this.handleInputClick}
             onFocus={this.handleInputFocus}
             onKeyDown={this.handleInputKeyDown}
-            onRef={this.handleInputRef}
+            wrappedRef={this.handleInputRef}
             value={value}
           />
 

--- a/packages/core/src/components/DatePickerInput/Input/index.tsx
+++ b/packages/core/src/components/DatePickerInput/Input/index.tsx
@@ -45,12 +45,12 @@ export default class PrivatePickerInput extends DayPickerInput {
 
   private handleRef = (ref: HTMLInputElement | null) => {
     // @ts-ignore Ignore typings
-    const { onRef } = this.props.inputProps;
+    const { wrappedRef } = this.props.inputProps;
 
     this.input = ref;
 
-    if (onRef) {
-      onRef(ref);
+    if (wrappedRef) {
+      wrappedRef(ref);
     }
   };
 
@@ -123,7 +123,7 @@ export default class PrivatePickerInput extends DayPickerInput {
           onKeyDown={this.handleInputKeyDown}
           onKeyUp={this.handleInputKeyUp}
           onClick={this.handleInputClick}
-          onRef={this.handleRef}
+          wrappedRef={this.handleRef}
         />
 
         {this.state.showOverlay && this.renderOverlay()}

--- a/packages/core/src/components/DatePickerInput/README.md
+++ b/packages/core/src/components/DatePickerInput/README.md
@@ -125,7 +125,7 @@ class DatePickerInputDemo extends React.Component {
             label="To"
             name="to-date"
             onChange={this.handleToChange}
-            onRef={this.handleToInputRef}
+            wrappedRef={this.handleToInputRef}
             placeholder="End date"
             value={to}
             datePickerProps={{

--- a/packages/core/src/components/FileInput/index.tsx
+++ b/packages/core/src/components/FileInput/index.tsx
@@ -133,8 +133,7 @@ export default class FileInput extends React.Component<Props, State> {
           type="file"
           tagName="input"
           onChange={this.handleChange}
-          // eslint-disable-next-line
-          onRef={this.ref}
+          wrappedRef={this.ref}
           hidden
         />
 

--- a/packages/core/src/components/TextArea/Proofreader/index.tsx
+++ b/packages/core/src/components/TextArea/Proofreader/index.tsx
@@ -621,10 +621,9 @@ export class Proofreader extends React.Component<Props & WithStylesProps, State,
           value={this.state.text}
           onClick={this.handleTextAreaClick}
           onKeyDown={this.handleTextAreaKeyDown}
-          // eslint-disable-next-line react/jsx-handler-names
-          onRef={this.textareaRef}
           onScroll={this.handleScroll}
           onInput={this.handleInput}
+          wrappedRef={this.textareaRef}
         />
 
         {position && selectedError && (

--- a/packages/core/src/components/private/BaseTextArea.tsx
+++ b/packages/core/src/components/private/BaseTextArea.tsx
@@ -85,7 +85,7 @@ export default class BaseTextArea extends React.Component<Props> {
       this.reflowTextarea();
     }
 
-    passThroughRef(this.props.onRef, ref);
+    passThroughRef(this.props.wrappedRef, ref);
   };
 
   render() {
@@ -95,7 +95,7 @@ export default class BaseTextArea extends React.Component<Props> {
       <FormInput
         {...restProps}
         onChange={this.handleChange}
-        onRef={this.handleRef}
+        wrappedRef={this.handleRef}
         tagName="textarea"
       />
     );

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -34,12 +34,12 @@ export type Props<T = any> = {
   invalid?: boolean;
   /** Add "notranslate" className to prevent Google Chrome translation. */
   noTranslate?: boolean;
-  /** Callback to access the underlying input DOM element. */
-  onRef?: React.Ref<T>;
   /** Mark the field as optional. */
   optional?: boolean;
   /** Current value. */
   value?: string;
+  /** Callback to access the underlying input DOM element. */
+  wrappedRef?: React.Ref<T>;
 };
 
 export type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, IgnoreAttributes> &
@@ -91,7 +91,7 @@ class FormInput extends React.Component<PrivateProps> {
       important,
       invalid,
       noTranslate,
-      onRef,
+      wrappedRef,
       optional,
       styles,
       tagName: Tag,
@@ -134,7 +134,7 @@ class FormInput extends React.Component<PrivateProps> {
     }
 
     // @ts-ignore [ts] JSX element type 'Component' does not have any construct or call signatures. [2604]
-    return <Tag {...props} ref={onRef} data-gramm="false" data-enable-grammarly="false" />;
+    return <Tag {...props} ref={wrappedRef} data-gramm="false" data-enable-grammarly="false" />;
   }
 }
 

--- a/packages/core/test/components/private/BaseTextArea.test.tsx
+++ b/packages/core/test/components/private/BaseTextArea.test.tsx
@@ -152,10 +152,10 @@ describe('<BaseTextArea />', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
-    it('passes to `onRef`', () => {
+    it('passes to `wrappedRef`', () => {
       const spy = jest.fn();
       const wrapper = shallow<BaseTextArea>(
-        <BaseTextArea name="foo" onChange={() => {}} onRef={spy} />,
+        <BaseTextArea name="foo" onChange={() => {}} wrappedRef={spy} />,
       );
 
       // @ts-ignore Allow private access


### PR DESCRIPTION
to: @stefhatcher @hayes @alecklandgraf

## Description

Renames `onRef` form field prop to `wrappedRef`.

## Motivation and Context

The "on" nomenclature is primarily used for callbacks, which this is not. Using `onRef` would also conflict with our ESLint rule, which was annoying. Furthermore, `wrappedRef` is a common prop name for this kind of pattern, so let's standardize.

## Testing

Simple unit tests.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the [CONTRIBUTING](https://github.com/airbnb/lunar/blob/master/.github/CONTRIBUTING.md) document.
