### PR TITLE
new(HierarchyPicker): Add new picker component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8602,24 +8602,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -8629,12 +8629,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8643,28 +8643,28 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
@@ -8679,25 +8679,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -8706,13 +8706,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -8728,7 +8728,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
@@ -8742,13 +8742,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -8757,7 +8757,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -8766,7 +8766,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -8776,18 +8776,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -8795,13 +8795,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -8809,12 +8809,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -8823,7 +8823,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
@@ -8832,7 +8832,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -8875,7 +8875,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -8901,7 +8901,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -8913,18 +8913,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -8932,19 +8932,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -8954,19 +8954,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -8978,7 +8978,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -8986,7 +8986,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -9001,7 +9001,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
@@ -9010,18 +9010,18 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
@@ -9033,19 +9033,19 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -9055,7 +9055,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -9064,7 +9064,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -9072,13 +9072,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
@@ -9093,13 +9093,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -9108,12 +9108,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
@@ -9159,6 +9159,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.4.tgz",
+      "integrity": "sha512-pyLQo/1oR5Ywf+a/tY8z4JygnIglmRxVUOiyFAbd11o9keUDpUJSMGRWJngcnkURj30kDHPmhoKY8ChJiz3EpQ=="
     },
     "fuzzy-search": {
       "version": "3.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "debounce-promise": "^3.1.0",
     "emojibase": "^2.2.0",
     "emojibase-regex": "^2.0.1",
+    "fuse.js": "^3.4.4",
     "hoist-non-react-statics": "^3.3.0",
     "interweave": "^10.1.3",
     "interweave-autolink": "^2.2.3",

--- a/packages/core/src/components/HierarchyPicker.story.tsx
+++ b/packages/core/src/components/HierarchyPicker.story.tsx
@@ -323,7 +323,11 @@ storiesOf('Core/HierarchyPicker', module)
       searchWidth={500}
       searchMaxHeight={150}
       items={demoItems2}
-      chosen={['Team 3', 'Team 3b']}
+      chosen={[
+        demoItems2[1].name,
+        demoItems2[1].items![2].name,
+        demoItems2[1].items![2].items![1].name,
+      ]}
     />
   ))
   .add('Disabled', () => <PickerDemo items={demoItems} disabled />)

