### PR TITLE
update(Text): Add startAlign prop

### DIFF
--- a/packages/core/src/components/Text.story.tsx
+++ b/packages/core/src/components/Text.story.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import Row from './Row';
 import Text from './Text';
 
 storiesOf('Core/Text', module)

--- a/packages/core/src/components/Text.story.tsx
+++ b/packages/core/src/components/Text.story.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
+import Row from './Row';
 import Text from './Text';
 
 storiesOf('Core/Text', module)
@@ -75,15 +76,21 @@ storiesOf('Core/Text', module)
     </Text>
   ))
   .add('With aligned text.', () => (
-    <>
+    <div style={{ textAlign: 'center' }}>
       <Text>
-        <LoremIpsum short />
+        <Text bold>Parent alignment</Text> <LoremIpsum short />
       </Text>
+      <br />
+      <Text startAlign>
+        <Text bold>Start align</Text> <LoremIpsum short />
+      </Text>
+      <br />
       <Text centerAlign>
-        <LoremIpsum short />
+        <Text bold>Center align</Text> <LoremIpsum short />
       </Text>
+      <br />
       <Text endAlign>
-        <LoremIpsum short />
+        <Text bold>End align</Text> <LoremIpsum short />
       </Text>
-    </>
+    </div>
   ));

--- a/packages/core/src/components/Text/index.tsx
+++ b/packages/core/src/components/Text/index.tsx
@@ -5,20 +5,20 @@ import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 const sizingProp = mutuallyExclusiveTrueProps('micro', 'small', 'large');
 const emphasisProp = mutuallyExclusiveTrueProps('bold', 'light');
 const stateProp = mutuallyExclusiveTrueProps('disabled', 'muted', 'inverted');
-const alignProp = mutuallyExclusiveTrueProps('centerAlign', 'endAlign');
+const alignProp = mutuallyExclusiveTrueProps('centerAlign', 'endAlign', 'startAlign');
 
 export type Props = {
   /** Render the text inline instead of block. */
   baseline?: boolean;
   /** Apply bold emphasis. */
   bold?: boolean;
-  /** Align the text in the center. */
+  /** Align the text to the center. */
   centerAlign?: boolean;
   /** The text to render. */
   children?: React.ReactNode;
   /** Mark the text as disabled. */
   disabled?: boolean;
-  /** Align the text on the end. */
+  /** Align the text to the end. */
   endAlign?: boolean;
   /** Render the text inline-block instead of block. */
   inline?: boolean;
@@ -36,6 +36,8 @@ export type Props = {
   preserveWhitespace?: boolean;
   /** Decrease font size to small. */
   small?: boolean;
+  /** Align the text to the start. */
+  startAlign?: boolean;
   /** Truncate the text with an ellipsis. */
   truncated?: boolean;
   /** Uppercase all text. */
@@ -72,6 +74,7 @@ export class Text extends React.Component<Props & WithStylesProps> {
     muted: false,
     preserveWhitespace: false,
     small: false,
+    startAlign: false,
     truncated: false,
     uppercased: false,
   };
@@ -92,6 +95,7 @@ export class Text extends React.Component<Props & WithStylesProps> {
       preserveWhitespace,
       endAlign,
       small,
+      startAlign,
       styles,
       truncated,
       uppercased,
@@ -124,7 +128,8 @@ export class Text extends React.Component<Props & WithStylesProps> {
           truncated && styles.text_truncated,
           uppercased && styles.text_uppercased,
           centerAlign && styles.text_center,
-          endAlign && styles.text_right,
+          endAlign && styles.text_end,
+          startAlign && styles.text_start,
         )}
       >
         {children}
@@ -204,7 +209,11 @@ export default withStyles(({ color, font, pattern }) => ({
     textAlign: 'center',
   },
 
-  text_right: {
+  text_end: {
     textAlign: 'right',
+  },
+
+  text_start: {
+    textAlign: 'left',
   },
 }))(Text);

--- a/packages/core/src/components/Text/index.tsx
+++ b/packages/core/src/components/Text/index.tsx
@@ -50,13 +50,14 @@ export class Text extends React.Component<Props & WithStylesProps> {
     bold: emphasisProp,
     centerAlign: alignProp,
     disabled: stateProp,
+    endAlign: alignProp,
     inverted: stateProp,
     large: sizingProp,
     light: emphasisProp,
     micro: sizingProp,
     muted: stateProp,
-    endAlign: alignProp,
     small: sizingProp,
+    startAlign: alignProp,
   };
 
   static defaultProps = {
@@ -86,6 +87,7 @@ export class Text extends React.Component<Props & WithStylesProps> {
       centerAlign,
       children,
       disabled,
+      endAlign,
       inline,
       inverted,
       large,
@@ -93,7 +95,6 @@ export class Text extends React.Component<Props & WithStylesProps> {
       micro,
       muted,
       preserveWhitespace,
-      endAlign,
       small,
       startAlign,
       styles,

--- a/packages/core/test/components/Text.test.tsx
+++ b/packages/core/test/components/Text.test.tsx
@@ -11,6 +11,14 @@ describe('<Text />', () => {
         </Text>,
       ).dive();
     }).toThrowError();
+
+    expect(() => {
+      shallow(
+        <Text startAlign endAlign>
+          Default
+        </Text>,
+      ).dive();
+    }).toThrowError();
   });
 
   it('errors when multiple states are used at once', () => {

--- a/packages/core/test/components/Text.test.tsx
+++ b/packages/core/test/components/Text.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Text from '../../src/components/Text';
 
 describe('<Text />', () => {
-  it.only('errors when multiple alignments are used at once', () => {
+  it('errors when multiple alignments are used at once', () => {
     expect(() => {
       shallow(
         <Text startAlign endAlign>

--- a/packages/core/test/components/Text.test.tsx
+++ b/packages/core/test/components/Text.test.tsx
@@ -3,15 +3,7 @@ import { shallow } from 'enzyme';
 import Text from '../../src/components/Text';
 
 describe('<Text />', () => {
-  it('errors when multiple alignments are used at once', () => {
-    expect(() => {
-      shallow(
-        <Text centerAlign endAlign>
-          Default
-        </Text>,
-      ).dive();
-    }).toThrowError();
-
+  it.only('errors when multiple alignments are used at once', () => {
     expect(() => {
       shallow(
         <Text startAlign endAlign>


### PR DESCRIPTION
to: @milesj @stefhatcher

## Description

This PR 
- adds a new `startAlign` prop to the `@airbnb/lunar` `Text` component, which is mutually exclusive with the existing `endAlign` and `centerAlign` props
- updates the `storybook` example

## Motivation and Context

Currently `Text` has `centerAlign` and `endAlign` props, which work to control alignment in most cases. 

However, if a parent sets a non-`left` alignment, there is no way to force `startAlign` because `textAlign` [is not set to `left` anywhere in `Text` styles](https://github.com/airbnb/lunar/blob/%40airbnb/lunar%401.4.0/packages/core/src/components/Text/index.tsx#L137) (just `center` and `right` for the current props) and also [is not set by `buildFont`](https://github.com/airbnb/lunar/blob/%40airbnb/lunar%401.4.0/packages/core/src/themes/buildFont.ts#L3).

## Testing

- [x] functional
- [x] added jest test that asserts the new prop is mutually exclusive with other alignment props

## Screenshots

**Before**
<img src="https://user-images.githubusercontent.com/4496521/57008017-d7722700-6ba1-11e9-9633-ff13cd8cc394.png" width="600" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/57008039-fa9cd680-6ba1-11e9-986a-0c2b5a17db38.png" width="600" />

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
