### PR TITLE
new(StatusLabel): add `compact` option

### DIFF
--- a/packages/core/src/components/StatusLabel/README.md
+++ b/packages/core/src/components/StatusLabel/README.md
@@ -57,6 +57,13 @@ With a border applied.
 </StatusLabel>
 ```
 
+With compact applied.
+
+```jsx
+<StatusLabel compact>Compact</StatusLabel>
+<StatusLabel compact inverted bordered>Compact</StatusLabel>
+```
+
 Within a block of text.
 
 ```jsx

--- a/packages/core/src/components/StatusLabel/README.md
+++ b/packages/core/src/components/StatusLabel/README.md
@@ -57,11 +57,12 @@ With a border applied.
 </StatusLabel>
 ```
 
-With compact applied.
+With compact padding.
 
 ```jsx
-<StatusLabel compact>Compact</StatusLabel>
-<StatusLabel compact inverted bordered>Compact</StatusLabel>
+<StatusLabel compact uppercased>Compact</StatusLabel>
+<StatusLabel info compact uppercased>Info</StatusLabel>
+<StatusLabel compact info inverted bordered uppercased>Info Inverted</StatusLabel>
 ```
 
 Within a block of text.

--- a/packages/core/src/components/StatusLabel/index.tsx
+++ b/packages/core/src/components/StatusLabel/index.tsx
@@ -15,6 +15,8 @@ export type Props = {
   bordered?: boolean;
   /** Content within the label. */
   children: NonNullable<React.ReactNode>;
+  /** Use compact padding. */
+  compact?: boolean;
   /** Dangerous/failure status (red). */
   danger?: boolean;
   /** Informational status (blue). */
@@ -54,6 +56,7 @@ export class StatusLabel extends React.Component<Props & WithStylesProps> {
     afterIcon: null,
     beforeIcon: null,
     bordered: false,
+    compact: false,
     danger: false,
     info: false,
     inverted: false,
@@ -72,6 +75,7 @@ export class StatusLabel extends React.Component<Props & WithStylesProps> {
       beforeIcon,
       bordered,
       children,
+      compact,
       danger,
       info,
       inverted,
@@ -92,6 +96,7 @@ export class StatusLabel extends React.Component<Props & WithStylesProps> {
           uppercased && styles.label_uppercased,
           inverted && styles.label_inverted,
           bordered && styles.label_bordered,
+          compact && styles.label_compact,
           danger && (inverted ? styles.label_inverted_danger : styles.label_danger),
           info && (inverted ? styles.label_inverted_info : styles.label_info),
           muted && (inverted ? styles.label_inverted_muted : styles.label_muted),
@@ -137,6 +142,13 @@ export default withStyles(({ color, font, ui, unit }) => ({
 
   label_bordered: {
     border: ui.border,
+  },
+
+  label_compact: {
+    paddingLeft: 0.75 * unit,
+    paddingRight: 0.75 * unit,
+    paddingTop: unit / 4,
+    paddingBottom: unit / 4,
   },
 
   label_inverted: {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

cc @elibrumbaugh @jpdanks @conglei

## Description

This PR adds an optional `compact` prop to `StatusLabel` (closes #769 in lunar).

## Motivation and Context

We have uses for compact labels in multiple projects, below are the specs 
<img src="https://user-images.githubusercontent.com/4496521/55762646-93fc2100-5a18-11e9-8b5b-7c57afff3dca.png" width="200" />

## Testing

Functional tests with style guide (didn't add additional snapshot tests since we are moving away from them)

## Screenshots

New style guide 
![image](https://user-images.githubusercontent.com/4496521/55762607-7038db00-5a18-11e9-9f57-df4b75268b01.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
