### PR TITLE
new: Add cross tab closes for toasts

### DIFF
--- a/packages/core/src/components/Toast/index.tsx
+++ b/packages/core/src/components/Toast/index.tsx
@@ -67,7 +67,7 @@ export class Toast extends React.Component<Props & WithStylesProps> {
     window.setTimeout(this.showToast, delay);
 
     if (duration > 0) {
-      this.hideTimer = window.setTimeout(this.handleClosePress, delay + duration);
+      this.hideTimer = window.setTimeout(this.handleClose, delay + duration);
     }
 
     if (crosstabClose) {

--- a/packages/core/src/components/Toast/index.tsx
+++ b/packages/core/src/components/Toast/index.tsx
@@ -8,10 +8,13 @@ import Button from '../Button';
 import Text from '../Text';
 import T from '../Translate';
 import Spacing from '../Spacing';
+import crosstab from '../../crosstab';
 
 const statusPropType = mutuallyExclusiveTrueProps('danger', 'success');
 
 export type Props = {
+  /** Use cross tab events to sync closes for the same toast id across tabs  */
+  crosstabClose?: boolean;
   /** Dangerous/failure status (red). */
   danger?: boolean;
   /** Delay before showing the toast. */
@@ -59,13 +62,21 @@ export class Toast extends React.Component<Props & WithStylesProps> {
   };
 
   componentDidMount() {
-    const { delay = 0, duration = 0 } = this.props;
+    const { delay = 0, duration = 0, crosstabClose } = this.props;
 
     window.setTimeout(this.showToast, delay);
 
     if (duration > 0) {
       this.hideTimer = window.setTimeout(this.handleClosePress, delay + duration);
     }
+
+    if (crosstabClose) {
+      crosstab.on(this.crosstabCloseEvent(), this.handleClose);
+    }
+  }
+
+  componentWillUnmount() {
+    crosstab.off(this.crosstabCloseEvent(), this.handleClose);
   }
 
   showToast = () => {
@@ -77,6 +88,14 @@ export class Toast extends React.Component<Props & WithStylesProps> {
   };
 
   private handleClosePress = () => {
+    this.handleClose();
+
+    if (this.props.crosstabClose) {
+      crosstab.emit(this.crosstabCloseEvent());
+    }
+  };
+
+  private handleClose = () => {
     window.clearTimeout(this.hideTimer);
 
     this.setState({ visible: false }, () => {
@@ -96,6 +115,10 @@ export class Toast extends React.Component<Props & WithStylesProps> {
   /* istanbul ignore next */
   private handleRefreshPress() {
     global.location.reload();
+  }
+
+  private crosstabCloseEvent() {
+    return `toast:crosstabClose:${this.props.id}`;
   }
 
   render() {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds a new option to toasts that allows the close action to be propagated across tabs and close toasts in other tabs with the same id. 

## Motivation and Context

This is useful for cases like websocket events that may trigger toasts in multiple tabs where you want to use to see the toast in the first tab they visit, but don't want to make the user close the toast in each tab. 

## Testing

added tests

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
