### PR TITLE
update(Sheet): Add header bar

### DIFF
--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -10,16 +10,20 @@ class SheetDemo extends React.Component<
   {},
   {
     animated: boolean;
+    compact: boolean;
     gap: boolean;
     headerBar: boolean;
+    headerShadow: boolean;
     portal: boolean;
     visible: boolean;
   }
 > {
   state = {
     animated: true,
+    compact: false,
     gap: false,
     headerBar: false,
+    headerShadow: false,
     portal: false,
     visible: false,
   };
@@ -32,12 +36,20 @@ class SheetDemo extends React.Component<
     this.setState(({ animated }) => ({ animated: !animated }));
   };
 
-  handleGapChange = () => {
+  handleCompactChange() {
+    this.setState(({ compact }) => ({ compact: !compact }));
+  }
+
+  handleGapChange() {
     this.setState(({ gap }) => ({ gap: !gap }));
-  };
+  }
 
   handleHeaderBarChange() {
     this.setState(({ headerBar }) => ({ headerBar: !headerBar }));
+  }
+
+  handleHeaderBarShadowChange() {
+    this.setState(({ headerShadow }) => ({ headerShadow: !headerShadow }));
   }
 
   handlePortalChange() {
@@ -45,7 +57,7 @@ class SheetDemo extends React.Component<
   }
 
   render() {
-    const { animated, gap, headerBar, portal, visible } = this.state;
+    const { animated, compact, gap, headerBar, headerShadow, portal, visible } = this.state;
 
     return (
       <SheetArea>
@@ -75,10 +87,26 @@ class SheetDemo extends React.Component<
           />
 
           <CheckBox
+            noSpacing
             name="header"
             label="Show header bar"
             checked={headerBar}
             onChange={this.handleHeaderBarChange}
+          />
+
+          <CheckBox
+            noSpacing
+            name="headerShadow"
+            label="Show shadow on header bar"
+            checked={headerShadow}
+            onChange={this.handleHeaderBarShadowChange}
+          />
+
+          <CheckBox
+            name="compact"
+            label="Render with compact spacing"
+            checked={compact}
+            onChange={this.handleCompactChange}
           />
 
           <Sheet
@@ -88,6 +116,8 @@ class SheetDemo extends React.Component<
             visible={visible}
             onClose={this.handleClick}
             headerBar={headerBar && <Text>This is the header!</Text>}
+            headerShadow={headerShadow}
+            compact={compact}
           >
             <Spacing inner vertical={12}>
               <Text>This is in a sheet!</Text>

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -89,7 +89,7 @@ class SheetDemo extends React.Component<
           <CheckBox
             noSpacing
             name="header"
-            label="Show header bar"
+            label="Show header"
             checked={header}
             onChange={this.handleHeaderChange}
           />
@@ -97,7 +97,7 @@ class SheetDemo extends React.Component<
           <CheckBox
             noSpacing
             name="headerShadow"
-            label="Show shadow on header bar"
+            label="Show shadow on header"
             checked={headerShadow}
             onChange={this.handleHeaderShadowChange}
           />

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -22,7 +22,7 @@ class SheetDemo extends React.Component<
     animated: true,
     compact: false,
     gap: false,
-    headerBar: false,
+    header: false,
     headerShadow: false,
     portal: false,
     visible: false,

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -11,6 +11,7 @@ class SheetDemo extends React.Component<
   {
     animated: boolean;
     gap: boolean;
+    headerBar: boolean;
     portal: boolean;
     visible: boolean;
   }
@@ -18,6 +19,7 @@ class SheetDemo extends React.Component<
   state = {
     animated: true,
     gap: false,
+    headerBar: false,
     portal: false,
     visible: false,
   };
@@ -34,12 +36,16 @@ class SheetDemo extends React.Component<
     this.setState(({ gap }) => ({ gap: !gap }));
   };
 
-  handlePortalChange = () => {
+  handleHeaderBarChange() {
+    this.setState(({ headerBar }) => ({ headerBar: !headerBar }));
+  }
+
+  handlePortalChange() {
     this.setState(({ portal }) => ({ portal: !portal }));
-  };
+  }
 
   render() {
-    const { animated, gap, portal, visible } = this.state;
+    const { animated, gap, headerBar, portal, visible } = this.state;
 
     return (
       <SheetArea>
@@ -61,10 +67,18 @@ class SheetDemo extends React.Component<
           />
 
           <CheckBox
+            noSpacing
             name="animated"
             label="Render with animation"
             checked={animated}
             onChange={this.handleAnimatedChange}
+          />
+
+          <CheckBox
+            name="header"
+            label="Show header bar"
+            checked={headerBar}
+            onChange={this.handleHeaderBarChange}
           />
 
           <Sheet
@@ -73,6 +87,7 @@ class SheetDemo extends React.Component<
             portal={portal}
             visible={visible}
             onClose={this.handleClick}
+            headerBar={headerBar && <Text>This is the header!</Text>}
           >
             <Spacing inner vertical={12}>
               <Text>This is in a sheet!</Text>

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -12,7 +12,7 @@ class SheetDemo extends React.Component<
     animated: boolean;
     compact: boolean;
     gap: boolean;
-    headerBar: boolean;
+    header: boolean;
     headerShadow: boolean;
     portal: boolean;
     visible: boolean;
@@ -44,11 +44,11 @@ class SheetDemo extends React.Component<
     this.setState(({ gap }) => ({ gap: !gap }));
   };
 
-  handleHeaderBarChange = () => {
-    this.setState(({ headerBar }) => ({ headerBar: !headerBar }));
+  handleHeaderChange = () => {
+    this.setState(({ header }) => ({ header: !header }));
   };
 
-  handleHeaderBarShadowChange = () => {
+  handleHeaderShadowChange = () => {
     this.setState(({ headerShadow }) => ({ headerShadow: !headerShadow }));
   };
 
@@ -57,7 +57,7 @@ class SheetDemo extends React.Component<
   };
 
   render() {
-    const { animated, compact, gap, headerBar, headerShadow, portal, visible } = this.state;
+    const { animated, compact, gap, header, headerShadow, portal, visible } = this.state;
 
     return (
       <SheetArea>
@@ -90,8 +90,8 @@ class SheetDemo extends React.Component<
             noSpacing
             name="header"
             label="Show header bar"
-            checked={headerBar}
-            onChange={this.handleHeaderBarChange}
+            checked={header}
+            onChange={this.handleHeaderChange}
           />
 
           <CheckBox
@@ -99,7 +99,7 @@ class SheetDemo extends React.Component<
             name="headerShadow"
             label="Show shadow on header bar"
             checked={headerShadow}
-            onChange={this.handleHeaderBarShadowChange}
+            onChange={this.handleHeaderShadowChange}
           />
 
           <CheckBox
@@ -115,7 +115,7 @@ class SheetDemo extends React.Component<
             portal={portal}
             visible={visible}
             onClose={this.handleClick}
-            headerBar={headerBar && <Text>This is the header!</Text>}
+            header={header && <Text>This is the header!</Text>}
             headerShadow={headerShadow}
             compact={compact}
           >

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -36,25 +36,25 @@ class SheetDemo extends React.Component<
     this.setState(({ animated }) => ({ animated: !animated }));
   };
 
-  handleCompactChange() {
+  handleCompactChange = () => {
     this.setState(({ compact }) => ({ compact: !compact }));
-  }
+  };
 
-  handleGapChange() {
+  handleGapChange = () => {
     this.setState(({ gap }) => ({ gap: !gap }));
-  }
+  };
 
-  handleHeaderBarChange() {
+  handleHeaderBarChange = () => {
     this.setState(({ headerBar }) => ({ headerBar: !headerBar }));
-  }
+  };
 
-  handleHeaderBarShadowChange() {
+  handleHeaderBarShadowChange = () => {
     this.setState(({ headerShadow }) => ({ headerShadow: !headerShadow }));
-  }
+  };
 
-  handlePortalChange() {
+  handlePortalChange = () => {
     this.setState(({ portal }) => ({ portal: !portal }));
-  }
+  };
 
   render() {
     const { animated, compact, gap, headerBar, headerShadow, portal, visible } = this.state;
@@ -80,6 +80,28 @@ class SheetDemo extends React.Component<
 
           <CheckBox
             noSpacing
+            name="header"
+            label="Show header bar"
+            checked={headerBar}
+            onChange={this.handleHeaderBarChange}
+          />
+
+          <CheckBox
+            noSpacing
+            name="headerShadow"
+            label="Show shadow on header bar"
+            checked={headerShadow}
+            onChange={this.handleHeaderBarShadowChange}
+          />
+
+          <CheckBox
+            name="compact"
+            label="Render with compact spacing"
+            checked={compact}
+            onChange={this.handleCompactChange}
+          />
+
+          <CheckBox
             name="animated"
             label="Render with animation"
             checked={animated}

--- a/packages/core/src/components/Sheet.story.tsx
+++ b/packages/core/src/components/Sheet.story.tsx
@@ -80,28 +80,6 @@ class SheetDemo extends React.Component<
 
           <CheckBox
             noSpacing
-            name="header"
-            label="Show header bar"
-            checked={headerBar}
-            onChange={this.handleHeaderBarChange}
-          />
-
-          <CheckBox
-            noSpacing
-            name="headerShadow"
-            label="Show shadow on header bar"
-            checked={headerShadow}
-            onChange={this.handleHeaderBarShadowChange}
-          />
-
-          <CheckBox
-            name="compact"
-            label="Render with compact spacing"
-            checked={compact}
-            onChange={this.handleCompactChange}
-          />
-
-          <CheckBox
             name="animated"
             label="Render with animation"
             checked={animated}

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -31,6 +31,10 @@ export type Props = {
   noAnimation?: boolean;
   /** Content of the header bar */
   headerBar?: React.ReactNode;
+  /** Render with reduced padding */
+  compact?: boolean;
+  /** Render the header area with a drop-shadow */
+  headerShadow?: boolean;
 };
 
 export type PrivateProps = {
@@ -163,7 +167,17 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
 
   render() {
     const { animating } = this.state;
-    const { gap, theme, styles, portal, visible, children, headerBar } = this.props;
+    const {
+      gap,
+      theme,
+      styles,
+      portal,
+      visible,
+      children,
+      headerBar,
+      compact,
+      headerShadow,
+    } = this.props;
 
     if (!visible && !animating) {
       return null;
@@ -218,13 +232,15 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
                 gap && animating && visible && styles.sheet_slide_in,
               )}
             >
-              <Spacing all={4} bottom={0}>
-                <Row middleAlign before={!gap && closeIcon} after={gap && closeIcon}>
-                  {headerBar || ''}
-                </Row>
-              </Spacing>
+              <div {...css(headerShadow && styles.headerShadow)}>
+                <Spacing all={compact ? 1 : 4} bottom={0}>
+                  <Row middleAlign before={!gap && closeIcon} after={gap && closeIcon}>
+                    {headerBar || ''}
+                  </Row>
+                </Spacing>
+              </div>
 
-              <div {...css(styles.content)}>{children}</div>
+              <div {...css(styles.content, compact && styles.contentCompact)}>{children}</div>
             </div>
           </div>
         </FocusTrap>
@@ -378,6 +394,14 @@ const InternalSheet = withStyles(
       padding: 4 * unit,
       paddingTop: 0,
       flex: 1,
+    },
+
+    contentCompact: {
+      padding: 1 * unit,
+    },
+
+    headerShadow: {
+      boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
     },
   }),
   {

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import IconClose from '@airbnb/lunar-icons/lib/interface/IconClose';
 import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
+import { Z_INDEX_PORTAL } from '../../constants';
 import { ESCAPE } from '../../keys';
 import focusableSelector from '../../utils/focusableSelector';
-import IconButton from '../IconButton';
+import toRGBA from '../../utils/toRGBA';
 import FocusTrap from '../FocusTrap';
+import IconButton from '../IconButton';
 import Portal from '../Portal';
+import Row from '../Row';
+import Spacing from '../Spacing';
 import T from '../Translate';
 import SheetArea from './SheetArea';
 import SheetContext, { Context } from './SheetContext';
-import toRGBA from '../../utils/toRGBA';
-import { Z_INDEX_PORTAL } from '../../constants';
 
 export { SheetArea, SheetContext };
 
@@ -27,6 +29,8 @@ export type Props = {
   gap?: boolean;
   /** Determines if the sheet animates in/out. */
   noAnimation?: boolean;
+  /** Content of the header bar */
+  headerBar?: React.ReactNode;
 };
 
 export type PrivateProps = {
@@ -159,13 +163,18 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
 
   render() {
     const { animating } = this.state;
-    const { gap, theme, styles, portal, visible, children } = this.props;
+    const { gap, theme, styles, portal, visible, children, headerBar } = this.props;
 
     if (!visible && !animating) {
       return null;
     }
 
     const closeText = T.phrase('Close', {}, 'Close a sheet popup');
+    const closeIcon = (
+      <IconButton onClick={this.handleClose}>
+        <IconClose accessibilityLabel={closeText} size={3 * theme!.unit} />
+      </IconButton>
+    );
 
     const sheetContent = (
       <div
@@ -209,11 +218,11 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
                 gap && animating && visible && styles.sheet_slide_in,
               )}
             >
-              <div {...css(styles.closeButton, gap && styles.closeButton_rightAlign)}>
-                <IconButton onClick={this.handleClose}>
-                  <IconClose accessibilityLabel={closeText} size={3 * theme!.unit} />
-                </IconButton>
-              </div>
+              <Spacing all={4} bottom={0}>
+                <Row middleAlign before={!gap && closeIcon} after={gap && closeIcon}>
+                  {headerBar || ''}
+                </Row>
+              </Spacing>
 
               <div {...css(styles.content)}>{children}</div>
             </div>
@@ -362,15 +371,6 @@ const InternalSheet = withStyles(
 
     wrapper_gap: {
       height: 'auto',
-    },
-
-    closeButton: {
-      padding: 4 * unit,
-      paddingBottom: 0,
-    },
-
-    closeButton_rightAlign: {
-      textAlign: 'right',
     },
 
     content: {

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -240,7 +240,7 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
                 </Spacing>
               </div>
 
-              <div {...css(styles.content, compact && styles.contentCompact)}>{children}</div>
+              <div {...css(styles.content, compact && styles.content_compact)}>{children}</div>
             </div>
           </div>
         </FocusTrap>
@@ -396,7 +396,7 @@ const InternalSheet = withStyles(
       flex: 1,
     },
 
-    contentCompact: {
+    content_compact: {
       padding: unit,
     },
 

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -17,24 +17,24 @@ import SheetContext, { Context } from './SheetContext';
 export { SheetArea, SheetContext };
 
 export type Props = {
-  /** Invoked when the sheet close button is pressed, or when escape is pressed when displaying a portal sheet. This function should set the `visible` prop to false. */
-  onClose: () => void;
   /** The contents of the sheet. */
   children: NonNullable<React.ReactNode>;
-  /** Determines if the sheet is currently visible or not. */
-  visible?: boolean;
-  /** Determines if the sheet is displayed as a full-page view that covers the entire application. */
-  portal?: boolean;
-  /** Determines if the sheet has a side gap. */
-  gap?: boolean;
-  /** Determines if the sheet animates in/out. */
-  noAnimation?: boolean;
-  /** Content of the header bar */
-  header?: React.ReactNode;
   /** Render with reduced padding */
   compact?: boolean;
+  /** Determines if the sheet has a side gap. */
+  gap?: boolean;
+  /** Content of the header bar */
+  header?: React.ReactNode;
   /** Render the header area with a drop-shadow */
   headerShadow?: boolean;
+  /** Determines if the sheet animates in/out. */
+  noAnimation?: boolean;
+  /** Invoked when the sheet close button is pressed, or when escape is pressed when displaying a portal sheet. This function should set the `visible` prop to false. */
+  onClose: () => void;
+  /** Determines if the sheet is displayed as a full-page view that covers the entire application. */
+  portal?: boolean;
+  /** Determines if the sheet is currently visible or not. */
+  visible?: boolean;
 };
 
 export type PrivateProps = {

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -30,7 +30,7 @@ export type Props = {
   /** Determines if the sheet animates in/out. */
   noAnimation?: boolean;
   /** Content of the header bar */
-  headerBar?: React.ReactNode;
+  header?: React.ReactNode;
   /** Render with reduced padding */
   compact?: boolean;
   /** Render the header area with a drop-shadow */
@@ -174,7 +174,7 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
       portal,
       visible,
       children,
-      headerBar,
+      header,
       compact,
       headerShadow,
     } = this.props;
@@ -235,7 +235,7 @@ class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, 
               <div {...css(headerShadow && styles.headerShadow)}>
                 <Spacing all={compact ? 1 : 4} bottom={0}>
                   <Row middleAlign before={!gap && closeIcon} after={gap && closeIcon}>
-                    {headerBar || ''}
+                    {header || ''}
                   </Row>
                 </Spacing>
               </div>

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -397,11 +397,11 @@ const InternalSheet = withStyles(
     },
 
     contentCompact: {
-      padding: 1 * unit,
+      padding: unit,
     },
 
     headerShadow: {
-      boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)',
+      boxShadow: ui.boxShadow,
     },
   }),
   {

--- a/packages/core/test/components/Sheet.test.tsx
+++ b/packages/core/test/components/Sheet.test.tsx
@@ -51,7 +51,7 @@ describe('<Sheet />', () => {
       </Sheet>,
     );
 
-    shallow(wrapper.find(Row).prop('before')).simulate('click');
+    shallow(wrapper.find(Row).prop('before') as React.ReactElement).simulate('click');
 
     expect(close).toHaveBeenCalled();
   });

--- a/packages/core/test/components/Sheet.test.tsx
+++ b/packages/core/test/components/Sheet.test.tsx
@@ -1,10 +1,12 @@
+import Enzyme, { mount, shallow } from 'enzyme';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Enzyme, { shallow, mount } from 'enzyme';
 import { mockContextConsumer, unwrapHOCs } from '@airbnb/lunar-test-utils';
-import IconButton from '../../src/components/IconButton';
+import IconButton from '../../lib/components/IconButton';
+import Row from '../../src/components/Row';
 import Sheet from '../../src/components/Sheet';
 import SheetContext from '../../src/components/Sheet/SheetContext';
+import Spacing from '../../src/components/Spacing';
 import { ESCAPE } from '../../src/keys';
 
 describe('<Sheet />', () => {
@@ -49,7 +51,7 @@ describe('<Sheet />', () => {
       </Sheet>,
     );
 
-    wrapper.find(IconButton).simulate('click');
+    shallow(wrapper.find(Row).prop('before')).simulate('click');
 
     expect(close).toHaveBeenCalled();
   });

--- a/packages/core/test/components/Sheet.test.tsx
+++ b/packages/core/test/components/Sheet.test.tsx
@@ -2,11 +2,9 @@ import Enzyme, { mount, shallow } from 'enzyme';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { mockContextConsumer, unwrapHOCs } from '@airbnb/lunar-test-utils';
-import IconButton from '../../lib/components/IconButton';
 import Row from '../../src/components/Row';
 import Sheet from '../../src/components/Sheet';
 import SheetContext from '../../src/components/Sheet/SheetContext';
-import Spacing from '../../src/components/Spacing';
 import { ESCAPE } from '../../src/keys';
 
 describe('<Sheet />', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds a section for sheets to pass in their own header content, could be a title, tool bar, or whatever.

## Motivation and Context

We need a tool bar on sheets


## Screenshots

#### Header
<img width="952" alt="Screen Shot 2019-04-08 at 12 09 53 PM" src="https://user-images.githubusercontent.com/320562/55750051-4c18d200-59f7-11e9-880b-f61da4792a90.png">

#### Header w/ gap
<img width="955" alt="Screen Shot 2019-04-08 at 12 10 48 PM" src="https://user-images.githubusercontent.com/320562/55750085-5fc43880-59f7-11e9-89ee-67262f00d786.png">

#### Header w/ shadow
<img width="789" alt="Screen Shot 2019-04-11 at 3 00 30 PM" src="https://user-images.githubusercontent.com/320562/55995946-cbfaa280-5c6a-11e9-9ec8-e7b5b2583e53.png">

#### Compact
<img width="789" alt="Screen Shot 2019-04-11 at 3 00 37 PM" src="https://user-images.githubusercontent.com/320562/55995947-cbfaa280-5c6a-11e9-9b54-a364aab306ce.png">