### PR TITLE
update(Query,Mutation): Limit error message to network errors

### DIFF
--- a/packages/apollo/src/components/Mutation/index.tsx
+++ b/packages/apollo/src/components/Mutation/index.tsx
@@ -28,6 +28,11 @@ export type Props<Data, Vars> = Omit<MutationProps<Data, Vars>, 'client'> & {
    * When not defined, this defaults to `Loader`.
    */
   loading?: RenderableProp;
+  /**
+   * Allow graphql errors to be passed to the render function.  If this is true the render function
+   * may receive partial data and is expected to be able to handle `result.errors`
+   */
+  ignoreGraphQLErrors?: boolean;
 };
 
 /**
@@ -39,6 +44,7 @@ export default class Mutation<Data = any, Vars = OperationVariables> extends Rea
 > {
   static defaultProps = {
     awaitRefetchQueries: false,
+    ignoreGraphQLErrors: false,
     ignoreResults: false,
     variables: {},
   };
@@ -48,7 +54,7 @@ export default class Mutation<Data = any, Vars = OperationVariables> extends Rea
       return renderElementOrFunction(this.props.loading) || <Loader static />;
     }
 
-    if (result.error) {
+    if (result.error && (!this.props.ignoreGraphQLErrors || result.error.networkError)) {
       // istanbul ignore next (need to fix tests)
       return (
         renderElementOrFunction(this.props.error, result.error) || (

--- a/packages/apollo/src/components/Mutation/index.tsx
+++ b/packages/apollo/src/components/Mutation/index.tsx
@@ -30,7 +30,7 @@ export type Props<Data, Vars> = Omit<MutationProps<Data, Vars>, 'client'> & {
   loading?: RenderableProp;
   /**
    * Allow graphql errors to be passed to the render function.  If this is true the render function
-   * may receive partial data and is expected to be able to handle `result.errors`
+   * may receive partial data and is expected to be able to handle `result.error.graphQLErrors`
    */
   ignoreGraphQLErrors?: boolean;
 };

--- a/packages/apollo/src/components/Query/index.tsx
+++ b/packages/apollo/src/components/Query/index.tsx
@@ -47,7 +47,7 @@ export default class Query<Data = any, Vars = OperationVariables> extends React.
       return renderElementOrFunction(this.props.loading) || <Loader static />;
     }
 
