### PR TITLE
style(Input, Button, MenuItem): Match padding to design specs

### DIFF
--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -130,7 +130,7 @@ export default withStyles(({ color, font, pattern, unit, transition }) => ({
     ...transition.box,
     ...font.textRegular,
     width: '100%',
-    padding: unit,
+    padding: `${unit}px ${1.5 * unit}px`,
     border: 0,
     textAlign: 'left',
     backgroundColor: 'transparent',

--- a/packages/core/src/themes/buildInputStyles.ts
+++ b/packages/core/src/themes/buildInputStyles.ts
@@ -89,8 +89,6 @@ export default function buildInputStyles({
   return {
     input: {
       ...common,
-      paddingLeft: unit * 1.5,
-      paddingRight: unit * 1.5,
     },
 
     input_important: {

--- a/packages/core/src/themes/buildInputStyles.ts
+++ b/packages/core/src/themes/buildInputStyles.ts
@@ -89,6 +89,8 @@ export default function buildInputStyles({
   return {
     input: {
       ...common,
+      paddingLeft: unit * 1.5,
+      paddingRight: unit * 1.5,
     },
 
     input_important: {

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -109,7 +109,7 @@ export default function buildTheme(
       },
       smallButton: {
         ...font.textSmall,
-        padding: `${unit * 0.75}px ${unit * 1.5}px`,
+        padding: `${unit * 0.75}px ${unit * 1.25}px`,
       },
       regularButton: {
         ...font.textRegular,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -113,7 +113,7 @@ export default function buildTheme(
       },
       regularButton: {
         ...font.textRegular,
-        padding: `${unit * 1.25}px ${unit * 2}px`,
+        padding: `${unit * 1.25}px ${unit * 1.5}px`,
       },
       largeButton: {
         ...font.textLarge,

--- a/packages/core/test/components/Menu/__snapshots__/Item.test.tsx.snap
+++ b/packages/core/test/components/Menu/__snapshots__/Item.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<MenuItem /> renders highlighted 1`] = `
   <ButtonOrLink
     aria-expanded={false}
     aria-haspopup={false}
-    className="item_1b05cuy-o_O-item_highlighted_16ovkzb"
+    className="item_1aie6rd-o_O-item_highlighted_16ovkzb"
     role="menuitem"
     tabIndex={-1}
   >
@@ -27,7 +27,7 @@ exports[`<MenuItem /> renders spacious 1`] = `
   <ButtonOrLink
     aria-expanded={false}
     aria-haspopup={false}
-    className="item_1b05cuy-o_O-item_spacious_1x0fg6n"
+    className="item_1aie6rd-o_O-item_spacious_1x0fg6n"
     role="menuitem"
     tabIndex={-1}
   >

--- a/packages/core/test/components/__snapshots__/Button.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Button.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<Button /> renders loading 1`] = `
 exports[`<Button /> renders small 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1lp5a5w-o_O-button_small_1ghjfam"
+  className="button_1lp5a5w-o_O-button_small_1uh2yjw"
 >
   Button
 </ButtonOrLink>

--- a/packages/core/test/components/__snapshots__/Button.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Button /> renders block 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1lp5a5w-o_O-button_regular_twgt7x-o_O-button_block_2ow2so"
+  className="button_1lp5a5w-o_O-button_regular_jprlrd-o_O-button_block_2ow2so"
 >
   Button
 </ButtonOrLink>
@@ -12,7 +12,7 @@ exports[`<Button /> renders block 1`] = `
 exports[`<Button /> renders borderless 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1lp5a5w-o_O-button_regular_twgt7x-o_O-button_inverted_1fj8x3s-o_O-button_borderless_1j06z2k"
+  className="button_1lp5a5w-o_O-button_regular_jprlrd-o_O-button_inverted_1fj8x3s-o_O-button_borderless_1j06z2k"
 >
   Button
 </ButtonOrLink>
@@ -21,7 +21,7 @@ exports[`<Button /> renders borderless 1`] = `
 exports[`<Button /> renders disabled 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1lp5a5w-o_O-button_regular_twgt7x-o_O-button_disabled_5k6q5e"
+  className="button_1lp5a5w-o_O-button_regular_jprlrd-o_O-button_disabled_5k6q5e"
   disabled={true}
 >
   Button
@@ -31,7 +31,7 @@ exports[`<Button /> renders disabled 1`] = `
 exports[`<Button /> renders inverted 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1lp5a5w-o_O-button_regular_twgt7x-o_O-button_inverted_1fj8x3s"
+  className="button_1lp5a5w-o_O-button_regular_jprlrd-o_O-button_inverted_1fj8x3s"
 >
   Button
 </ButtonOrLink>
@@ -49,7 +49,7 @@ exports[`<Button /> renders large 1`] = `
 exports[`<Button /> renders loading 1`] = `
 <ButtonOrLink
   aria-busy={true}
-  className="button_1lp5a5w-o_O-button_regular_twgt7x-o_O-button_disabled_5k6q5e-o_O-button_loading_1ety1lk"
+  className="button_1lp5a5w-o_O-button_regular_jprlrd-o_O-button_disabled_5k6q5e-o_O-button_loading_1ety1lk"
   loading={true}
 >
   <Loader

--- a/packages/core/test/components/__snapshots__/DangerButton.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/DangerButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<DangerButton /> renders a primary button 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_1aptcl0-o_O-button_regular_twgt7x"
+  className="button_1aptcl0-o_O-button_regular_jprlrd"
 >
   Button
 </ButtonOrLink>

--- a/packages/core/test/components/__snapshots__/MutedButton.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/MutedButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<MutedButton /> renders a secondary button 1`] = `
 <ButtonOrLink
   aria-busy={false}
-  className="button_zv9584-o_O-button_regular_twgt7x"
+  className="button_zv9584-o_O-button_regular_jprlrd"
 >
   Button
 </ButtonOrLink>

--- a/packages/core/test/components/private/__snapshots__/FormInput.test.tsx.snap
+++ b/packages/core/test/components/private/__snapshots__/FormInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<FormInput /> renders compact 1`] = `
 <input
-  className="input_1iiw5o0-o_O-input_compact_dnro66"
+  className="input_1spld4k-o_O-input_compact_dnro66"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -16,7 +16,7 @@ exports[`<FormInput /> renders compact 1`] = `
 
 exports[`<FormInput /> renders important 1`] = `
 <input
-  className="input_1iiw5o0-o_O-input_important_7iy6bw"
+  className="input_1spld4k-o_O-input_important_7iy6bw"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -30,7 +30,7 @@ exports[`<FormInput /> renders important 1`] = `
 
 exports[`<FormInput /> renders select compact 1`] = `
 <select
-  className="input_1iiw5o0-o_O-input_compact_dnro66-o_O-select_173na0f-o_O-select_compact_1lll1pq"
+  className="input_1spld4k-o_O-input_compact_dnro66-o_O-select_173na0f-o_O-select_compact_1lll1pq"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -44,7 +44,7 @@ exports[`<FormInput /> renders select compact 1`] = `
 
 exports[`<FormInput /> sets hidden 1`] = `
 <input
-  className="input_1iiw5o0-o_O-input_hidden_i17vo6"
+  className="input_1spld4k-o_O-input_hidden_i17vo6"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -58,7 +58,7 @@ exports[`<FormInput /> sets hidden 1`] = `
 
 exports[`<FormInput /> supports prefixes 1`] = `
 <input
-  className="input_1iiw5o0-o_O-input_hasPrefix_omi9gr"
+  className="input_1spld4k-o_O-input_hasPrefix_omi9gr"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -72,7 +72,7 @@ exports[`<FormInput /> supports prefixes 1`] = `
 
 exports[`<FormInput /> supports suffixes 1`] = `
 <input
-  className="input_1iiw5o0-o_O-input_hasSuffix_1mimzu3"
+  className="input_1spld4k-o_O-input_hasSuffix_1mimzu3"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}

--- a/packages/core/test/components/private/__snapshots__/FormInput.test.tsx.snap
+++ b/packages/core/test/components/private/__snapshots__/FormInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<FormInput /> renders compact 1`] = `
 <input
-  className="input_1spld4k-o_O-input_compact_dnro66"
+  className="input_1spld4k-o_O-input_compact_zooi1o"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}
@@ -30,7 +30,7 @@ exports[`<FormInput /> renders important 1`] = `
 
 exports[`<FormInput /> renders select compact 1`] = `
 <select
-  className="input_1spld4k-o_O-input_compact_dnro66-o_O-select_173na0f-o_O-select_compact_1lll1pq"
+  className="input_1spld4k-o_O-input_compact_zooi1o-o_O-select_173na0f-o_O-select_compact_1lll1pq"
   data-enable-grammarly="false"
   data-gramm="false"
   disabled={false}


### PR DESCRIPTION
to: @milesj @stefhatcher
cc: @elibrumbaugh

## Description

This PR updates the `Input` and `Menu.Item` to match design and implementation of `Input` and `Row` `Item` padding (and closes #763 in `solar`). It specifically
- decreases `Input` left/right padding from `16px` to `12px` , to match the design spec
- increases `Menu.Item` left/right padding from `8px` to `12px`, to match the design spec (note the original design issue #763 refers to `Autocomplete` items, which are implemented with `Menu.Item`)

**UPDATE**
This also makes the following updates to `Button`, to match the changes to `Input`:
- `small` ~`12, 6`~ => `10, 6` (left/right, top/bottom)
- `regular` ~`16, 10`~ => `12, 10` (now matches default `Input`)
- `large` `20, 12` (no change) 

## Motivation and Context

Design and implementation ideally match ✨ 

## Testing

Functionally verified with style guide.

## Screenshots

#### `Input`
**Before**
![image](https://user-images.githubusercontent.com/4496521/55757919-1e895400-5a0a-11e9-96c3-254a9c0e774a.png)

**After**
![image](https://user-images.githubusercontent.com/4496521/55757928-221cdb00-5a0a-11e9-843d-87f1e6ec4c05.png)


#### `MenuItem`
**Before**
![image](https://user-images.githubusercontent.com/4496521/55757944-2ea13380-5a0a-11e9-8c04-59006ce52df9.png)

**After**
![image](https://user-images.githubusercontent.com/4496521/55757950-3234ba80-5a0a-11e9-974f-2065be4b95e6.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
