### PR TITLE
[WIP] Add(Modal): Add compact mode 

### DIFF
--- a/packages/core/src/components/Modal/README.md
+++ b/packages/core/src/components/Modal/README.md
@@ -182,6 +182,68 @@ class ModalDemo extends React.Component {
 <ModalDemo />;
 ```
 
+Display a compact Modal.
+
+```jsx
+import Button from '../Button';
+import ButtonGroup from '../ButtonGroup';
+import Spacing from '../Spacing';
+import Tooltip from '../Tooltip';
+import Text from '../Text';
+
+class ModalDemo extends React.Component {
+  constructor() {
+    super();
+    this.state = { visible: false };
+    this.handleToggle = () => this.setState({ visible: !this.state.visible });
+    this.handleClose = () => this.setState({ visible: false });
+  }
+
+  render() {
+    const { visible } = this.state;
+    return (
+      <div>
+        <Button onClick={this.handleToggle}>Open a compact modal</Button>
+
+        {visible && (
+          <Modal
+            compact
+            footer={
+              <ButtonGroup>
+                <Button onClick={this.handleToggle}>OK</Button>
+                <Button inverted onClick={this.handleToggle}>
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            }
+            onClose={this.handleClose}
+            title="Modal Header"
+            visible={this.state.visible}
+          >
+            <div>
+              <Text>
+                <div>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam leo erat, lacinia nec
+                  porttitor sed, mollis sed nibh. Nam porta sit amet risus quis interdum. Sed
+                  feugiat lorem vitae augue blandit, sed mollis mi laoreet. Donec auctor, enim eget
+                  tempus auctor, est lorem laoreet nisi, a rutrum dolor quam eget mi. Integer nibh
+                  orci, faucibus in dolor ut, maximus euismod erat. Nam efficitur vulputate augue
+                  non pretium. Suspendisse vitae dui elit. Aliquam erat volutpat. Curabitur rutrum
+                  id elit ut hendrerit. Pellentesque ullamcorper quam a nibh aliquam bibendum. Fusce
+                  at fermentum velit. Phasellus malesuada dapibus tincidunt.
+                </div>
+              </Text>
+            </div>
+          </Modal>
+        )}
+      </div>
+    );
+  }
+}
+
+<ModalDemo />;
+```
+
 Display a Modal with a centered image.
 
 ```jsx

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -66,13 +66,14 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
   };
 
   render() {
-    const { children, footer, image, large, styles, title } = this.props;
+    const { children, footer, image, large, compact, styles, title } = this.props;
     const showLargeContent = large || !!image;
 
     const innerContent = (
       <ModalInnerContent
         footer={footer}
         large={showLargeContent}
+        compact={compact}
         onClose={this.handleClose}
         title={title}
       >

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import IconClose from '@airbnb/lunar-icons/lib/interface/IconClose';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
 import Title from '../../Title';
 import Spacing from '../../Spacing';
 import IconButton from '../../IconButton';
@@ -15,26 +16,36 @@ export type Props = {
   large?: boolean;
   /** Dialog header title. */
   title?: React.ReactNode;
+  /** True to make whole layout compact */
+  compact?: boolean;
   /** Callback for when the Dialog should be closed.  */
   onClose: (event: React.MouseEvent<any> | React.KeyboardEvent) => void;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
-export default function ModalInnerContent({ children, footer, large, onClose, title }: Props) {
+function ModalInnerContent({ children, footer, large, compact, onClose, title, styles }: Props & WithStylesProps) {
   const theme = useTheme();
+  const closeButton = (
+    <IconButton onClick={onClose}>
+      <IconClose
+        accessibilityLabel={T.phrase('Close', {}, 'Close a modal popup')}
+        size={3 * theme.unit}
+      />
+    </IconButton>
+  );
 
   return (
     <Spacing bottom={6} horizontal={4} top={4}>
-      <Spacing bottom={title ? 3 : 0} tag="header">
-        <Spacing bottom={4}>
-          <IconButton onClick={onClose}>
-            <IconClose
-              accessibilityLabel={T.phrase('Close', {}, 'Close a modal popup')}
-              size={3 * theme.unit}
-            />
-          </IconButton>
-        </Spacing>
-
+      <Spacing bottom={title ? 3 : 0} right={compact ? 6 : 0 } tag="header">
+        {compact ? (
+          <div {...css(styles.floatCloseButton)}>
+            {closeButton}
+          </div>
+        ) : (
+          <Spacing bottom={4}>
+            {closeButton}
+          </Spacing>
+        )}
         {title && <Title level={large ? 1 : 3}>{title}</Title>}
       </Spacing>
 
@@ -48,3 +59,11 @@ export default function ModalInnerContent({ children, footer, large, onClose, ti
     </Spacing>
   );
 }
+
+export default withStyles(({ unit }) => ({
+  floatCloseButton: {
+    position: 'absolute',
+    right: 4 * unit,
+  }
+}))(ModalInnerContent);
+

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -219,6 +219,25 @@ describe('<Modal />', () => {
     expect(titleWrapper.prop('children')).toBe('Title wave');
   });
 
+  it('render a large titel when prop large is true', () => {
+    const { wrapper } = setup(
+      {
+        title: 'Title wave',
+        large: true,
+      },
+      false /* isShallow */,
+    );
+
+    const headerWrapper = wrapper
+      .find(Spacing)
+      .find({ tag: 'header' })
+      .first();
+    expect(headerWrapper.prop('bottom')).toEqual(3);
+
+    const titleWrapper = wrapper.find(Title);
+    expect(titleWrapper.prop('level')).toEqual(1);
+  });
+
   it('adjusts header spacing if no title is provided', () => {
     const { wrapper } = setup(
       {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

cc: @kenchendesign  @elibrumbaugh

## Description

This PR is to add the compact mode support for `Modal` component. Tests are added accordingly.

## Motivation and Context

The main goal of this iteration is to reduce the amount of space in the modal header, so that users will read large content more easily. In addition, this iteration added the design for scrollable content, stepped modals and modal appearing transition.

## Testing

Unit test coverage

## Screenshots

![Screen Shot 2019-04-08 at 2 36 58 PM](https://user-images.githubusercontent.com/2024960/55758641-3366e700-5a0c-11e9-8c4c-a9d7935e180f.png)


<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