-    if (result.error) {
+    if (result.error && result.error.networkError) {
       return (
         renderElementOrFunction(this.props.error, result.error) || (
           <ErrorMessage error={result.error} />

--- a/packages/apollo/src/components/Query/index.tsx
+++ b/packages/apollo/src/components/Query/index.tsx
@@ -26,7 +26,7 @@ export type Props<Data, Vars> = Omit<QueryProps<Data, Vars>, 'children' | 'clien
   loading?: RenderableProp;
   /**
    * Allow graphql errors to be passed to the render function.  If this is true the render function
-   * may receive partial data and is expected to be able to handle `result.errors`
+   * may receive partial data and is expected to be able to handle `result.error.graphQLErrors`
    */
   ignoreGraphQLErrors?: boolean;
 };

--- a/packages/apollo/src/components/Query/index.tsx
+++ b/packages/apollo/src/components/Query/index.tsx
@@ -24,6 +24,11 @@ export type Props<Data, Vars> = Omit<QueryProps<Data, Vars>, 'children' | 'clien
    * When not defined, this defaults to `Loader`.
    */
   loading?: RenderableProp;
+  /**
+   * Allow graphql errors to be passed to the render function.  If this is true the render function
+   * may receive partial data and is expected to be able to handle `result.errors`
+   */
+  ignoreGraphQLErrors?: boolean;
 };
 
 /**
@@ -34,6 +39,7 @@ export default class Query<Data = any, Vars = OperationVariables> extends React.
   Props<Data, Vars>
 > {
   static defaultProps = {
+    ignoreGraphQLErrors: false,
     notifyOnNetworkStatusChange: false,
     partialRefetch: false,
     pollInterval: 0,
@@ -47,7 +53,7 @@ export default class Query<Data = any, Vars = OperationVariables> extends React.
       return renderElementOrFunction(this.props.loading) || <Loader static />;
     }
 
-    if (result.error && result.error.networkError) {
+    if (result.error && (!this.props.ignoreGraphQLErrors || result.error.networkError)) {
       return (
         renderElementOrFunction(this.props.error, result.error) || (
           <ErrorMessage error={result.error} />

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -157,7 +157,7 @@ describe('Mutation', () => {
 
       renderer.create(
         <MockedProvider mocks={[mock]} addTypename={false}>
-          <Mutation mutation={MUTATION} ignoreGraphQLErrors={true}>
+          <Mutation mutation={MUTATION} ignoreGraphQLErrors>
             {spy}
           </Mutation>
         </MockedProvider>,

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -79,6 +79,19 @@ describe('Mutation', () => {
         variables: { id: 123, name: 'Something' },
       },
       result: {
+        errors: [
+          {
+            message: 'Error!',
+            locations: undefined,
+            path: undefined,
+            nodes: undefined,
+            source: undefined,
+            positions: undefined,
+            originalError: undefined,
+            extensions: undefined,
+            name: '',
+          },
+        ],
         data: {
           updateSomething: {
             id: 123,
@@ -87,7 +100,6 @@ describe('Mutation', () => {
           },
         },
       },
-      error: new Error('404'),
     };
 
     it('renders an `ErrorMessage` by default', async () => {
@@ -136,6 +148,20 @@ describe('Mutation', () => {
       } catch (error) {
         // Ignore
       }
+    });
+
+    it('will ignore an error with the `ignoreGraphQLErrors` prop', async () => {
+      const spy = jest.fn(() => null);
+
+      renderer.create(
+        <MockedProvider mocks={[mock]} addTypename={false}>
+          <Mutation mutation={MUTATION} ignoreGraphQLErrors={true}>
+            {spy}
+          </Mutation>
+        </MockedProvider>,
+      );
+
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -37,7 +37,11 @@ describe('Mutation', () => {
       },
       result: {
         data: {
-          updateSomething: {},
+          updateSomething: {
+            id: 123,
+            name: 'Something',
+            __typename: 'something',
+          },
         },
       },
     };
@@ -70,9 +74,7 @@ describe('Mutation', () => {
     });
   });
 
-  // Cannot figure out why these  throwing an error
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('error', () => {
+  describe('error', () => {
     const mock = {
       request: {
         query: MUTATION,

--- a/packages/apollo/test/components/Query.test.tsx
+++ b/packages/apollo/test/components/Query.test.tsx
@@ -116,7 +116,7 @@ describe('Query', () => {
 
       renderer.create(
         <MockedProvider mocks={[mock]} addTypename={false}>
-          <Query query={QUERY} ignoreGraphQLErrors={true}>
+          <Query query={QUERY} ignoreGraphQLErrors>
             {spy}
           </Query>
         </MockedProvider>,

--- a/packages/apollo/test/components/Query.test.tsx
+++ b/packages/apollo/test/components/Query.test.tsx
@@ -54,7 +54,27 @@ describe('Query', () => {
         query: QUERY,
         variables: {},
       },
-      error: new Error('404'),
+      result: {
+        errors: [
+          {
+            message: 'Error!',
+            locations: undefined,
+            path: undefined,
+            nodes: undefined,
+            source: undefined,
+            positions: undefined,
+            originalError: undefined,
+            extensions: undefined,
+            name: '',
+          },
+        ],
+        data: {
+          something: {
+            id: 123,
+            name: 'Something',
+          },
+        },
+      },
     };
 
     it('renders an `ErrorMessage` by default', async () => {
@@ -71,7 +91,7 @@ describe('Query', () => {
       expect(error).toBeDefined();
       expect(error.props).toEqual(
         expect.objectContaining({
-          error: new Error('Network error: 404'),
+          error: new Error('GraphQL error: Error!'),
         }),
       );
     });
@@ -89,6 +109,22 @@ describe('Query', () => {
       await wait();
 
       expect(wrapper.root.findByType('div').children).toEqual(['Failed!']);
+    });
+
+    it('will ignore graphQLErrors via `ignoreGraphQLErrors` prop', async () => {
+      const spy = jest.fn(() => null);
+
+      renderer.create(
+        <MockedProvider mocks={[mock]} addTypename={false}>
+          <Query query={QUERY} ignoreGraphQLErrors={true}>
+            {spy}
+          </Query>
+        </MockedProvider>,
+      );
+
+      await wait();
+
+      expect(spy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add a prop to make `<ErrorMessage />` only show up on network errors.  Any graphql errors will pass through `null` values along with the error object.

## Motivation and Context

There are two types of possible errors: Network errors & graphql errors.  We want to pass through graphql errors so that client can a) decide how to display them and b) show the data for the part of the query that succeeded which is often the majority of it.

[Apollo docs](https://www.apollographql.com/docs/react/features/error-handling#options)

## Testing

Created forced errors and verified that this passes through gql errors and still fails with disconnected wifi

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
