### PR TITLE
update(FormActions): Add danger prop

### DIFF
--- a/packages/core/src/components/FormActions/README.md
+++ b/packages/core/src/components/FormActions/README.md
@@ -21,10 +21,10 @@ With no cancel button.
 <FormActions hideCancel />
 ```
 
-With a reset button.
+With a reset button and a danger state.
 
 ```jsx
-<FormActions showReset />
+<FormActions showReset danger />
 ```
 
 With small buttons in a processing state.

--- a/packages/core/src/components/FormActions/index.tsx
+++ b/packages/core/src/components/FormActions/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import T from '../Translate';
-import Button from '../Button';
+import NormalButton from '../Button';
+import DangerButton from '../DangerButton';
+import MutedButton from '../MutedButton';
 import ButtonGroup from '../ButtonGroup';
 
 export type Props = {
@@ -8,6 +10,8 @@ export type Props = {
   cancelText?: React.ReactNode;
   /** Text to display in the continue/submit button. Defaults to "Submit". */
   continueText?: React.ReactNode;
+  /** Render a danger button over a regular button. */
+  danger?: boolean;
   /** Whether to disable the continue button. */
   disabled?: boolean;
   /** Hide the cancel button. */
@@ -33,6 +37,7 @@ export default class FormActions extends React.PureComponent<Props> {
   static defaultProps = {
     cancelText: null,
     continueText: null,
+    danger: false,
     disabled: false,
     hideCancel: false,
     processing: false,
@@ -46,6 +51,7 @@ export default class FormActions extends React.PureComponent<Props> {
     const {
       cancelText,
       continueText,
+      danger,
       disabled,
       hideCancel,
       onCancel,
@@ -56,6 +62,7 @@ export default class FormActions extends React.PureComponent<Props> {
       showReset,
       small,
     } = this.props;
+    const Button = danger ? DangerButton : NormalButton;
 
     return (
       <ButtonGroup>
@@ -74,15 +81,15 @@ export default class FormActions extends React.PureComponent<Props> {
         </Button>
 
         {!hideCancel && (
-          <Button inverted onClick={onCancel} small={small} disabled={processing}>
+          <MutedButton inverted onClick={onCancel} small={small} disabled={processing}>
             {cancelText || <T phrase="Cancel" context="Button label to cancel a form action" />}
-          </Button>
+          </MutedButton>
         )}
 
         {showReset && (
-          <Button type="reset" inverted small={small} disabled={processing}>
+          <MutedButton type="reset" inverted small={small} disabled={processing}>
             {resetText || <T phrase="Reset" context="Button label to reset a form" />}
-          </Button>
+          </MutedButton>
         )}
       </ButtonGroup>
     );

--- a/packages/core/test/components/FormActions.test.tsx
+++ b/packages/core/test/components/FormActions.test.tsx
@@ -2,63 +2,51 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FormActions from '../../src/components/FormActions';
 import Button from '../../src/components/Button';
+import DangerButton from '../../src/components/DangerButton';
+import MutedButton from '../../src/components/MutedButton';
 
 describe('<FormField />', () => {
   it('renders 2 buttons', () => {
     const wrapper = shallow(<FormActions />).dive();
 
-    expect(wrapper.find(Button)).toHaveLength(2);
-    expect(
-      wrapper
-        .find(Button)
-        .at(0)
-        .prop('type'),
-    ).toBe('submit');
-    expect(
-      wrapper
-        .find(Button)
-        .at(1)
-        .prop('inverted'),
-    ).toBe(true);
+    expect(wrapper.find(Button)).toHaveLength(1);
+    expect(wrapper.find(MutedButton)).toHaveLength(1);
+    expect(wrapper.find(Button).prop('type')).toBe('submit');
+    expect(wrapper.find(MutedButton).prop('inverted')).toBe(true);
   });
 
   it('renders 3 buttons with reset', () => {
     const wrapper = shallow(<FormActions showReset />).dive();
 
-    expect(wrapper.find(Button)).toHaveLength(3);
+    expect(wrapper.find(Button)).toHaveLength(1);
+    expect(wrapper.find(MutedButton)).toHaveLength(2);
+  });
+
+  it('renders a danger button', () => {
+    const wrapper = shallow(<FormActions danger />).dive();
+
+    expect(wrapper.find(Button)).toHaveLength(0);
+    expect(wrapper.find(DangerButton)).toHaveLength(1);
   });
 
   it('can change button text', () => {
     const wrapper = shallow(<FormActions cancelText="Close" continueText="Send" />).dive();
 
-    expect(
-      wrapper
-        .find(Button)
-        .at(0)
-        .prop('children'),
-    ).toBe('Send');
-    expect(
-      wrapper
-        .find(Button)
-        .at(1)
-        .prop('children'),
-    ).toBe('Close');
+    expect(wrapper.find(Button).prop('children')).toBe('Send');
+    expect(wrapper.find(MutedButton).prop('children')).toBe('Close');
   });
 
   it('can hide cancel button', () => {
     const wrapper = shallow(<FormActions hideCancel />).dive();
 
-    expect(wrapper.find(Button)).toHaveLength(1);
+    expect(wrapper.find(MutedButton)).toHaveLength(0);
   });
 
   it('triggers `onContinue` when clicked', () => {
     const spy = jest.fn();
     const wrapper = shallow(<FormActions onContinue={spy} />).dive();
 
-    wrapper
-      .find(Button)
-      .at(0)
-      .simulate('click');
+    wrapper.find(Button).simulate('click');
 
     expect(spy).toHaveBeenCalled();
   });
@@ -67,10 +55,7 @@ describe('<FormField />', () => {
     const spy = jest.fn();
     const wrapper = shallow(<FormActions onCancel={spy} />).dive();
 
-    wrapper
-      .find(Button)
-      .at(1)
-      .simulate('click');
+    wrapper.find(MutedButton).simulate('click');
 
     expect(spy).toHaveBeenCalled();
   });
@@ -78,12 +63,7 @@ describe('<FormField />', () => {
   it('disables button when disabled', () => {
     const wrapper = shallow(<FormActions disabled />).dive();
 
-    expect(
-      wrapper
-        .find(Button)
-        .at(0)
-        .prop('disabled'),
-    ).toBe(true);
+    expect(wrapper.find(Button).prop('disabled')).toBe(true);
   });
 
   it('disables buttons while processing', () => {
@@ -98,21 +78,18 @@ describe('<FormField />', () => {
   it('shows processing text while processing', () => {
     const wrapper = shallow(<FormActions processing processingText="Sending" />).dive();
 
-    expect(
-      wrapper
-        .find(Button)
-        .at(0)
-        .prop('children'),
-    ).toBe('Sending');
+    expect(wrapper.find(Button).prop('children')).toBe('Sending');
   });
 
   it('has small buttons when small', () => {
     const wrapper = shallow(<FormActions showReset small />).dive();
+
     wrapper.find(Button).forEach(button => expect(button.prop('small')).toBeTruthy());
   });
 
   it('does not habe small buttons when not small', () => {
     const wrapper = shallow(<FormActions showReset />).dive();
+
     wrapper.find(Button).forEach(button => expect(button.prop('small')).toBeFalsy());
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds a `danger` prop to toggle between normal `Button` and `DangerButton`. Also updated the secondary buttons to `MutedButton`.

## Motivation and Context

Matches new designs.

## Testing

Unit tests.

## Screenshots

<img width="297" alt="Screen Shot 2019-04-15 at 1 25 23 PM" src="https://user-images.githubusercontent.com/143744/56162933-fc4f8300-5f81-11e9-8ab0-7b6dff276dcb.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
