### PR TITLE
update(DataTable): Column header casing

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
-import startCase from 'lodash/startCase';
 import { SortDirection } from 'react-virtualized';
 
 import SortCarets from '../SortCarets';
 import Spacing from '../Spacing';
 import Text from '../Text';
 import { css, WithStylesProps } from '../../composers/withStyles';
-import { getHeight } from './helpers';
-import { ColumnMetadata, ColumnToLabel, HeightOptions, RowHeightOptions } from './types';
+import { caseColumnLabel, getHeight } from './helpers';
+import {
+  ColumnLabelCase,
+  ColumnMetadata,
+  ColumnToLabel,
+  HeightOptions,
+  RowHeightOptions,
+} from './types';
 
 // Theses anys are required to match the param types from react-virtualized
 // https://github.com/bvaughn/react-virtualized/blob/master/source/Table/types.js
@@ -32,6 +37,7 @@ export default function ColumnLabels({
   expandable,
   selectable,
   columnMetadata,
+  columnLabelCase,
 }: {
   styles?: WithStylesProps['styles'];
   columnToLabel?: ColumnToLabel;
@@ -41,6 +47,7 @@ export default function ColumnLabels({
   expandable?: boolean;
   selectable?: boolean;
   columnMetadata?: ColumnMetadata;
+  columnLabelCase?: ColumnLabelCase;
 }) {
   return ({ className, columns, style }: ColumnLabelsProps) => {
     const leftmostIdx = Number(expandable) + Number(selectable);
@@ -56,7 +63,9 @@ export default function ColumnLabels({
     const newColumns = columns.map((col: React.ReactElement, idx: number) => {
       const { children } = col.props;
       const key = children[0].props.children;
-      const label = columnToLabel[key] ? columnToLabel[key] : key && startCase(key).toUpperCase();
+      const label = columnToLabel[key]
+        ? columnToLabel[key]
+        : key && caseColumnLabel(key, columnLabelCase);
       const sort = children[1] && children[1].props.sortDirection;
 
       const isLeftmost = idx === leftmostIdx;

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -12,9 +12,9 @@ export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
     return s[0] + s.toLowerCase().slice(1);
   } else if (casing === 'uppercase') {
     return startCase(label).toUpperCase();
-  } else {
-    return label;
   }
+
+  return label;
 }
 
 function getStatusColor(theme: WithStylesProps['theme'], status: Status) {

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -1,6 +1,20 @@
+import startCase from 'lodash/startCase';
+
 import { WithStylesProps } from '../../composers/withStyles';
 import { STATUS_OPTIONS, HEIGHT_TO_PX } from './constants';
-import { HeightOptions, ExpandedRow, RowHeightOptions, Status } from './types';
+import { ColumnLabelCase, HeightOptions, ExpandedRow, RowHeightOptions, Status } from './types';
+
+export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
+  if (casing === undefined) {
+    return label;
+  } else if (casing === 'title') {
+    return startCase(label);
+  } else if (casing === 'sentence') {
+    return startCase(label.toLowerCase());
+  } else {
+    return startCase(label).toUpperCase();
+  }
+}
 
 function getStatusColor(theme: WithStylesProps['theme'], status: Status) {
   if (status === STATUS_OPTIONS.ALERT) {

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -7,10 +7,15 @@ import { ColumnLabelCase, HeightOptions, ExpandedRow, RowHeightOptions, Status }
 export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
   if (casing === 'title') {
     return startCase(label);
-  } else if (casing === 'sentence') {
+  }
+
+  if (casing === 'sentence') {
     const s = startCase(label);
+
     return s[0] + s.toLowerCase().slice(1);
-  } else if (casing === 'uppercase') {
+  }
+
+  if (casing === 'uppercase') {
     return startCase(label).toUpperCase();
   }
 

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -5,14 +5,15 @@ import { STATUS_OPTIONS, HEIGHT_TO_PX } from './constants';
 import { ColumnLabelCase, HeightOptions, ExpandedRow, RowHeightOptions, Status } from './types';
 
 export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
-  if (casing === undefined) {
-    return label;
-  } else if (casing === 'title') {
+  if (casing === 'title') {
     return startCase(label);
   } else if (casing === 'sentence') {
-    return startCase(label.toLowerCase());
-  } else {
+    const s = startCase(label);
+    return s[0] + s.toLowerCase().slice(1);
+  } else if (casing === 'caps') {
     return startCase(label).toUpperCase();
+  } else {
+    return label;
   }
 }
 

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -10,7 +10,7 @@ export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
   } else if (casing === 'sentence') {
     const s = startCase(label);
     return s[0] + s.toLowerCase().slice(1);
-  } else if (casing === 'caps') {
+  } else if (casing === 'uppercase') {
     return startCase(label).toUpperCase();
   } else {
     return label;

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -51,6 +51,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   static defaultProps: Pick<DataTableProps, DefaultDataTableProps> = {
     columnHeaderHeight: undefined,
     columnMetadata: {},
+    columnLabelCase: 'sentence',
     columnToLabel: {},
     data: [],
     defaultEditCallback: () => {},

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -50,8 +50,8 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
   static defaultProps: Pick<DataTableProps, DefaultDataTableProps> = {
     columnHeaderHeight: undefined,
-    columnMetadata: {},
     columnLabelCase: 'sentence',
+    columnMetadata: {},
     columnToLabel: {},
     data: [],
     defaultEditCallback: () => {},

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -50,7 +50,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
   static defaultProps: Pick<DataTableProps, DefaultDataTableProps> = {
     columnHeaderHeight: undefined,
-    columnLabelCase: 'sentence',
+    columnLabelCase: '',
     columnMetadata: {},
     columnToLabel: {},
     data: [],

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -6,7 +6,7 @@ export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | '';
+export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | '' | undefined;
 
 export type SelectedRows = {
   [key: number]: {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -47,7 +47,7 @@ export type DefaultDataTableProps = keyof DataTableProps;
 export interface DataTableProps {
   /** Height of the column header. */
   columnHeaderHeight?: HeightOptions;
-  /** Change all column label keys to ALL CAPS or Sentence Case*/
+  /** Change all column label keys to UPPERCASE or Title Case or Sentence case*/
   columnLabelCase?: ColumnLabelCase;
   /** Keys mapped onto custom column label names. */
   columnToLabel?: ColumnToLabel;

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -6,7 +6,7 @@ export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | '' | undefined;
+export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '' | undefined;
 
 export type SelectedRows = {
   [key: number]: {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -6,7 +6,7 @@ export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '' | undefined;
+export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '';
 
 export type SelectedRows = {
   [key: number]: {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -6,6 +6,7 @@ export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
+export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | undefined;
 
 export type SelectedRows = {
   [key: number]: {
@@ -46,6 +47,8 @@ export type DefaultDataTableProps = keyof DataTableProps;
 export interface DataTableProps {
   /** Height of the column header. */
   columnHeaderHeight?: HeightOptions;
+  /** Change all column label keys to ALL CAPS or Sentence Case*/
+  columnLabelCase?: ColumnLabelCase;
   /** Keys mapped onto custom column label names. */
   columnToLabel?: ColumnToLabel;
   /** Override default width for specific a column's properties. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -6,7 +6,7 @@ export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | undefined;
+export type ColumnLabelCase = 'sentence' | 'title' | 'caps' | '';
 
 export type SelectedRows = {
   [key: number]: {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -47,7 +47,7 @@ export type DefaultDataTableProps = keyof DataTableProps;
 export interface DataTableProps {
   /** Height of the column header. */
   columnHeaderHeight?: HeightOptions;
-  /** Change all column label keys to UPPERCASE or Title Case or Sentence case*/
+  /** Change all column label keys to UPPERCASE or Title Case or Sentence case */
   columnLabelCase?: ColumnLabelCase;
   /** Keys mapped onto custom column label names. */
   columnToLabel?: ColumnToLabel;

--- a/packages/core/src/components/SortCarets/index.tsx
+++ b/packages/core/src/components/SortCarets/index.tsx
@@ -80,7 +80,7 @@ export default withStyles((theme: WithStylesProps['theme']) => ({
     right: 0.5 * theme!.unit,
   },
   caret_inactive: {
-    color: theme!.color.core.neutral[1],
+    color: theme!.color.core.neutral[3],
   },
   caret_active: {
     color: theme!.color.core.neutral[4],

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -332,6 +332,27 @@ describe('<DataTable /> renders column labels', () => {
     });
   });
 
+  it('should not format labels if you provide an empty string', () => {
+    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="" />).dive();
+    const table = wrapper
+      .find(AutoSizer)
+      .at(1)
+      .dive()
+      .find(Table)
+      .dive();
+    const columnLabels = table.childAt(0);
+    const labels = ['name', 'jobTitle', 'tenureDays', 'menu', 'cats', 'log', 'colspan'];
+
+    columnLabels.find(Text).forEach((node, idx) => {
+      expect(
+        node
+          .dive()
+          .dive()
+          .text(),
+      ).toBe(labels[idx]);
+    });
+  });
+
   it('should render the correct column labels in caps', () => {
     const wrapper = shallow(<DataTable data={data} editable columnLabelCase="caps" />).dive();
     const table = wrapper

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -311,8 +311,29 @@ describe('<DataTable /> renders and sorts data', () => {
 });
 
 describe('<DataTable /> renders column labels', () => {
-  it('should render the correct column labels', () => {
+  it('should render the correct column labels in sentence case by default', () => {
     const wrapper = shallow(<DataTable data={data} editable />).dive();
+    const table = wrapper
+      .find(AutoSizer)
+      .at(1)
+      .dive()
+      .find(Table)
+      .dive();
+    const columnLabels = table.childAt(0);
+    const labels = ['Name', 'Job title', 'Tenure days', 'Menu', 'Cats', 'Log', 'Colspan'];
+
+    columnLabels.find(Text).forEach((node, idx) => {
+      expect(
+        node
+          .dive()
+          .dive()
+          .text(),
+      ).toBe(labels[idx]);
+    });
+  });
+
+  it('should render the correct column labels in caps', () => {
+    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="caps" />).dive();
     const table = wrapper
       .find(AutoSizer)
       .at(1)
@@ -331,6 +352,28 @@ describe('<DataTable /> renders column labels', () => {
       ).toBe(labels[idx]);
     });
   });
+
+  it('should render the correct column labels in title case', () => {
+    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="title" />).dive();
+    const table = wrapper
+      .find(AutoSizer)
+      .at(1)
+      .dive()
+      .find(Table)
+      .dive();
+    const columnLabels = table.childAt(0);
+    const labels = ['Name', 'Job Title', 'Tenure Days', 'Menu', 'Cats', 'Log', 'Colspan'];
+
+    columnLabels.find(Text).forEach((node, idx) => {
+      expect(
+        node
+          .dive()
+          .dive()
+          .text(),
+      ).toBe(labels[idx]);
+    });
+  });
+
   it('should render custom column labels', () => {
     const labels = [
       'CUSTOM NAME',

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -354,7 +354,7 @@ describe('<DataTable /> renders column labels', () => {
   });
 
   it('should render the correct column labels in caps', () => {
-    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="caps" />).dive();
+    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="uppercase" />).dive();
     const table = wrapper
       .find(AutoSizer)
       .at(1)

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -311,8 +311,8 @@ describe('<DataTable /> renders and sorts data', () => {
 });
 
 describe('<DataTable /> renders column labels', () => {
-  it('should render the correct column labels in sentence case by default', () => {
-    const wrapper = shallow(<DataTable data={data} editable />).dive();
+  it('should render the correct column labels in sentence case', () => {
+    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="sentence" />).dive();
     const table = wrapper
       .find(AutoSizer)
       .at(1)
@@ -332,8 +332,8 @@ describe('<DataTable /> renders column labels', () => {
     });
   });
 
-  it('should not format labels if you provide an empty string', () => {
-    const wrapper = shallow(<DataTable data={data} editable columnLabelCase="" />).dive();
+  it('should not format labels by default', () => {
+    const wrapper = shallow(<DataTable data={data} editable />).dive();
     const table = wrapper
       .find(AutoSizer)
       .at(1)

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -353,7 +353,7 @@ describe('<DataTable /> renders column labels', () => {
     });
   });
 
-  it('should render the correct column labels in caps', () => {
+  it('should render the correct column labels in uppercase', () => {
     const wrapper = shallow(<DataTable data={data} editable columnLabelCase="uppercase" />).dive();
     const table = wrapper
       .find(AutoSizer)


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
As per Eli's comments, column label casing now defaults to sentence case.

This can be configured through the new columnLabelCasing prop, options are `caps`, `title` and `sentence` or `""` for no formatting.

I'm bundling in a tiny tweak to Sort Carets, Eli asked to darken the inactive state for better contrast.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
