### PR TITLE
new(Grid): Add horizontal alignment props. Fix offset % definition.

### DIFF
--- a/packages/core/src/components/Grid.story.tsx
+++ b/packages/core/src/components/Grid.story.tsx
@@ -170,11 +170,38 @@ storiesOf('Core/Grid', module)
   .add('Supports columns with offsets for advanced spacing.', () => (
     <Text>
       <Grid>
+        <Col span={12}>
+          <Box>12</Box>
+        </Col>
+      </Grid>
+      <br />
+      <Grid>
         <Col span={7}>
           <Box>7</Box>
         </Col>
         <Col span={4} offset={1}>
           <Box>4 + 1 offset</Box>
+        </Col>
+      </Grid>
+    </Text>
+  ))
+  .add('Can align children along the horizontal axis (default is space-between)', () => (
+    <Text>
+      <Grid leftAlign>
+        <Col span={6}>
+          <Box>6</Box>
+        </Col>
+      </Grid>
+      <br />
+      <Grid centered>
+        <Col span={6}>
+          <Box>6</Box>
+        </Col>
+      </Grid>
+      <br />
+      <Grid rightAlign>
+        <Col span={6}>
+          <Box>6</Box>
         </Col>
       </Grid>
     </Text>

--- a/packages/core/src/components/Grid.story.tsx
+++ b/packages/core/src/components/Grid.story.tsx
@@ -187,19 +187,19 @@ storiesOf('Core/Grid', module)
   ))
   .add('Can align children along the horizontal axis (default is space-between)', () => (
     <Text>
-      <Grid leftAlign>
+      <Grid startAlign>
         <Col span={6}>
           <Box>6</Box>
         </Col>
       </Grid>
       <br />
-      <Grid centered>
+      <Grid centerAlign>
         <Col span={6}>
           <Box>6</Box>
         </Col>
       </Grid>
       <br />
-      <Grid rightAlign>
+      <Grid endAlign>
         <Col span={6}>
           <Box>6</Box>
         </Col>

--- a/packages/core/src/components/Grid/Col.tsx
+++ b/packages/core/src/components/Grid/Col.tsx
@@ -47,7 +47,7 @@ export default withStyles(({ unit }) => {
     };
 
     offsets[`offset${offset}`] = {
-      marginLeft: offset > 0 ? 100 / (12 / offset) : 0,
+      marginLeft: offset > 0 ? `${100 / (12 / offset)}%` : 0,
     };
 
     return span;

--- a/packages/core/src/components/Grid/index.tsx
+++ b/packages/core/src/components/Grid/index.tsx
@@ -3,24 +3,24 @@ import { childrenOfType, mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 import Col from './Col';
 
-const horizontalAlignProp = mutuallyExclusiveTrueProps('centered', 'leftAlign', 'rightAlign');
+const horizontalAlignProp = mutuallyExclusiveTrueProps('centerAlign', 'startAlign', 'endAlign');
 const verticalAlignProp = mutuallyExclusiveTrueProps('bottomAlign', 'middleAlign', 'topAlign');
 
 export type Props = {
   /** Vertically align the columns at the bottom. */
   bottomAlign?: boolean;
   /** Horizontally align the columns to the center. */
-  centered?: boolean;
+  centerAlign?: boolean;
   /** Columns to render. */
   children: NonNullable<React.ReactNode>;
-  /** Horizontally align the columns to the left (flex-start). */
-  leftAlign?: boolean;
+  /** Horizontally align the columns to the end (flex-end). */
+  endAlign?: boolean;
   /** Vertically align the columns in the middle. */
   middleAlign?: boolean;
   /** Reverse the order of columns. */
   reversed?: boolean;
-  /** Horizontally align the columns to the left (flex-end). */
-  rightAlign?: boolean;
+  /** Horizontally align the columns to the start (flex-start). */
+  startAlign?: boolean;
   /** Vertically align the columns at the top. */
   topAlign?: boolean;
 };
@@ -29,33 +29,33 @@ export type Props = {
 export class Grid extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     bottomAlign: verticalAlignProp,
-    centered: horizontalAlignProp,
+    centerAlign: horizontalAlignProp,
     children: childrenOfType(Col).isRequired,
-    leftAlign: horizontalAlignProp,
+    endAlign: horizontalAlignProp,
     middleAlign: verticalAlignProp,
-    rightAlign: horizontalAlignProp,
+    startAlign: horizontalAlignProp,
     topAlign: verticalAlignProp,
   };
 
   static defaultProps = {
     bottomAlign: false,
-    centered: false,
-    leftAlign: false,
+    centerAlign: false,
+    endAlign: false,
     middleAlign: false,
     reversed: false,
-    rightAlign: false,
+    startAlign: false,
     topAlign: false,
   };
 
   render() {
     const {
       bottomAlign,
-      centered,
+      centerAlign,
       children,
-      leftAlign,
+      endAlign,
       middleAlign,
       reversed,
-      rightAlign,
+      startAlign,
       styles,
       topAlign,
     } = this.props;
@@ -68,9 +68,9 @@ export class Grid extends React.Component<Props & WithStylesProps> {
           bottomAlign && styles.grid_bottom,
           middleAlign && styles.grid_middle,
           topAlign && styles.grid_top,
-          leftAlign && styles.grid_left,
-          rightAlign && styles.grid_right,
-          centered && styles.grid_centered,
+          startAlign && styles.grid_start,
+          endAlign && styles.grid_end,
+          centerAlign && styles.grid_center,
         )}
       >
         {children}
@@ -97,15 +97,15 @@ export default withStyles(({ unit }) => ({
     flexDirection: 'row-reverse',
   },
 
-  grid_centered: {
+  grid_center: {
     justifyContent: 'center',
   },
 
-  grid_left: {
+  grid_start: {
     justifyContent: 'flex-start',
   },
 
-  grid_right: {
+  grid_end: {
     justifyContent: 'flex-end',
   },
 

--- a/packages/core/src/components/Grid/index.tsx
+++ b/packages/core/src/components/Grid/index.tsx
@@ -3,17 +3,24 @@ import { childrenOfType, mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 import Col from './Col';
 
-const alignProp = mutuallyExclusiveTrueProps('bottomAlign', 'middleAlign', 'topAlign');
+const horizontalAlignProp = mutuallyExclusiveTrueProps('centered', 'leftAlign', 'rightAlign');
+const verticalAlignProp = mutuallyExclusiveTrueProps('bottomAlign', 'middleAlign', 'topAlign');
 
 export type Props = {
   /** Vertically align the columns at the bottom. */
   bottomAlign?: boolean;
+  /** Horizontally align the columns to the center. */
+  centered?: boolean;
   /** Columns to render. */
   children: NonNullable<React.ReactNode>;
+  /** Horizontally align the columns to the left (flex-start). */
+  leftAlign?: boolean;
   /** Vertically align the columns in the middle. */
   middleAlign?: boolean;
   /** Reverse the order of columns. */
   reversed?: boolean;
+  /** Horizontally align the columns to the left (flex-end). */
+  rightAlign?: boolean;
   /** Vertically align the columns at the top. */
   topAlign?: boolean;
 };
@@ -21,21 +28,37 @@ export type Props = {
 /** A grid to contain columns. */
 export class Grid extends React.Component<Props & WithStylesProps> {
   static propTypes = {
-    bottomAlign: alignProp,
+    bottomAlign: verticalAlignProp,
+    centered: horizontalAlignProp,
     children: childrenOfType(Col).isRequired,
-    middleAlign: alignProp,
-    topAlign: alignProp,
+    leftAlign: horizontalAlignProp,
+    middleAlign: verticalAlignProp,
+    rightAlign: horizontalAlignProp,
+    topAlign: verticalAlignProp,
   };
 
   static defaultProps = {
     bottomAlign: false,
+    centered: false,
+    leftAlign: false,
     middleAlign: false,
     reversed: false,
+    rightAlign: false,
     topAlign: false,
   };
 
   render() {
-    const { children, reversed, styles, bottomAlign, middleAlign, topAlign } = this.props;
+    const {
+      bottomAlign,
+      centered,
+      children,
+      leftAlign,
+      middleAlign,
+      reversed,
+      rightAlign,
+      styles,
+      topAlign,
+    } = this.props;
 
     return (
       <section
@@ -45,6 +68,9 @@ export class Grid extends React.Component<Props & WithStylesProps> {
           bottomAlign && styles.grid_bottom,
           middleAlign && styles.grid_middle,
           topAlign && styles.grid_top,
+          leftAlign && styles.grid_left,
+          rightAlign && styles.grid_right,
+          centered && styles.grid_centered,
         )}
       >
         {children}
@@ -69,6 +95,18 @@ export default withStyles(({ unit }) => ({
 
   grid_reversed: {
     flexDirection: 'row-reverse',
+  },
+
+  grid_centered: {
+    justifyContent: 'center',
+  },
+
+  grid_left: {
+    justifyContent: 'flex-start',
+  },
+
+  grid_right: {
+    justifyContent: 'flex-end',
   },
 
   grid_top: {

--- a/packages/core/test/components/Grid.test.tsx
+++ b/packages/core/test/components/Grid.test.tsx
@@ -14,7 +14,15 @@ describe('<Grid />', () => {
     expect(wrapper.find(Col)).toHaveLength(2);
   });
 
-  ['topAlign', 'middleAlign', 'bottomAlign', 'reversed'].forEach(type => {
+  [
+    'bottomAlign',
+    'centered',
+    'leftAlign',
+    'middleAlign',
+    'reversed',
+    'rightAlign',
+    'topAlign',
+  ].forEach(type => {
     it(`renders ${type}`, () => {
       const wrapper = shallow(
         <Grid {...{ [type]: true }}>

--- a/packages/core/test/components/Grid.test.tsx
+++ b/packages/core/test/components/Grid.test.tsx
@@ -16,11 +16,11 @@ describe('<Grid />', () => {
 
   [
     'bottomAlign',
-    'centered',
-    'leftAlign',
+    'centerAlign',
+    'endAlign',
     'middleAlign',
     'reversed',
-    'rightAlign',
+    'startAlign',
     'topAlign',
   ].forEach(type => {
     it(`renders ${type}`, () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

<!--- Describe your change in detail. -->
these updates help make single column grid layouts more flexible with horizontal alignments:
- `startAlign` for `justify-content: flex-start`
- `centerAlign` for `justify-content: center`
- `endAlign` for `justify-content: flex-end`

also noticed that the offsets were being calculated as `px` instead of `%`. added a fix for that!

updated storybook to demonstrate the changes.

## Motivation and Context

tried to do a single column, centered by offsets and couldn't achieve it. this'll help!

## Testing

<!--- Please describe in detail how you tested your change. -->
storybook examples

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->
<img width="1279" alt="Storybook 2019-04-19 14-20-26" src="https://user-images.githubusercontent.com/306275/56444638-62a01280-62ae-11e9-8d6a-daaf8db82c66.png">
<img width="1279" alt="Screen Shot 2019-04-19 at 2 20 55 PM" src="https://user-images.githubusercontent.com/306275/56444639-62a01280-62ae-11e9-81c6-93c189e7514b.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
