### PR TITLE
fix(removeFocusOnMouseUp): Remove focus from currentTarget.

### DIFF
--- a/packages/core/src/utils/removeFocusOnMouseUp.ts
+++ b/packages/core/src/utils/removeFocusOnMouseUp.ts
@@ -2,7 +2,7 @@
 export default function removeFocusOnMouseUp<T>(event: React.MouseEvent<T>) {
   // This event takes too long, and prevents onClick occasionally.
   // And we do not need to do it syncronously.
-  const { target } = event;
+  const { currentTarget, target } = event;
 
-  window.setTimeout(() => (target as HTMLElement).blur(), 0);
+  window.setTimeout(() => ((currentTarget || target) as HTMLElement).blur(), 0);
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Noticed the outline isn't always removed. Did some debugging and sometimes the remove would be applied to the target, e.g. a child of the the that has focus, and not the actual element that the onClick fired from. so a `blur` on the child wouldn't remove the focus. `currentTarget` solves this. defaults back to `target` for good measure

## Motivation and Context

Wanting that outline to be removed!!

## Testing

tested locally in the storybook

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
