### PR TITLE
new(Apollo,Query,Mutation): Re-export types for consumers.

### DIFF
--- a/packages/apollo/src/components/Mutation/index.tsx
+++ b/packages/apollo/src/components/Mutation/index.tsx
@@ -14,6 +14,8 @@ import renderElementOrFunction, {
   RenderableProp,
 } from '@airbnb/lunar/lib/utils/renderElementOrFunction';
 
+export * from 'react-apollo/Mutation';
+
 export type Props<Data, Vars> = Omit<MutationProps<Data, Vars>, 'client'> & {
   /**
    * Render an element or a function that returns an element when an error occurs.

--- a/packages/apollo/src/components/Query/index.tsx
+++ b/packages/apollo/src/components/Query/index.tsx
@@ -8,6 +8,8 @@ import renderElementOrFunction, {
   RenderableProp,
 } from '@airbnb/lunar/lib/utils/renderElementOrFunction';
 
+export * from 'react-apollo/Query';
+
 export type Props<Data, Vars> = Omit<QueryProps<Data, Vars>, 'children' | 'client'> & {
   /** Child function to render when the data has been received. */
   children: (data: Data | null, result: QueryResult<Data, Vars>) => React.ReactNode;

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -8,6 +8,8 @@ import Mutation from './components/Mutation';
 import Query from './components/Query';
 import Provider from './components/Provider';
 
+export * from 'apollo-client';
+
 export { onError, HttpLink, Mutation, Query, Provider };
 
 export type Settings = {


### PR DESCRIPTION
to: @stefhatcher @hayes @alecklandgraf

## Description

As the title states, re-exports Apollo types downstream.

## Motivation and Context

We've run into a few cases where we need the underlying types, but would need to import them from `apollo-client` or `react-apollo` directly. This usually causes lint errors as those dependencies are transitive (they are in this package, not the application explicitly).

## Testing

I ran build.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