--- a/packages/core/src/components/HierarchyPicker.story.tsx
+++ b/packages/core/src/components/HierarchyPicker.story.tsx
@@ -1,0 +1,330 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import HierarchyPicker, { Props } from './HierarchyPicker';
+import Button from './Button';
+
+const demoItems = [
+  {
+    name: 'Item 1',
+    label: 'Custom label',
+    readonly: true,
+    items: [
+      {
+        name: 'Item 1a',
+        readonly: true,
+        items: [
+          {
+            name: 'Item 1a i',
+          },
+          {
+            name: 'Item 1a ii (description)',
+            description: 'A little bit of info.',
+          },
+        ],
+      },
+      {
+        name: 'Item 1b',
+        readonly: true,
+        items: [
+          {
+            name: 'Item 1b i',
+          },
+        ],
+      },
+      {
+        name: 'Item 1c',
+        label: 'Item 1c (description)',
+        description:
+          'Something that does not fit in the other categories in this taxonomy, like an apple, a pear, a plum, or maybe the distant call of a long lost friend.',
+        keywords: 'bonjour Bonsoir',
+      },
+      {
+        name: 'Funtastic Testing',
+        label: 'Amazing Testing',
+        description: 'Something something testing',
+        keywords: 'Specific thing testing',
+      },
+    ],
+  },
+  {
+    name: 'Item 2 (clickable)',
+    items: [
+      {
+        name: 'Item 2a',
+      },
+      {
+        name: 'Item 2b',
+      },
+      {
+        name: 'Item 2c',
+      },
+      {
+        name: 'Item 2d (clickable)',
+        items: [
+          {
+            name: 'Item 2d i (description)',
+            description: 'Description of the item',
+          },
+        ],
+      },
+      {
+        name: 'Item 2e (not clickable)',
+        readonly: true,
+        items: [
+          {
+            name: 'Item 2e i (description)',
+            description: 'Description of the item',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Item 3 (not clickable)',
+    readonly: true,
+    items: [
+      {
+        name: 'Should not see me',
+        readonly: true,
+        items: [
+          {
+            name: 'nested',
+            readonly: true,
+          },
+        ],
+      },
+      {
+        name: 'Item 3b (others filtered)',
+      },
+      {
+        name: 'Should not see me 2',
+        readonly: true,
+      },
+    ],
+  },
+  {
+    name: 'Item 4 (description)',
+    section: 'Section label',
+    description:
+      'Description of the item. It is clickable and searchable. It can be long and will wrap.',
+  },
+  {
+    name: 'Item 5',
+    label: 'Item with long label & overflown description',
+    description:
+      'testingoverflowtestingoverflowtestingoverflowtestingoverflowtestingoverflowtestingoverflowtestingoverflowtestingoverflow',
+  },
+];
+
+const demoItems2 = [
+  {
+    section: 'Top-level teams',
+    name: 'Team 1',
+    readonly: true,
+    items: [
+      {
+        section: 'Sub-teams',
+        name: 'Team 1a',
+        readonly: true,
+        items: [
+          {
+            section: 'Sub-sub-teams',
+            name: 'Team 1a i',
+          },
+          {
+            name: 'Team 1a ii',
+          },
+          {
+            name: 'Team 1a iii',
+          },
+        ],
+      },
+      {
+        name: 'Team 1b',
+      },
+      {
+        name: 'Team 1c',
+        readonly: true,
+        items: [
+          {
+            section: 'Sub-sub-teams',
+            name: 'Team 1c i',
+          },
+          {
+            name: 'Team 1c ii',
+          },
+          {
+            name: 'Team 1c iii',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Team 2 (clickable)',
+    items: [
+      {
+        section: 'Sub-teams',
+        name: 'Team 2a',
+      },
+      {
+        name: 'Team 2b',
+      },
+      {
+        name: 'Team 2c',
+        readonly: true,
+        items: [
+          {
+            section: 'Sub-sub-teams',
+            name: 'Team 2c i',
+          },
+          {
+            name: 'Team 2c ii',
+          },
+          {
+            name: 'Team 2c iii',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Team 3 (not clickable)',
+    readonly: true,
+    items: [
+      {
+        section: 'Sub-teams',
+        name: 'Team 3a',
+      },
+      {
+        name: 'Team 3b',
+        readonly: true,
+        items: [
+          {
+            section: 'Sub-sub-teams',
+            name: 'Team 3b i',
+          },
+          {
+            name: 'Team 3b ii',
+          },
+          {
+            name: 'Team 3b iii',
+          },
+        ],
+      },
+      {
+        name: 'Team 3c',
+      },
+    ],
+  },
+  {
+    name: 'Team no-sub-teams',
+  },
+  {
+    name: 'Team (description)',
+    description:
+      'Description of the item. It is clickable and searchable. It can be long and will wrap.',
+  },
+  {
+    name: 'Overflown sub-teams',
+    readonly: true,
+    items: [
+      {
+        section: 'Sub-teams',
+        name: 'Team 4a',
+      },
+      {
+        name: 'Team 4b',
+      },
+      {
+        name: 'Team 4c',
+        readonly: true,
+        items: [
+          {
+            section: 'Sub-sub-teams',
+            name: 'Team 4c i',
+          },
+        ],
+      },
+      {
+        name: 'Team 4d',
+      },
+      {
+        name: 'Team 4e',
+      },
+      {
+        name: 'Team 4f',
+      },
+      {
+        name: 'Team 4g',
+      },
+      {
+        name: 'Team 4h',
+      },
+      {
+        name: 'Team 4i',
+      },
+      {
+        name: 'Team 4j',
+      },
+    ],
+  },
+];
+
+class PickerDemo extends React.Component<Partial<Props>, { chosen: Props['chosen'] }> {
+  state = { chosen: undefined };
+
+  render() {
+    const { items = [], chosen: initChosen, ...passThroughProps } = this.props;
+    const { chosen = initChosen } = this.state;
+
+    return (
+      <>
+        <HierarchyPicker
+          items={items}
+          chosen={chosen}
+          searchWidth={400}
+          onItemPicked={(nextChosen: Props['chosen']) => {
+            console.log(nextChosen);
+            this.setState({ chosen: nextChosen || undefined });
+          }}
+          searchPlaceholder="Search all the things"
+          noResultsLabel="No results match your query."
+          {...passThroughProps}
+        />
+        <br />
+        <Button>Padding test</Button>
+      </>
+    );
+  }
+}
+
+storiesOf('Core/HierarchyPicker', module)
+  .addParameters({
+    inspectComponents: [HierarchyPicker],
+  })
+  .add('Vertically offset menu', () => <PickerDemo items={demoItems} />)
+  .add('Vertically aligned menu', () => <PickerDemo items={demoItems} verticallyAlign />)
+  .add('With sub-sections and hierarchy dimensions', () => (
+    <PickerDemo items={demoItems2} verticallyAlign hierarchyMaxHeight={272} hierarchyWidth={260} />
+  ))
+  .add('With chosen value', () => (
+    <PickerDemo items={demoItems} chosen={['Item 1', 'Funtastic Testing']} />
+  ))
+  .add('Custom hierarchy width', () => (
+    <PickerDemo
+      hierarchyWidth={150}
+      items={demoItems2}
+      chosen={[demoItems2[1].name, demoItems2[1].items![2].name]}
+    />
+  ))
+  .add('Custom search dimensions', () => (
+    <PickerDemo
+      searchWidth={500}
+      searchMaxHeight={150}
+      items={demoItems2}
+      chosen={['Team 3', 'Team 3b']}
+    />
+  ))
+  .add('Disabled', () => <PickerDemo items={demoItems} disabled />)
+  .add('Invalid', () => <PickerDemo items={demoItems} invalid />);

--- a/packages/core/src/components/HierarchyPicker.story.tsx
+++ b/packages/core/src/components/HierarchyPicker.story.tsx
@@ -284,7 +284,7 @@ class PickerDemo extends React.Component<Partial<Props>, { chosen: Props['chosen
           items={items}
           chosen={chosen}
           searchWidth={400}
-          onItemPicked={(nextChosen: Props['chosen']) => {
+          onItemPicked={(nextChosen: string[] | null) => {
             console.log(nextChosen);
             this.setState({ chosen: nextChosen || undefined });
           }}

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
+import IconCheckmark from '@airbnb/lunar-icons/lib/interface/IconCheck';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import { ENTER, SPACE, ARROW_RIGHT, ARROW_LEFT } from '../../../keys';
+import Text from '../../Text';
+import {
+  ItemPickedHandler,
+  DeepFocusHandler,
+  ShallowFocusHandler,
+  TreePath,
+  SubTreeHandler,
+  ItemShape,
+  ItemRenderer,
+} from '../types';
+
+export type Props = {
+  item: ItemShape;
+  definition: TreePath;
+  renderItem?: ItemRenderer;
+  selected: boolean;
+  focused: boolean;
+  onSubtree: SubTreeHandler;
+  onItemPicked: ItemPickedHandler;
+  onDomFocusDeeper: DeepFocusHandler;
+  onDomFocusShallower: ShallowFocusHandler;
+};
+
+const ICON_SIZE = 18;
+
+class HierarchyItem extends React.Component<Props & WithStylesProps> {
+  maybePick = () => {
+    const { onItemPicked, item, definition } = this.props;
+
+    if (item.readonly) {
+      onItemPicked(null);
+      this.goDeeper();
+    } else {
+      onItemPicked(definition);
+    }
+  };
+
+  goDeeper = () => {
+    const { onSubtree, onDomFocusDeeper, definition, item } = this.props;
+
+    if (item.items || item.description) {
+      onSubtree(definition, onDomFocusDeeper, true);
+    }
+  };
+
+  goShallower = () => {
+    const { onSubtree, onDomFocusShallower, definition } = this.props;
+
+    onDomFocusShallower();
+    onSubtree(definition.slice(0, -2), undefined, true);
+  };
+
+  private handleClick = () => {
+    this.maybePick();
+  };
+
+  private handleMouseMove = () => {
+    const { onSubtree, definition } = this.props;
+
+    onSubtree(definition);
+  };
+
+  private handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case ENTER:
+      case SPACE:
+        this.maybePick();
+        break;
+
+      case ARROW_RIGHT:
+        this.goDeeper();
+        break;
+
+      case ARROW_LEFT:
+        this.goShallower();
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  renderItem = () => {
+    const { focused, item, styles, selected, renderItem, theme } = this.props;
+
+    return renderItem ? (
+      renderItem(item, selected, focused)
+    ) : (
+      <>
+        {selected && (
+          <span {...css(styles.checkmark)}>
+            <IconCheckmark color={theme!.color.core.primary[3]} size={ICON_SIZE} decorative />
+          </span>
+        )}
+
+        <span {...css(styles.label)}>{<Text>{item.label || item.name}</Text>}</span>
+      </>
+    );
+  };
+
+  render() {
+    const { focused, item, styles, selected } = this.props;
+
+    return (
+      <div
+        {...css(styles.item, focused && styles.item_focused, item.readonly && styles.item_readonly)}
+        role="option"
+        aria-selected={selected}
+        onMouseMove={this.handleMouseMove}
+        onClick={this.handleClick}
+        onKeyDown={this.handleKeyDown}
+        tabIndex={focused ? 1 : 0} // this is needed to find a focused parent item in a vertically aligned list
+      >
+        {this.renderItem()}
+        {item.items && <IconChevronRight size="1.4em" decorative inline />}
+      </div>
+    );
+  }
+}
+
+export default withStyles(
+  ({ color, unit, ui }) => ({
+    item: {
+      display: 'flex',
+      alignItems: 'center',
+      padding: `${unit}px ${1.5 * unit}px ${unit}px ${2.75 * unit}px`,
+      cursor: 'pointer',
+      position: 'relative',
+      borderRadius: ui.borderRadius,
+
+      '@selectors': {
+        ':hover, :focus': {
+          backgroundColor: color.accent.bgHover,
+          outline: 'none',
+        },
+      },
+    },
+
+    item_focused: {
+      backgroundColor: color.accent.bgHover,
+    },
+
+    item_readonly: {
+      cursor: 'initial',
+    },
+
+    label: {
+      flexGrow: 1,
+    },
+
+    checkmark: {
+      position: 'absolute',
+      left: 0.25 * unit + 1,
+      top: ICON_SIZE / 2 + 1,
+    },
+  }),
+  { passThemeProp: true },
+)(HierarchyItem);

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyList.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyList.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import Text from '../../Text';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import HierarchyItem from './HierarchyItem';
+import ItemDescription from './ItemDescription';
+import { ItemShape, TreePath, SubTreeHandler, ItemPickedHandler, ItemRenderer } from '../types';
+
+export type Props = {
+  items?: ItemShape[];
+  chosen?: TreePath;
+  focus: TreePath;
+  maxHeight?: number;
+  renderItem?: ItemRenderer;
+  parents?: TreePath;
+  onSubtree: SubTreeHandler;
+  onItemPicked: ItemPickedHandler;
+  width?: number;
+  verticallyAlign?: boolean;
+};
+
+export class HierarchyList extends React.Component<Props & WithStylesProps> {
+  static defaultProps = {
+    chosen: [],
+    items: [],
+    parents: [],
+    verticallyAlign: false,
+  };
+
+  ref = React.createRef<HTMLDivElement>();
+
+  isChosen(definition: TreePath): boolean {
+    const { chosen } = this.props;
+
+    return definition.every((name, i) => chosen![i] === name);
+  }
+
+  /** Returns the closest <li> to the current document activeElement */
+  closestRowToActiveElement(): HTMLLIElement | null {
+    const { activeElement } = document;
+
+    if (!activeElement || !activeElement.closest || !this.ref.current) {
+      return null;
+    }
+
+    return activeElement.closest('li');
+  }
+
+  private handleDomFocusDeeper = () => {
+    const { verticallyAlign } = this.props;
+    const li = this.closestRowToActiveElement();
+
+    let deeper;
+    if (verticallyAlign) {
+      // next HierarchyList is a sibling
+      const ul = li && li.parentElement;
+      const parentDiv = ul && ul.parentElement;
+      const nextMenu = parentDiv && parentDiv.nextElementSibling;
+      deeper = nextMenu && nextMenu.querySelector('[tabindex]');
+    } else {
+      // next HierarchyList is a child
+      const ul = li && li.lastElementChild;
+      deeper = ul && ul.querySelector('[tabindex]');
+    }
+
+    if (deeper) {
+      (deeper as HTMLElement).focus();
+    }
+  };
+
+  private handleDomFocusShallower = () => {
+    const { verticallyAlign } = this.props;
+    const li = this.closestRowToActiveElement();
+
+    let shallower;
+    if (verticallyAlign) {
+      // prev HierarchyList is a sibling
+      const ul = li && li.parentElement;
+      const parentDiv = ul && ul.parentElement;
+      const prevMenu = parentDiv && parentDiv.previousElementSibling;
+      // focused parent tabIndex is higher than other parents
+      shallower = prevMenu && prevMenu.querySelector('[tabindex="1"]');
+    } else {
+      // prev HierarchyList is a parent
+      const parentLi = li && li.parentElement && li.parentElement.closest('li');
+      shallower = parentLi && parentLi.querySelector('[tabindex]');
+    }
+
+    if (shallower) {
+      (shallower as HTMLElement).focus();
+    }
+  };
+
+  renderAside(item: ItemShape) {
+    const { styles, parents = [], onItemPicked, width, verticallyAlign } = this.props;
+
+    if (item.items || !item.description) {
+      return null;
+    }
+
+    return (
+      <aside
+        {...css(
+          styles.pane,
+          styles.pane_nested, // descriptions are always nested
+          !verticallyAlign && styles.pane_verticallyOffset,
+          styles.aside,
+          { width },
+        )}
+      >
+        <button
+          {...css(styles.asideButton)}
+          onClick={() => onItemPicked([...parents, item.name])}
+          tabIndex={-1}
+          type="button"
+        >
+          <ItemDescription item={item} />
+        </button>
+      </aside>
+    );
+  }
+
+  render() {
+    const { focus, items, styles, parents, verticallyAlign, ...passThruProps } = this
+      .props as Required<Props & WithStylesProps>;
+
+    if (items.length === 0) {
+      return null;
+    }
+
+    const [focusName, ...focusRest] = focus;
+    const { maxHeight, width } = passThruProps;
+    const isNested = parents.length > 0;
+
+    // Track focused item to render as a sibling if vertically aligned
+    let focusedItem: ItemShape | undefined;
+    let currentSection: string | undefined;
+
+    return (
+      <>
+        <div
+          key="list"
+          {...css(
+            styles.pane,
+            verticallyAlign && styles.pane_verticallyAlign,
+            isNested && styles.pane_nested,
+            isNested && !verticallyAlign && styles.pane_verticallyOffset,
+            {
+              width,
+              maxHeight: verticallyAlign ? maxHeight : undefined,
+              zIndex: 1,
+            },
+          )}
+          ref={this.ref}
+        >
+          <ul {...css(styles.list)}>
+            {items.map((item, index) => {
+              const { name, section } = item;
+              const definition = parents.concat(name);
+              const isFocused = name === focusName;
+              const shouldRenderSection = typeof section === 'string' && section !== currentSection;
+
+              focusedItem = verticallyAlign && isFocused ? item : focusedItem;
+              currentSection = shouldRenderSection ? section : currentSection;
+
+              return (
+                <React.Fragment key={item.name}>
+                  {shouldRenderSection && index > 0 ? <li {...css(styles.divider)} /> : null}
+
+                  {shouldRenderSection && section ? (
+                    <li {...css(styles.sectionHeader)}>
+                      <Text small bold uppercased>
+                        {section}
+                      </Text>
+                    </li>
+                  ) : null}
+
+                  <li {...css(styles.row)}>
+                    <HierarchyItem
+                      {...passThruProps}
+                      onDomFocusDeeper={this.handleDomFocusDeeper}
+                      onDomFocusShallower={this.handleDomFocusShallower}
+                      item={item}
+                      definition={definition}
+                      selected={this.isChosen(definition)}
+                      focused={isFocused}
+                    />
+
+                    {!verticallyAlign && isFocused && item.items && item.items.length > 0 ? (
+                      <HierarchyList
+                        {...passThruProps}
+                        styles={styles}
+                        items={item.items!}
+                        focus={focusRest}
+                        parents={parents.concat(item.name)}
+                        verticallyAlign={false}
+                      />
+                    ) : (
+                      !verticallyAlign && isFocused && this.renderAside(item)
+                    )}
+                  </li>
+                </React.Fragment>
+              );
+            })}
+          </ul>
+        </div>
+
+        {verticallyAlign && focusedItem && focusedItem!.items && focusedItem.items.length > 0 ? (
+          <HierarchyList
+            key="sub-list"
+            {...passThruProps}
+            styles={styles}
+            items={focusedItem!.items}
+            focus={focusRest}
+            parents={parents.concat(focusedItem!.name)}
+            verticallyAlign
+          />
+        ) : (
+          verticallyAlign && focusedItem && this.renderAside(focusedItem)
+        )}
+      </>
+    );
+  }
+}
+
+export default withStyles(({ color, pattern, unit, ui }) => ({
+  pane: {
+    display: 'flex',
+    borderRadius: ui.borderRadius,
+  },
+
+  pane_verticallyAlign: {
+    overflowY: 'auto',
+    borderRadius: 0,
+  },
+
+  pane_nested: {
+    borderLeft: ui.border,
+  },
+
+  pane_verticallyOffset: {
+    position: 'absolute',
+    overflow: 'visible',
+    top: 0,
+    marginLeft: -2,
+    transform: 'translateX(100%)',
+    background: color.accent.bg,
+    border: ui.border,
+    boxShadow: ui.boxShadowMedium,
+  },
+
+  list: {
+    flex: 1,
+    listStyleType: 'none',
+    padding: 0,
+    margin: 0,
+  },
+
+  sectionHeader: {
+    padding: `${1.5 * unit}px ${3 * unit}px`,
+  },
+
+  divider: {
+    borderBottom: ui.border,
+    marginTop: 0.5 * unit,
+    marginBottom: 0.5 * unit,
+  },
+
+  aside: {
+    flex: 1,
+    alignItems: 'flex-start',
+    overflow: 'auto',
+    wordBreak: 'break-word',
+  },
+
+  asideButton: {
+    ...pattern.resetButton,
+    flex: 1,
+    padding: unit * 2,
+    textAlign: 'left',
+    cursor: 'help',
+  },
+
+  row: {
+    position: 'relative',
+  },
+}))(HierarchyList);

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/ItemDescription.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/ItemDescription.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import Text from '../../Text';
+import T from '../../Translate';
+import { ItemShape } from '../types';
+
+export type Props = {
+  item: ItemShape;
+};
+
+export class ItemDescription extends React.Component<Props & WithStylesProps> {
+  render() {
+    const { item, styles } = this.props;
+
+    return (
+      <div>
+        <Text bold>
+          <T phrase="Description" context="Description of item" />
+        </Text>
+
+        <div {...css(styles.description)}>
+          <Text>{item.description}</Text>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default withStyles(({ unit }) => ({
+  description: {
+    marginTop: unit / 2,
+  },
+}))(ItemDescription);

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/helpers.ts
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/helpers.ts
@@ -1,0 +1,24 @@
+import { ItemShape } from '../types';
+
+export function allChildrenReadonly(parent: ItemShape): boolean {
+  const children = parent.items || [];
+
+  return children.length > 0
+    ? children.reduce((acc: boolean, item: ItemShape) => acc && allChildrenReadonly(item), true)
+    : !!parent.readonly;
+}
+
+/** remove readonly parents that only contain readonly children */
+export function readonlyReducer(acc: ItemShape[], item: ItemShape): ItemShape[] {
+  if (!(item.readonly && allChildrenReadonly(item))) {
+    // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
+    const children = (item.items || []).reduce(readonlyReducer, []);
+
+    acc.push({
+      ...item,
+      items: children.length > 0 ? children : null,
+    });
+  }
+
+  return acc;
+}

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import debounce from 'lodash/debounce';
+import HierarchyList from './HierarchyList';
+import { readonlyReducer } from './helpers';
+import {
+  DeepFocusHandler,
+  Formatter,
+  ItemRenderer,
+  ItemShape,
+  ItemPickedHandler,
+  TreePath,
+} from '../types';
+
+export type Props = {
+  /** An array of names define the path to the currently selected item. */
+  chosen?: TreePath;
+  /** A function to format the display of choice. */
+  formatter: Formatter;
+  /** Maximum height of the hierarchy menu. */
+  hierarchyMaxHeight?: number;
+  /** Width of a single level of the hierarchy menu. */
+  hierarchyWidth?: number;
+  /** The hierarchy of things to choose from. */
+  items?: ItemShape[];
+  /** Callback for when user selects an item. */
+  onItemPicked: ItemPickedHandler;
+  /** Render a hierarchy item */
+  renderItem?: ItemRenderer;
+  /** Vertically align nested hierarchy levels. */
+  verticallyAlign?: boolean;
+};
+
+export type State = {
+  focusDef: TreePath;
+  filteredItems: ItemShape[];
+};
+
+export default class Hierarchy extends React.Component<Props, State> {
+  static defaultProps = {
+    chosen: [],
+    items: [],
+  };
+
+  state = {
+    focusDef: [],
+    filteredItems: [],
+  };
+
+  componentDidMount() {
+    this.filterItems();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.items !== prevProps.items) {
+      this.filterItems();
+    }
+  }
+
+  filterItems() {
+    this.setState({
+      // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
+      filteredItems: (this.props.items || []).reduce(readonlyReducer, []),
+    });
+  }
+
+  setFocus(focusDef: TreePath, callback?: DeepFocusHandler) {
+    this.setState({ focusDef }, callback);
+  }
+
+  setFocusDebounced = debounce(this.setFocus, 100);
+
+  private handleSubtree = (
+    focusDef: TreePath,
+    callback?: DeepFocusHandler,
+    immediate: boolean = false,
+  ) => {
+    if (immediate) {
+      this.setFocus(focusDef, callback);
+    } else {
+      this.setFocusDebounced(focusDef, callback);
+    }
+  };
+
+  private handleItemPicked = (chosen: TreePath | null) => {
+    this.props.onItemPicked(chosen, { origin: 'Hierarchy' });
+  };
+
+  render() {
+    const { filteredItems, focusDef } = this.state;
+    const { chosen, renderItem, hierarchyMaxHeight, hierarchyWidth, verticallyAlign } = this.props;
+
+    return (
+      <HierarchyList
+        chosen={chosen}
+        focus={focusDef}
+        items={filteredItems}
+        maxHeight={hierarchyMaxHeight}
+        onItemPicked={this.handleItemPicked}
+        onSubtree={this.handleSubtree}
+        renderItem={renderItem}
+        width={hierarchyWidth}
+        verticallyAlign={verticallyAlign}
+      />
+    );
+  }
+}

--- a/packages/core/src/components/HierarchyPicker/Picker/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Picker/index.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import Hierarchy from '../Hierarchy';
+import Search from '../Search';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import { ARROW_UP, ARROW_DOWN } from '../../../keys';
+import {
+  ChoiceDetails,
+  Formatter,
+  ItemPickedHandler,
+  ItemRenderer,
+  ItemShape,
+  TreePath,
+} from '../types';
+
+export type Props = {
+  chosen?: TreePath;
+  hierarchyMaxHeight?: number;
+  hierarchyWidth?: number;
+  indexParentPath?: boolean;
+  items: ItemShape[];
+  formatter: Formatter;
+  noResultsLabel: string;
+  onClose: () => void;
+  onItemPicked: ItemPickedHandler;
+  renderItem?: ItemRenderer;
+  searchMaxHeight?: number;
+  searchPlaceholder: string;
+  searchWidth?: number;
+  verticallyAlign?: boolean;
+};
+
+export type State = {
+  searchQuery: string;
+};
+
+export class Picker extends React.Component<Props & WithStylesProps, State> {
+  static defaultProps = {
+    searchWidth: 300,
+  };
+
+  state = {
+    searchQuery: '',
+  };
+
+  ref = React.createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    const [focusable] = this.getFocusables();
+    const { scrollX, scrollY } = window;
+
+    // We want to focus the first focusable item,
+    // but that could cause a scroll of the document
+    // depending on where the dropdown is positioned.
+    // This would break initial alignment of the dropdown with the trigger.
+    // so we get scroll position before focus, then set it back.
+    if (focusable) {
+      focusable.focus();
+      window.scrollTo(scrollX, scrollY);
+    }
+  }
+
+  getFocusables(): HTMLElement[] {
+    const el = this.ref.current;
+
+    return el ? Array.from(el.querySelectorAll('input,[tabindex]')) : [];
+  }
+
+  focusNext(forward: boolean = true) {
+    const f = this.getFocusables();
+    const index = f.findIndex(el => el === document.activeElement);
+
+    if (index >= 0) {
+      if (forward) {
+        f[index < f.length - 1 ? index + 1 : 0].focus();
+      } else {
+        f[(index || f.length) - 1].focus();
+      }
+    }
+  }
+
+  private handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const { searchQuery } = this.state;
+    if (searchQuery) return;
+
+    switch (event.key) {
+      case ARROW_DOWN:
+      case ARROW_UP:
+        event.preventDefault();
+        this.focusNext(event.key === ARROW_DOWN);
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleSearch = (searchQuery: string) => {
+    this.setState({ searchQuery });
+  };
+
+  private handleItemPicked = (def: TreePath | null, details?: ChoiceDetails) => {
+    if (def) {
+      // null if item.readonly
+      this.props.onItemPicked(def, details);
+      this.props.onClose();
+    }
+  };
+
+  render() {
+    const {
+      chosen,
+      hierarchyMaxHeight,
+      hierarchyWidth,
+      indexParentPath,
+      items,
+      formatter,
+      noResultsLabel,
+      renderItem,
+      searchMaxHeight,
+      searchPlaceholder,
+      searchWidth,
+      styles,
+      verticallyAlign,
+    } = this.props;
+
+    const { searchQuery } = this.state;
+
+    return (
+      /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
+      <div {...css(styles.pane)} ref={this.ref} onKeyDown={this.handleKeyDown}>
+        <Search
+          formatter={formatter}
+          indexParentPath={indexParentPath}
+          items={items}
+          maxHeight={searchMaxHeight}
+          noResultsLabel={noResultsLabel}
+          onSearch={this.handleSearch}
+          onItemPicked={this.handleItemPicked}
+          placeholder={searchPlaceholder}
+          query={searchQuery}
+          width={searchWidth!}
+        />
+
+        {!searchQuery && (
+          <div role="listbox" {...css(styles.hierarchy)}>
+            <Hierarchy
+              chosen={chosen}
+              items={items}
+              formatter={formatter}
+              onItemPicked={this.handleItemPicked}
+              hierarchyMaxHeight={hierarchyMaxHeight}
+              hierarchyWidth={hierarchyWidth}
+              renderItem={renderItem}
+              verticallyAlign={verticallyAlign}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default withStyles(({ ui, unit, color }) => ({
+  pane: {
+    display: 'inline-block',
+    borderRadius: ui.borderRadius,
+    backgroundColor: color.accent.bg,
+    boxShadow: ui.boxShadowMedium,
+    marginBottom: unit,
+  },
+
+  hierarchy: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+}))(Picker);

--- a/packages/core/src/components/HierarchyPicker/Search/Highlight.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/Highlight.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import { FuseMatch } from '../types';
+
+export type Props = {
+  fallback?: string;
+  match?: FuseMatch | null;
+  word?: string;
+};
+
+export class Highlight extends React.Component<Props & WithStylesProps> {
+  render() {
+    const { fallback, match, styles, word: searchWord } = this.props;
+
+    if (!match) {
+      return <>{fallback}</>;
+    }
+
+    const { value, indices = [] } = match;
+    const matchIndices = [...indices]; // clean ref
+
+    const output: React.ReactElement<any>[] = [];
+    let pair = matchIndices.shift();
+    let substr = '';
+
+    for (let i = 0; i < value.length; i += 1) {
+      // if substr exists and we reach the start index of a match, push current substr and reset
+      if (pair && substr && i === pair[0]) {
+        output.push(<span key={`${i}-start`}>{substr}</span>);
+        substr = '';
+      }
+
+      substr += value.charAt(i);
+
+      // push highlight when we reach the end index of a match
+      if (pair && i === pair[1]) {
+        if (substr) {
+          output.push(
+            <span
+              key={`end-${i}`}
+              {...css(
+                styles.highlight,
+                substr.trim().toLowerCase() === searchWord && styles.highlight_dark,
+              )}
+            >
+              <mark>{substr}</mark>
+            </span>,
+          );
+        }
+
+        substr = '';
+        pair = matchIndices.shift();
+      }
+    }
+
+    if (substr) {
+      output.push(<span key="last">{substr}</span>);
+    }
+
+    return <>{output}</>;
+  }
+}
+
+export default withStyles(({ color, ui }) => ({
+  highlight: {
+    borderRadius: ui.borderRadius,
+    backgroundColor: color.core.warning[0],
+
+    '@selectors': {
+      '> mark': {
+        backgroundColor: 'transparent',
+        color: 'inherit',
+        position: 'relative',
+        whiteSpace: 'nowrap',
+      },
+    },
+  },
+
+  highlight_dark: {
+    backgroundColor: color.core.warning[3],
+  },
+}))(Highlight);

--- a/packages/core/src/components/HierarchyPicker/Search/SearchResult.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/SearchResult.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import groupBy from 'lodash/groupBy';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import Text from '../../Text';
+import Highlight from './Highlight';
+import { ItemShape, FuseMatch } from '../types';
+
+export type Props = {
+  item: ItemShape;
+  formattedParents: string;
+  matches?: FuseMatch[];
+  query?: string;
+};
+
+export class SearchResult extends React.Component<Props & WithStylesProps> {
+  static defaultProps = {
+    matches: [],
+    query: '',
+  };
+
+  render() {
+    const { styles, item, formattedParents, matches, query } = this.props;
+    const { description, label, name } = item;
+    const mbk = groupBy(matches, 'key');
+    const [labelMatch = null] = mbk.label || [];
+    const [descMatch = null] = mbk.description || [];
+    const [keywMatch = null] = mbk.keywords || [];
+    const [longest] = query!.split(/\s{1,}/).sort((a, b) => b.length - a.length);
+
+    return (
+      <div {...css(styles.resultItem)}>
+        <Text bold>
+          {formattedParents}
+          <Highlight word={longest} match={labelMatch} fallback={label || name} />
+        </Text>
+
+        {description && (
+          <Text>
+            <Highlight word={longest} match={descMatch} fallback={description} />
+          </Text>
+        )}
+
+        {keywMatch && (
+          <Text>
+            <Highlight word={longest} match={keywMatch} />
+          </Text>
+        )}
+      </div>
+    );
+  }
+}
+
+export default withStyles(({ color, unit }) => ({
+  resultItem: {
+    padding: unit,
+    wordBreak: 'break-word',
+  },
+}))(SearchResult);

--- a/packages/core/src/components/HierarchyPicker/Search/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/index.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import Fuse from 'fuse.js';
+import Autocomplete from '../../Autocomplete';
+import SearchResult from './SearchResult';
+import T from '../../Translate';
+import withStyles, { css, WithStylesProps } from '../../../composers/withStyles';
+import {
+  Formatter,
+  ItemPickedHandler,
+  ItemShape,
+  SearchItemShape,
+  SearchItemResult,
+  TreePath,
+} from '../types';
+
+export type Props = {
+  items?: ItemShape[];
+  onItemPicked: ItemPickedHandler;
+  formatter: Formatter;
+  query?: string;
+  noResultsLabel: NonNullable<React.ReactNode>;
+  onSearch: (searchQuery: string) => void;
+  placeholder?: string;
+  indexParentPath?: boolean;
+  fuseOptions?: Fuse.FuseOptions<SearchItemShape>;
+  width: number;
+  maxHeight?: number;
+};
+
+const defaultFuseOptions: Fuse.FuseOptions<SearchItemShape> = {
+  shouldSort: true,
+  includeMatches: true,
+  tokenize: true,
+  matchAllTokens: true,
+  findAllMatches: true,
+  threshold: 0.1,
+  distance: 200,
+  maxPatternLength: 32,
+  minMatchCharLength: 3,
+};
+
+type FuseKey = { name: keyof SearchItemShape; weight: number };
+
+const defaultFuseKeys: FuseKey[] = [
+  {
+    name: 'label',
+    weight: 0.8,
+  },
+  {
+    name: 'keywords',
+    weight: 0.7,
+  },
+  {
+    name: 'description',
+    weight: 0.5,
+  },
+];
+
+export class Search extends React.Component<Props & WithStylesProps> {
+  static defaultProps = {
+    fuseOptions: {},
+    items: [],
+    query: '',
+  };
+
+  fuse?: Fuse<SearchItemShape, Fuse.FuseOptions<SearchItemShape>>;
+
+  componentDidMount() {
+    this.buildIndex(this.props.items);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const { items, indexParentPath } = this.props;
+
+    if (items !== prevProps.items || indexParentPath !== prevProps.indexParentPath) {
+      this.buildIndex(items);
+    }
+  }
+
+  buildIndex(inputItems: ItemShape[] = []) {
+    const flatItemList: SearchItemShape[] = [];
+
+    const walk = (one: ItemShape, parents: TreePath = []) => {
+      const definition = [...parents, one.name];
+      const { items, ...item } = one;
+      const { readonly } = item;
+
+      if (!readonly) {
+        flatItemList.push({
+          ...item,
+          definition,
+          label: item.label || item.name,
+          formattedParents: parents.length > 0 ? this.props.formatter([...parents, '']) : '',
+        });
+      }
+
+      (items || []).forEach(sub => walk(sub, definition));
+    };
+
+    if (inputItems) {
+      inputItems.forEach(item => walk(item));
+    }
+
+    const fuseKeys = [...defaultFuseKeys];
+
+    if (this.props.indexParentPath) {
+      fuseKeys.push({
+        name: 'formattedParents',
+        weight: 0.2,
+      });
+    }
+
+    const fuseOptions = { ...defaultFuseOptions, keys: fuseKeys };
+
+    this.fuse = new Fuse(flatItemList, {
+      ...fuseOptions,
+      ...this.props.fuseOptions,
+    });
+  }
+
+  getItemValue = (result: SearchItemResult) => result.item.name;
+
+  handleItemPicked = (itemValue: string, result: SearchItemResult | null) => {
+    const { query, onItemPicked } = this.props;
+    onItemPicked((result && result.item.definition) || null, {
+      origin: 'Search',
+      charCount: query!.length,
+    });
+  };
+
+  handleSearch = (query: string) => {
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery || !this.fuse) {
+      return [];
+    }
+
+    return (this.fuse.search(trimmedQuery) as unknown) as SearchItemResult[];
+  };
+
+  handleAsyncSearch = (query: string) => Promise.resolve(this.handleSearch(query));
+
+  renderItem = ({ matches, item: { formattedParents, ...item } }: SearchItemResult) => {
+    const { query } = this.props;
+
+    return (
+      <SearchResult
+        query={(query || '').toLowerCase()}
+        item={item}
+        formattedParents={formattedParents}
+        matches={matches}
+      />
+    );
+  };
+
+  render() {
+    const { noResultsLabel, maxHeight, onSearch, placeholder, query, styles, width } = this.props;
+
+    return (
+      <div {...css(styles.container, { width: query ? width : undefined })}>
+        <Autocomplete<SearchItemResult>
+          accessibilityLabel={T.phrase(
+            'Hierarchy item search',
+            {},
+            'Search functionality to find items within the hierarchy menu.',
+          )}
+          hideLabel
+          label=""
+          getItemValue={this.getItemValue}
+          maxHeight={maxHeight}
+          name="autocomplete-search"
+          noResultsText={noResultsLabel}
+          onChange={onSearch}
+          onLoadOptions={this.handleAsyncSearch}
+          onSelectItem={this.handleItemPicked}
+          optional
+          placeholder={placeholder}
+          renderItem={this.renderItem}
+          type="search"
+          value={query}
+        />
+      </div>
+    );
+  }
+}
+
+export default withStyles(({ unit }) => ({
+  container: {
+    padding: unit,
+  },
+}))(Search);

--- a/packages/core/src/components/HierarchyPicker/defaultFormatter.ts
+++ b/packages/core/src/components/HierarchyPicker/defaultFormatter.ts
@@ -1,0 +1,12 @@
+import T from '../Translate';
+import { TreePath, Labeler } from './types';
+
+export default function defaultFormatter(chosen: TreePath, getLabel: Labeler): string {
+  if (chosen.length > 0) {
+    const labels = chosen.map((_, i, a) => getLabel(a.slice(0, i + 1)));
+
+    return labels.join(' > ');
+  }
+
+  return T.phrase('Select from hierarchy', {}, 'placeholder for HierarchyPicker');
+}

--- a/packages/core/src/components/HierarchyPicker/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/index.tsx
@@ -10,12 +10,12 @@ import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 import buildInputStyles from '../../themes/buildInputStyles';
 
 import {
-  ItemShape,
-  TreePath,
-  Labeler,
   ItemPickedHandler,
   ItemRenderer,
+  ItemShape,
+  Labeler,
   ToggleHandler,
+  TreePath,
 } from './types';
 
 import defaultFormatter from './defaultFormatter';
@@ -28,7 +28,7 @@ export type Props = {
   /** Disables the picker. */
   disabled?: boolean;
   /** A function to format the display of choice. */
-  formatter?: (chosen: TreePath, labeler: Labeler) => NonNullable<React.ReactNode>;
+  formatter?: (chosen: TreePath, labeler: Labeler) => string;
   /** Fuse.js search options to override. */
   fuseOptions?: FuseOptions<any>;
   /** Maximum height of a (vertically aligned) hierarchy menu. */

--- a/packages/core/src/components/HierarchyPicker/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/index.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { FuseOptions } from 'fuse.js';
+import IconCaretDown from '@airbnb/lunar-icons/lib/interface/IconCaretDown';
+import Overlay from '../Overlay';
+import { SPACE, ENTER } from '../../keys';
+import T from '../Translate';
+import Text from '../Text';
+import Picker from './Picker';
+import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
+import buildInputStyles from '../../themes/buildInputStyles';
+
+import {
+  ItemShape,
+  TreePath,
+  Labeler,
+  ItemPickedHandler,
+  ItemRenderer,
+  ToggleHandler,
+} from './types';
+
+import defaultFormatter from './defaultFormatter';
+
+export type Props = {
+  /** Content to display in the select button. */
+  children?: React.ReactNode;
+  /** An array of names define the path to the currently selected item. */
+  chosen?: TreePath;
+  /** Disables the picker. */
+  disabled?: boolean;
+  /** A function to format the display of choice. */
+  formatter?: (chosen: TreePath, labeler: Labeler) => NonNullable<React.ReactNode>;
+  /** Fuse.js search options to override. */
+  fuseOptions?: FuseOptions<any>;
+  /** Maximum height of a (vertically aligned) hierarchy menu. */
+  hierarchyMaxHeight?: number;
+  /** Width of a single level of the hierarchy menu. */
+  hierarchyWidth?: number;
+  /** Include path of parent nodes in search index. */
+  indexParentPath?: boolean;
+  /** Styles the picker as containing an invalid value. */
+  invalid?: boolean;
+  /** The hierarchy of things to choose from. */
+  items: ItemShape[];
+  /** Text to show when there are no search results. */
+  noResultsLabel?: string;
+  /** Callback for when user selects an item. */
+  onItemPicked: ItemPickedHandler;
+  /** Callback for when user opens/closes the dropdown. */
+  onPickerToggle?: ToggleHandler;
+  /** Override rendering of a hierarchy list item. */
+  renderItem?: ItemRenderer;
+  /** Maximum height of Hierarchy Search result list. */
+  searchMaxHeight?: number;
+  /** Placeholder label for the search input. */
+  searchPlaceholder?: string;
+  /** Width of the Hierarchy Search result list. */
+  searchWidth?: number;
+  /** Vertically align nested hierarchy levels. */
+  verticallyAlign?: boolean;
+};
+
+export type State = {
+  open: boolean;
+};
+
+export class HierarchyPicker extends React.Component<Props & WithStylesProps, State> {
+  static defaultProps = {
+    chosen: [],
+    disabled: false,
+    formatter: defaultFormatter,
+    hierarchyMaxHeight: 400,
+    hierarchyWidth: 225,
+    invalid: false,
+    onPickerToggle: () => {},
+    searchMaxHeight: 400,
+    searchWidth: 300,
+    verticallyAlign: false,
+  };
+
+  state = {
+    open: false,
+  };
+
+  ref = React.createRef<HTMLDivElement>();
+
+  /**
+   * Given a "chosen" array, what's the best label for the item?
+   */
+  getLabel = (chosen: TreePath) => {
+    const label = chosen.reduce((items: string | ItemShape[], path, i) => {
+      if (Array.isArray(items) && items.length > 0) {
+        const item = items.find(({ name }) => path === name);
+
+        if (!item) {
+          return '';
+        }
+
+        return i < chosen.length - 1 ? item.items || [] : item.label || item.name;
+      }
+
+      return '';
+    }, this.props.items);
+
+    return typeof label === 'string' ? label : '';
+  };
+
+  boundFormatter = (chosen: TreePath) => this.props.formatter!(chosen, this.getLabel);
+
+  toggle = () => {
+    if (this.props.disabled) {
+      return;
+    }
+
+    this.setState(
+      state => ({ open: !state.open }),
+      () => {
+        const { open } = this.state;
+        if (open) {
+          this.props.onPickerToggle!(true);
+        } else {
+          this.handleClose();
+        }
+      },
+    );
+  };
+
+  private handleClose = () => {
+    this.props.onPickerToggle!(false);
+    this.setState({ open: false });
+
+    const el = this.ref.current;
+
+    if (el) {
+      el.focus();
+    }
+  };
+
+  private handleClick = () => {
+    this.toggle();
+  };
+
+  private handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== this.ref.current) {
+      return;
+    }
+
+    switch (event.key) {
+      case ENTER:
+      case SPACE:
+        event.preventDefault();
+        this.toggle();
+        break;
+      default:
+        break;
+    }
+  };
+
+  render() {
+    const {
+      children,
+      disabled,
+      invalid,
+      noResultsLabel,
+      searchPlaceholder,
+      styles,
+      ...passThruProps
+    } = this.props;
+    const { chosen } = passThruProps;
+    const { open } = this.state;
+
+    return (
+      <div>
+        <div
+          {...css(
+            styles.selectlike,
+            !disabled && styles.selectlike_enabled,
+            styles.input,
+            styles.select,
+            invalid && styles.input_invalid,
+            disabled && styles.input_disabled,
+          )}
+          tabIndex={disabled ? -1 : 0}
+          role="button"
+          onKeyDown={this.handleKeyDown}
+          onClick={this.handleClick}
+          ref={this.ref}
+        >
+          {children || <Text>{this.boundFormatter(chosen || [])}</Text>}
+
+          <span {...css(styles.arrow)}>
+            <IconCaretDown decorative size="1.5em" />
+          </span>
+        </div>
+
+        <Overlay open={open} onClose={this.handleClose}>
+          <Picker
+            {...passThruProps}
+            formatter={this.boundFormatter}
+            onClose={this.handleClose}
+            searchPlaceholder={
+              searchPlaceholder ||
+              T.phrase('Search', {}, 'Search for a topic within the hierarchy picker')
+            }
+            noResultsLabel={
+              noResultsLabel ||
+              T.phrase(
+                'No results',
+                {},
+                'Label to display when no results are found for hierarchy picker search',
+              )
+            }
+          />
+        </Overlay>
+      </div>
+    );
+  }
+}
+
+export default withStyles(theme => ({
+  ...buildInputStyles(theme),
+
+  selectlike: {
+    position: 'relative',
+  },
+
+  selectlike_enabled: {
+    cursor: 'pointer',
+  },
+
+  arrow: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    overflow: 'hidden',
+    width: theme.unit * 5,
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}))(HierarchyPicker);

--- a/packages/core/src/components/HierarchyPicker/types.ts
+++ b/packages/core/src/components/HierarchyPicker/types.ts
@@ -1,0 +1,65 @@
+import { Item as AutocompleteItem } from '../Autocomplete';
+
+export interface ItemShape {
+  /** Identifier used in chosen definition. */
+  name: string;
+  /** Localized content displayed in lieu of name. */
+  label?: string;
+  /** Long-worded localized description of an item. */
+  description?: string;
+  /** Optional flag to signal item should not be pickable. */
+  readonly?: boolean;
+  /** Optional keywords for use in search. */
+  keywords?: string;
+  /** Optional recursive sub-items. */
+  items?: ItemShape[] | null;
+  /** Optional menu section label. */
+  section?: string;
+}
+
+export type FuseMatch = {
+  indices?: number[][];
+  key: string;
+  value: string;
+};
+
+export type TreePath = string[];
+
+export interface SearchItemShape extends ItemShape {
+  definition: TreePath;
+  label: string;
+  formattedParents: string;
+}
+
+export interface SearchItemResult extends AutocompleteItem {
+  item: SearchItemShape;
+  matches: FuseMatch[];
+}
+
+export type TopicOriginKey = 'Hierarchy' | 'Search';
+
+export type ChoiceDetails = { origin: TopicOriginKey; charCount?: number };
+
+export type Labeler = (chosen: TreePath) => string;
+
+export type Formatter = (chosen: TreePath) => string;
+
+export type ItemRenderer = (
+  item: ItemShape,
+  selected: boolean,
+  focused: boolean,
+) => NonNullable<React.ReactNode>;
+
+export type ItemPickedHandler = (chosen: TreePath | null, details?: ChoiceDetails) => void;
+
+export type DeepFocusHandler = () => void;
+
+export type ToggleHandler = (open: boolean) => void;
+
+export type ShallowFocusHandler = () => void;
+
+export type SubTreeHandler = (
+  path: TreePath,
+  onDeeper?: DeepFocusHandler,
+  immediate?: boolean,
+) => void;

--- a/packages/core/test/components/HierarchyPicker/Hierarchy.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Hierarchy.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Hierarchy from '../../../src/components/HierarchyPicker/Hierarchy';
+import HierarchyList, {
+  HierarchyList as BaseHierarchyList,
+  Props as HierarchyListProps,
+} from '../../../src/components/HierarchyPicker/Hierarchy/HierarchyList';
+import HierarchyItem, {
+  Props as HierarchyItemProps,
+} from '../../../src/components/HierarchyPicker/Hierarchy/HierarchyItem';
+import ItemDescription from '../../../src/components/HierarchyPicker/Hierarchy/ItemDescription';
+import { ChoiceDetails } from '../../../src/components/HierarchyPicker/types';
+import { SPACE, ENTER, ARROW_LEFT, ARROW_RIGHT } from '../../../src/keys';
+import testItems from './mockItems';
+
+const props = {
+  onClose: jest.fn(),
+  onSubtree: jest.fn(),
+  onItemPicked: jest.fn(),
+  chosen: ['foo', 'bar'],
+  searchPlaceholder: 'search',
+  noResultsLabel: 'nope',
+  items: testItems,
+  formatter: jest.fn(),
+};
+
+describe('<Hierarchy />', () => {
+  describe('Hierarchy', () => {
+    it('filters readonly items and updates on prop change', () => {
+      const readOnlyItems = [
+        { name: 'test', readonly: true, items: [{ name: 'test 2', readonly: true }] },
+      ];
+      const wrapper = shallow(<Hierarchy {...props} />);
+      expect(wrapper.state('filteredItems')).toHaveLength(props.items.length);
+
+      wrapper.setProps({ items: readOnlyItems });
+      expect(wrapper.state('filteredItems')).toHaveLength(0);
+
+      wrapper.setProps({ items: undefined });
+      expect(wrapper.state('filteredItems')).toHaveLength(0);
+    });
+
+    it('decorates onItemPicked with correct origin', () => {
+      const handlePicked = jest.fn();
+      const wrapper = shallow(<Hierarchy {...props} onItemPicked={handlePicked} />);
+      expect(handlePicked).not.toHaveBeenCalled();
+      wrapper.find(HierarchyList).simulate('itemPicked', ['foo']);
+      expect(handlePicked).toHaveBeenCalledWith(['foo'], {
+        origin: 'Hierarchy',
+      } as ChoiceDetails);
+    });
+
+    it('handles focus definition updates', () => {
+      const wrapper = shallow(<Hierarchy {...props} />);
+      expect(wrapper.state('focusDef')).toEqual([]);
+
+      const list = wrapper.find(HierarchyList);
+
+      list.prop('onSubtree')(['foo']); // debounced = no affect
+      expect(wrapper.state('focusDef')).toEqual([]);
+
+      list.prop('onSubtree')(['foo', 'bar'], undefined, /** immediate= */ true);
+      expect(wrapper.state('focusDef')).toEqual(['foo', 'bar']);
+    });
+  });
+
+  describe('HierarchyList', () => {
+    let wrapper: Enzyme.ShallowWrapper<HierarchyListProps>;
+    let instance: BaseHierarchyList;
+
+    beforeEach(() => {
+      wrapper = shallow(<HierarchyList {...props} focus={['foo']} />).dive();
+      instance = wrapper.instance() as BaseHierarchyList;
+    });
+
+    describe('instance', () => {
+      it('isChosen(definition) correctly matches props.chosen', () => {
+        expect(instance.isChosen(['blah'])).toBe(false);
+        expect(instance.isChosen(['foo'])).toBe(true);
+        expect(instance.isChosen(['foo', 'bar'])).toBe(true);
+        expect(instance.isChosen(['foo', 'bar', 'whatever'])).toBe(false);
+      });
+
+      it('has domFocus functions that do not throw', () => {
+        // @ts-ignore Allow private access
+        expect(instance.handleDomFocusDeeper).not.toThrow();
+        // @ts-ignore Allow private access
+        expect(instance.handleDomFocusShallower).not.toThrow();
+
+        wrapper.setProps({ verticallyAlign: true });
+        instance = wrapper.instance() as BaseHierarchyList;
+
+        // @ts-ignore Allow private access
+        expect(instance.handleDomFocusDeeper).not.toThrow();
+        // @ts-ignore Allow private access
+        expect(instance.handleDomFocusShallower).not.toThrow();
+      });
+    });
+
+    describe('recursive', () => {
+      it('renders nested HierarchyList', () => {
+        expect(wrapper.find(BaseHierarchyList)).toHaveLength(1);
+      });
+
+      it('renders HierarchyList as <ul> child verticallyAlign=false', () => {
+        const ul = wrapper.find('ul');
+        expect(ul.find(BaseHierarchyList)).toHaveLength(1);
+      });
+
+      it('renders HierarchyList as <ul> sibling li if verticallyAlign=true', () => {
+        wrapper.setProps({ verticallyAlign: true });
+        const ul = wrapper.find('ul');
+        expect(ul.find(BaseHierarchyList)).toHaveLength(0);
+      });
+    });
+
+    describe('ItemDescription', () => {
+      it('renders an ItemDescription if a description is focused', () => {
+        wrapper.setProps({ focus: ['foo', 'coverage is hard'] });
+        let nestedList = wrapper.find(BaseHierarchyList).dive();
+        expect(nestedList.find(ItemDescription)).toHaveLength(1);
+
+        wrapper.setProps({ verticallyAlign: true });
+        nestedList = wrapper.find(BaseHierarchyList).dive();
+        expect(nestedList.find(ItemDescription)).toHaveLength(1);
+      });
+
+      it('renders null if a description is focused', () => {
+        wrapper.setProps({ focus: ['foo', 'hello'] });
+        const nestedList = wrapper.find(BaseHierarchyList).dive();
+        expect(nestedList.find(ItemDescription)).toHaveLength(0);
+      });
+
+      it('renders description text', () => {
+        wrapper.setProps({ focus: ['foo', 'coverage is hard'] });
+        const nestedList = wrapper.find(BaseHierarchyList).dive();
+        const description = nestedList.find(ItemDescription);
+        expect(description.html()).toMatch('very hard');
+      });
+
+      it('Clicking description invokes onItemPicked', () => {
+        wrapper.setProps({ focus: ['foo', 'coverage is hard'] });
+        const nestedList = wrapper.find(BaseHierarchyList).dive();
+        const button = nestedList.find('aside button');
+        button.simulate('click');
+
+        expect(props.onItemPicked).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('HierarchyItem', () => {
+    let itemProps: any;
+    let wrapper: Enzyme.ShallowWrapper<HierarchyItemProps>;
+
+    beforeEach(() => {
+      itemProps = {
+        item: testItems[0].items[0],
+        definition: ['foo', 'bar'],
+        selected: false,
+        focused: false,
+        onSubtree: jest.fn((d, cb) => cb && cb()),
+        onItemPicked: jest.fn(),
+        onDomFocusDeeper: jest.fn(),
+        onDomFocusShallower: jest.fn(),
+        renderItem: jest.fn(),
+      };
+      wrapper = shallow(<HierarchyItem {...itemProps} />).dive();
+    });
+
+    it('calls onDomFocusDeeper on key right', () => {
+      wrapper.simulate('keyDown', { key: ARROW_RIGHT });
+      expect(itemProps.onSubtree).toHaveBeenCalled();
+      expect(itemProps.onDomFocusDeeper).toHaveBeenCalled();
+    });
+
+    it('calls onDomFocusShallower on key left', () => {
+      wrapper.simulate('keyDown', { key: ARROW_LEFT });
+      expect(itemProps.onSubtree).toHaveBeenCalled();
+      expect(itemProps.onDomFocusShallower).toHaveBeenCalled();
+    });
+
+    it('calls onItemPicked on space key', () => {
+      wrapper.simulate('keyDown', { key: SPACE });
+      expect(itemProps.onItemPicked).toHaveBeenCalled();
+    });
+
+    it('calls onItemPicked on enter key', () => {
+      wrapper.simulate('keyDown', { key: ENTER });
+      expect(itemProps.onItemPicked).toHaveBeenCalled();
+    });
+
+    it('does nothing in default case', () => {
+      wrapper.simulate('keyDown', {});
+      expect(itemProps.onItemPicked).not.toHaveBeenCalled();
+    });
+
+    it('calls onItemPicked on click', () => {
+      wrapper.simulate('click');
+      expect(itemProps.onItemPicked).toHaveBeenCalled();
+    });
+
+    it('calls onSubtree on mousemove', () => {
+      wrapper.simulate('mousemove');
+      expect(itemProps.onSubtree).toHaveBeenCalledWith(itemProps.definition);
+    });
+
+    it('sets tabIndex=1 when focused', () => {
+      expect(wrapper.prop('tabIndex')).toBe(0);
+      wrapper.setProps({ focused: true });
+      expect(wrapper.prop('tabIndex')).toBe(1);
+    });
+
+    it('allows override with renderItem', () => {
+      expect(itemProps.renderItem).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/HierarchyPicker.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/HierarchyPicker.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import HierarchyPicker, {
+  HierarchyPicker as BaseHierarchyPicker,
+  Props as HierarchyPickerProps,
+  State as HierarchyPickerState,
+} from '../../../src/components/HierarchyPicker';
+import { SPACE, ENTER } from '../../../src/keys';
+import Overlay from '../../../src/components/Overlay';
+import testItems from './mockItems';
+import Picker, { Props as PickerProps } from '../../../src/components/HierarchyPicker/Picker';
+
+jest.mock('lodash/debounce', () => jest.fn(fn => fn));
+
+const props = {
+  chosen: ['foo', 'bar'],
+  hierarchyMaxHeight: 127,
+  hierarchyWidth: 1000,
+  indexParentPath: true,
+  items: testItems,
+  noResultsLabel: 'nope',
+  onClose: jest.fn(),
+  onSubtree: jest.fn(),
+  onItemPicked: jest.fn(),
+  renderItem: undefined,
+  searchMaxHeight: 101,
+  searchPlaceholder: 'search',
+  searchWidth: 27,
+  verticallyAlign: true,
+};
+
+describe('<HierarchyPicker />', () => {
+  describe('formatter', () => {
+    it('default works', () => {
+      const wrapper = shallow(<HierarchyPicker {...props} />).dive();
+      const instance = wrapper.instance() as BaseHierarchyPicker;
+
+      expect(instance.boundFormatter(['foo'])).toBe('Foo');
+      expect(instance.boundFormatter(['foo', 'hello'])).toBe('Foo > hello');
+      expect(instance.boundFormatter(props.chosen)).toBe('Foo > Barrrrrr');
+      expect(instance.boundFormatter([])).toBe('Select from hierarchy');
+    });
+
+    it('custom works', () => {
+      const formatter = jest.fn(() => 'test');
+      const wrapper = shallow(<HierarchyPicker {...props} formatter={formatter} />).dive();
+      const instance = wrapper.instance() as BaseHierarchyPicker;
+
+      expect(instance.boundFormatter([])).toBe('test');
+      expect(formatter).toHaveBeenCalledTimes(2); // shallow + above call
+    });
+  });
+
+  describe('handler functions', () => {
+    let wrapper: Enzyme.ShallowWrapper<HierarchyPickerProps, HierarchyPickerState>;
+    let instance: BaseHierarchyPicker;
+    let button: Enzyme.ShallowWrapper;
+    let handleToggle: jest.Mock;
+
+    beforeEach(() => {
+      handleToggle = jest.fn();
+      wrapper = shallow(<HierarchyPicker {...props} onPickerToggle={handleToggle} />).dive();
+      instance = wrapper.instance() as BaseHierarchyPicker;
+      button = wrapper.find('div[role="button"]');
+    });
+
+    it('toggle and handleClose', () => {
+      expect(handleToggle).not.toHaveBeenCalled();
+      expect(instance.state.open).toBe(false);
+      instance.toggle();
+      expect(instance.state.open).toBe(true);
+      expect(handleToggle).toHaveBeenCalledWith(true);
+      wrapper.find(Overlay).simulate('close');
+      expect(instance.state.open).toBe(false);
+      expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    it('disabled prop prevents toggle', () => {
+      wrapper.setProps({ disabled: true });
+      expect(handleToggle).not.toHaveBeenCalled();
+      expect(instance.state.open).toBe(false);
+      instance.toggle();
+      expect(instance.state.open).toBe(false);
+      expect(handleToggle).not.toHaveBeenCalled();
+    });
+
+    it('handleClick', () => {
+      expect(handleToggle).not.toHaveBeenCalled();
+      expect(instance.state.open).toBe(false);
+      button.simulate('click');
+
+      expect(instance.state.open).toBe(true);
+      expect(handleToggle).toHaveBeenCalledWith(true);
+      wrapper.find(Overlay).simulate('close');
+      expect(instance.state.open).toBe(false);
+      expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    describe('handleKeyDown', () => {
+      let event: any;
+
+      beforeEach(() => {
+        event = { preventDefault: jest.fn(), target: instance.ref.current };
+        expect(instance.state.open).toBe(false);
+      });
+
+      it('default', () => {
+        button.simulate('keydown', event);
+        expect(instance.state.open).toBe(false);
+        expect(handleToggle).not.toHaveBeenCalled();
+      });
+
+      it('with wrong target', () => {
+        button.simulate('keydown', { ...event, target: null });
+        expect(instance.state.open).toBe(false);
+        expect(handleToggle).not.toHaveBeenCalled();
+      });
+
+      it('ENTER', () => {
+        button.simulate('keydown', { ...event, key: ENTER });
+        expect(instance.state.open).toBe(true);
+        expect(handleToggle).toHaveBeenCalledWith(true);
+      });
+
+      it('SPACE', () => {
+        button.simulate('keydown', { ...event, key: SPACE });
+        expect(instance.state.open).toBe(true);
+        expect(handleToggle).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
+  describe('<Picker />', () => {
+    it('renders a Picker', () => {
+      const wrapper = shallow(<HierarchyPicker {...props} />).dive();
+      expect(wrapper.find(Picker)).toHaveLength(1);
+    });
+
+    it('passes through relevant props', () => {
+      const wrapper = shallow(<HierarchyPicker {...props} />).dive();
+      const pickerProps = wrapper.find(Picker).props() as PickerProps;
+      expect(pickerProps.chosen).toBe(props.chosen);
+      expect(pickerProps.hierarchyMaxHeight).toBe(props.hierarchyMaxHeight);
+      expect(pickerProps.hierarchyWidth).toBe(props.hierarchyWidth);
+      expect(pickerProps.indexParentPath).toBe(props.indexParentPath);
+      expect(pickerProps.items).toBe(props.items);
+      expect(pickerProps.noResultsLabel).toBe(props.noResultsLabel);
+      expect(pickerProps.searchMaxHeight).toBe(props.searchMaxHeight);
+      expect(pickerProps.searchPlaceholder).toBe(props.searchPlaceholder);
+      expect(pickerProps.searchWidth).toBe(props.searchWidth);
+      expect(pickerProps.renderItem).toBe(props.renderItem);
+      expect(pickerProps.searchPlaceholder).toBe(props.searchPlaceholder);
+      expect(pickerProps.verticallyAlign).toBe(props.verticallyAlign);
+    });
+  });
+
+  it('accepts invalid prop', () => {
+    const emptyItems = { ...props, items: [] };
+    const wrapper = shallow(<HierarchyPicker {...emptyItems} />).dive();
+    const markupValid = wrapper.html();
+    wrapper.setProps({ invalid: true });
+    expect(wrapper.html()).not.toEqual(markupValid);
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/Highlight.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Highlight.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Highlight, { Props } from '../../../src/components/HierarchyPicker/Search/Highlight';
+
+describe('<Highlight />', () => {
+  let wrapper: Enzyme.ShallowWrapper<Props>;
+
+  beforeEach(() => {
+    wrapper = shallow(<Highlight fallback="fallback" />).dive();
+  });
+
+  it('shows fallback by default', () => {
+    expect(wrapper.text()).toBe('fallback');
+  });
+
+  it('shows value if match without indices', () => {
+    wrapper.setProps({
+      match: { indices: [], value: 'whatever', key: 'test' },
+    });
+    expect(wrapper.find('mark')).toHaveLength(0);
+    expect(wrapper.text()).toBe('whatever');
+  });
+
+  describe('with indices', () => {
+    beforeEach(() => {
+      wrapper.setProps({
+        match: { indices: [[0, 5], [12, 14]], value: 'hello world foo', key: 'test' },
+        word: 'hello',
+      });
+    });
+
+    it('shows highlighted matches', () => {
+      expect(wrapper.find('mark')).toHaveLength(2);
+      expect(wrapper.text()).toBe('hello world foo');
+    });
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/Picker.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Picker.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import Enzyme, { shallow, mount } from 'enzyme';
+import Picker, {
+  Picker as BasePicker,
+  Props as PickerProps,
+  State as PickerState,
+} from '../../../src/components/HierarchyPicker/Picker';
+import Search from '../../../src/components/HierarchyPicker/Search';
+import Hierarchy from '../../../src/components/HierarchyPicker/Hierarchy';
+import { ARROW_DOWN, ARROW_UP } from '../../../src/keys';
+import testItems from './mockItems';
+
+const props = {
+  onClose: jest.fn(),
+  onSubtree: jest.fn(),
+  onItemPicked: jest.fn(),
+  onSearch: jest.fn(),
+  chosen: ['foo', 'bar'],
+  searchPlaceholder: 'search',
+  noResultsLabel: 'nope',
+  items: testItems,
+  formatter: (chosen: string[]) => chosen.join(' > '),
+};
+
+describe('<Picker />', () => {
+  it('renders a Search', () => {
+    const wrapper = shallow(<Picker {...props} />).dive();
+    expect(wrapper.find(Search)).toHaveLength(1);
+  });
+
+  it('renders a Hierarchy when Search is empty', () => {
+    const wrapper = shallow(<Picker {...props} />).dive();
+    expect(wrapper.find(Hierarchy)).toHaveLength(1);
+    wrapper.setState({ searchQuery: 'search ' });
+    expect(wrapper.find(Hierarchy)).toHaveLength(0);
+  });
+
+  describe('handles scroll and focus', () => {
+    const oldScrollTo = window.scrollTo;
+    const oldFocus = HTMLDivElement.prototype.focus;
+    const oldGetFocusables = BasePicker.prototype.getFocusables;
+
+    beforeEach(() => {
+      window.scrollTo = jest.fn();
+    });
+
+    afterEach(() => {
+      window.scrollTo = oldScrollTo;
+      HTMLDivElement.prototype.focus = oldFocus;
+      BasePicker.prototype.getFocusables = oldGetFocusables;
+    });
+
+    it('calls scrollTo on mount', () => {
+      mount(<Picker {...props} />);
+      expect(window.scrollTo).toHaveBeenCalled();
+    });
+
+    describe('focusables', () => {
+      it('has getFocusables() fn', () => {
+        const instance = shallow(<Picker {...props} />)
+          .dive()
+          .instance();
+        expect(() => (instance as BasePicker).getFocusables()).not.toThrow();
+      });
+
+      it('focusNext() invokes .focus() on focusables', () => {
+        HTMLDivElement.prototype.focus = jest.fn();
+        const mockElement = document.createElement('div');
+        const mockFocusables = [mockElement];
+
+        mockFocusables.findIndex = () => 0;
+        const mockGetFocusables = jest.fn(() => mockFocusables);
+        BasePicker.prototype.getFocusables = mockGetFocusables;
+
+        const instance = shallow(<Picker {...props} />)
+          .dive()
+          .instance();
+
+        // @ts-ignore private invocation
+        instance.focusNext();
+        // @ts-ignore private invocation
+        instance.focusNext(true);
+
+        // these are also called at mount
+        expect(mockGetFocusables).toHaveBeenCalledTimes(3);
+        expect(HTMLDivElement.prototype.focus).toHaveBeenCalledTimes(3);
+      });
+    });
+  });
+
+  describe('has a focusNext function', () => {
+    let wrapper: Enzyme.ShallowWrapper<PickerProps, PickerState>;
+    let instance: BasePicker;
+
+    beforeEach(() => {
+      wrapper = shallow(<Picker {...props} />).dive();
+      instance = wrapper.instance() as BasePicker;
+    });
+
+    it('will focus forward', () => {
+      expect(() => instance.focusNext()).not.toThrow();
+    });
+
+    it('will focus backwards', () => {
+      expect(() => instance.focusNext(false)).not.toThrow();
+    });
+  });
+
+  describe('handler functions', () => {
+    let myProps: any;
+    let wrapper: Enzyme.ShallowWrapper<PickerProps, PickerState>;
+
+    beforeEach(() => {
+      myProps = { ...props, onItemPicked: jest.fn(), onClose: jest.fn() };
+      wrapper = shallow(<Picker {...myProps} />).dive();
+    });
+
+    describe('handleItemPicked', () => {
+      it('calls close if passed something', () => {
+        const details = { origin: 'Search' };
+        wrapper.find(Search).simulate('itemPicked', ['foo'], details);
+
+        expect(myProps.onClose).toHaveBeenCalled();
+        expect(myProps.onItemPicked).toHaveBeenCalledWith(['foo'], details);
+      });
+
+      it('does not call close if passed falsy', () => {
+        wrapper.find(Search).simulate('itemPicked', null);
+
+        expect(myProps.onClose).not.toHaveBeenCalled();
+        expect(myProps.onItemPicked).not.toHaveBeenCalled();
+      });
+    });
+
+    it('updates searchQuery state upon searching', () => {
+      const onSearch = wrapper.find(Search).prop('onSearch') as (q: string) => void;
+      onSearch('hello');
+      expect(wrapper.state('searchQuery')).toBe('hello');
+    });
+
+    describe('handleKeyDown', () => {
+      it('default', () => {
+        wrapper.simulate('keydown', {});
+        expect(myProps.onClose).not.toHaveBeenCalled();
+      });
+
+      describe('ARROWs', () => {
+        it('ARROW_UP', () => {
+          const spy = jest.fn();
+          wrapper.simulate('keydown', { key: ARROW_UP, preventDefault: spy });
+          expect(spy).toHaveBeenCalled();
+        });
+
+        it('ARROW_DOWN', () => {
+          const spy = jest.fn();
+          wrapper.simulate('keydown', { key: ARROW_DOWN, preventDefault: spy });
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/Search.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Search.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import Autocomplete from '../../../src/components/Autocomplete';
-import Search, { Props as SearchProps } from '../../../src/components/HierarchyPicker/Search';
+import Search, {
+  Search as BaseSearch,
+  Props as SearchProps,
+} from '../../../src/components/HierarchyPicker/Search';
 import { SearchResult } from '../../../src/components/HierarchyPicker/Search/SearchResult';
 import { SearchItemResult, ChoiceDetails } from '../../../src/components/HierarchyPicker/types';
 import testItems from './mockItems';
@@ -22,12 +25,12 @@ const props = {
 describe('<Search />', () => {
   let wrapper: Enzyme.ShallowWrapper<SearchProps>;
   let handlePicked: jest.Mock;
-  let instance: Search;
+  let instance: BaseSearch;
 
   beforeEach(() => {
     handlePicked = jest.fn();
     wrapper = shallow(<Search {...props} onItemPicked={handlePicked} />).dive();
-    instance = wrapper.instance() as Search;
+    instance = wrapper.instance() as BaseSearch;
   });
 
   describe('Autocomplete', () => {
@@ -118,7 +121,7 @@ describe('<Search />', () => {
 
     it('when true, should match items against formattedParents', () => {
       wrapper = shallow(<Search {...props} indexParentPath />).dive();
-      instance = wrapper.instance() as Search;
+      instance = wrapper.instance() as BaseSearch;
       expect(instance.handleSearch('foo bar')).toHaveLength(2); // 'foo > bar >' has 2 children
     });
   });
@@ -126,7 +129,7 @@ describe('<Search />', () => {
   describe('overriding fuse options with no keys', () => {
     it('shows no results', () => {
       wrapper = shallow(<Search {...props} fuseOptions={{ keys: [] }} />).dive();
-      instance = wrapper.instance() as Search;
+      instance = wrapper.instance() as BaseSearch;
       expect(instance.handleSearch('coverage')).toHaveLength(0);
     });
   });

--- a/packages/core/test/components/HierarchyPicker/Search.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Search.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Autocomplete from '../../../src/components/Autocomplete';
+import Search, { Props as SearchProps } from '../../../src/components/HierarchyPicker/Search';
+import { SearchResult } from '../../../src/components/HierarchyPicker/Search/SearchResult';
+import { SearchItemResult, ChoiceDetails } from '../../../src/components/HierarchyPicker/types';
+import testItems from './mockItems';
+
+const props = {
+  onClose: jest.fn(),
+  onItemPicked: jest.fn(),
+  onSearch: jest.fn(),
+  onSubtree: jest.fn(),
+  chosen: ['foo', 'bar'],
+  searchPlaceholder: 'search',
+  noResultsLabel: 'nope',
+  items: testItems,
+  formatter: (chosen: string[]) => chosen.join(' > '),
+  width: 300,
+};
+
+describe('<Search />', () => {
+  let wrapper: Enzyme.ShallowWrapper<SearchProps>;
+  let handlePicked: jest.Mock;
+  let instance: Search;
+
+  beforeEach(() => {
+    handlePicked = jest.fn();
+    wrapper = shallow(<Search {...props} onItemPicked={handlePicked} />).dive();
+    instance = wrapper.instance() as Search;
+  });
+
+  describe('Autocomplete', () => {
+    it('renders an <Autocomplete />', () => {
+      expect(wrapper.find(Autocomplete)).toHaveLength(1);
+    });
+
+    it('renderItem renders SearchResults', () => {
+      const auto = wrapper.find(Autocomplete);
+      const item = shallow(
+        auto.prop('renderItem')({
+          item: { definition: ['foo'], label: '', formattedParents: '', name: '' },
+          matches: [],
+        }),
+      );
+
+      expect(item.type()).toBe(SearchResult);
+    });
+  });
+
+  it('calls handlePicked upon picking', () => {
+    const query = 'fo';
+    wrapper.setProps({ query });
+
+    const autocomplete = wrapper.find(Autocomplete);
+    const onSelectItem = autocomplete.prop('onSelectItem') as (
+      v: string,
+      r: SearchItemResult,
+    ) => void;
+    onSelectItem('', {
+      item: { definition: ['foo'], label: '', formattedParents: '', name: '' },
+      matches: [],
+    });
+    expect(handlePicked).toHaveBeenCalledWith(['foo'], {
+      charCount: query.length,
+      origin: 'Search',
+    } as ChoiceDetails);
+  });
+
+  describe('search functionality', () => {
+    it('finds child items by name', () => {
+      expect(instance.handleSearch('coverage')).toHaveLength(1);
+    });
+
+    it('updates items on change and handles empty items', () => {
+      wrapper.setProps({ items: [] });
+      expect(instance.handleSearch('coverage')).toHaveLength(0);
+    });
+
+    it('finds grandchild items by name', () => {
+      expect(instance.handleSearch('whatever')).toHaveLength(1);
+    });
+
+    it('finds items by description', () => {
+      expect(instance.handleSearch('what I want')).toHaveLength(1);
+    });
+
+    it('finds items by keywords', () => {
+      expect(instance.handleSearch('bonsoir')).toHaveLength(1);
+    });
+
+    it('trims the query', () => {
+      expect(instance.handleSearch(' ')).toHaveLength(0);
+    });
+
+    it('filters non-matching results', () => {
+      expect(instance.handleSearch('nonsense')).toHaveLength(0);
+    });
+
+    it('filters readonly results', () => {
+      expect(instance.handleSearch('hello')).toHaveLength(0);
+    });
+
+    it('handleAsyncSearch resolves to handleSearch', () => {
+      expect.assertions(1);
+      const syncResult = instance.handleSearch('coverage');
+
+      return instance.handleAsyncSearch('coverage').then((asyncResult: SearchItemResult[]) => {
+        expect(syncResult).toEqual(asyncResult);
+      });
+    });
+  });
+
+  describe('indexParentPath', () => {
+    it('when false, should filter items matching formattedParents', () => {
+      expect(instance.handleSearch('foo bar')).toHaveLength(0);
+    });
+
+    it('when true, should match items against formattedParents', () => {
+      wrapper = shallow(<Search {...props} indexParentPath />).dive();
+      instance = wrapper.instance() as Search;
+      expect(instance.handleSearch('foo bar')).toHaveLength(2); // 'foo > bar >' has 2 children
+    });
+  });
+
+  describe('overriding fuse options with no keys', () => {
+    it('shows no results', () => {
+      wrapper = shallow(<Search {...props} fuseOptions={{ keys: [] }} />).dive();
+      instance = wrapper.instance() as Search;
+      expect(instance.handleSearch('coverage')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/SearchResult.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/SearchResult.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SearchResult from '../../../src/components/HierarchyPicker/Search/SearchResult';
+
+const item = { name: 'foo', label: 'bar', description: 'baz description' };
+
+describe('<SearchResult />', () => {
+  it('renders the item label', () => {
+    const wrapper = shallow(<SearchResult item={item} formattedParents="" query="more coverage" />);
+    expect(wrapper.html()).toMatch(item.label);
+  });
+
+  it('renders a description', () => {
+    const wrapper = shallow(<SearchResult item={item} formattedParents="" />);
+    expect(wrapper.html()).toMatch(item.description);
+  });
+
+  it('renders a keyword match', () => {
+    const wrapper = shallow(
+      <SearchResult
+        item={item}
+        formattedParents=""
+        matches={[{ key: 'keywords', indices: [], value: 'keyword match' }]}
+      />,
+    );
+    expect(wrapper.html()).toMatch('keyword match');
+  });
+});

--- a/packages/core/test/components/HierarchyPicker/mockItems.ts
+++ b/packages/core/test/components/HierarchyPicker/mockItems.ts
@@ -1,0 +1,26 @@
+export default [
+  {
+    name: 'foo',
+    label: 'Foo',
+    readonly: true,
+    items: [
+      {
+        name: 'bar',
+        label: 'Barrrrrr',
+        description: 'a place to have a drink',
+        readonly: true,
+        items: [{ name: 'baz' }, { name: 'whatever', description: 'I do what I want' }],
+      },
+      {
+        name: 'hello',
+        readonly: true,
+      },
+      {
+        name: 'coverage is hard',
+        description: 'very hard',
+        keywords: 'bonjour bonsoir',
+        section: 'test them',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
to: @milesj @stefhatcher
cc: @elibrumbaugh @jpdanks 

## Motivation and Context

Implements @jpdanks 's 2.0 version of the picker.

## Description

**Note** Replaces #43 which got borked 🤦‍♂ 

This PR adds a `HierarchyPicker` `"2.0"` to `@airbnb/lunar`, and is derived mostly from the old `HierarchyPicker` `"1.0"` component (which was removed in the open-source move).

For easier code review, the component architecture / logic basically looks like the following (this is mostly the same vs 1.0):
```jsx
<>
  <FauxSelect>
  <Portal>
    <Autocomplete />
    <Hierarchy />
  </Portal>
</>
```

The follow changes were made vs the `"1.0"` component:

#### New
- adds `verticallyAlign` prop which will result in vertical alignment (vs vertical offset) of nested hierarchy lists. DOM-wise, this results in **_sibling_** `ul`s rather than _**nested**_ `ul`s and required updates to the hierarchy focus traversal logic
- adds more hooks to control the sizing of the `HierarchyPicker` pieces:
  - `hierarchyWidth` sets the width of a given level of hierarchy 
  - `hierarchyMaxHeight` sets the overflow height of a given hierarchy level. the height of the overall hierarchy picker is the `max` of any visible nested menu. 
  - `searchWidth` sets the width of the hierarchy search input
  - `searchMaxHeight` sets the max height of the search result list
- adds `renderItem: (item, selected, focused) => ReactNode` to override rendering of a hierarchy list item
- adds general support for sub-section headings/organization within hierarchy menu by specifying a `section` string in the `items` definition (example in the readme)
- adds padding around search input
- wraps items better (with `break-word` style)

#### Breaking (vs 1.0)
- previously the component took a `suggestions` list, which provided a limited API to organize the menu. suggestions are **no longer supported**, and generic support for menu sections was added.
- removes lazy-loading of `fuse.js` (no `import()`)

#### Refactor
- refactors hierarchy search to leverage the `Autocomplete` component
- delete snapshot tests, adds new tests back to coverage thresholds

## Screenshots

**Vertically offset**
<kbd>
  <img src="https://user-images.githubusercontent.com/4496521/56836666-dac98380-682c-11e9-99e2-3f48709cbd14.png" width="600" />
</kbd>

**Vertically aligned, with subheadings**
<kbd>
  <img src="https://user-images.githubusercontent.com/4496521/56836726-f16fda80-682c-11e9-9334-55f8cdd1081a.png" width="600" />
</kbd>

**Keyboard nav demo**
<kbd>
  <img src="https://user-images.githubusercontent.com/4496521/56836948-92f72c00-682d-11e9-8024-b4f6ca336b45.gif" width="600" />
</kbd>

**Custom hierarchy width**
<kbd>
  <img src="https://user-images.githubusercontent.com/4496521/56836850-41e73800-682d-11e9-8395-8e97832017a8.png" width="600" />
</kbd>

**Custom search dimensions**
<kbd>
  <img src="https://user-images.githubusercontent.com/4496521/56836894-6d6a2280-682d-11e9-9c3c-6293dc7e6d3e.png" width="600" />
</kbd>

## Testing

- [x] functional
- [x] add unit tests to coverage limits

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.