### PR TITLE
new(DataTable): Add showAllRows and propagateRef props

### DIFF
--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -96,6 +96,20 @@ storiesOf('Core/DataTable', module)
       selectable
     />
   ))
+  .add('A table that shows all rows.', () => (
+    // This shows the height dynamically change with expanded rows
+    <div style={{ background: '#835EFE', padding: 8 }}>
+      <DataTable
+        tableHeaderLabel="Auto height table"
+        data={getData()}
+        keys={['name', 'jobTitle']}
+        expandable
+        selectable
+        showAllRows
+        showRowDividers
+      />
+    </div>
+  ))
   .add('An editable table.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -130,13 +130,14 @@ export function TableHeader({
   );
 }
 
-export default withStyles(theme => ({
+export default withStyles(({ unit, color }) => ({
   tableHeader_inner: {
+    background: color.accent.bg,
     display: 'flex',
     alignItems: 'center',
     height: '100%',
     justifyContent: 'space-between',
-    marginLeft: 2 * theme!.unit,
-    marginRight: 2 * theme!.unit,
+    paddingLeft: 2 * unit,
+    paddingRight: 2 * unit,
   },
 }))(TableHeader);

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -110,17 +110,21 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     outline: 'none',
   });
 
-  getTableHeight = (expandedDataList: ExpandedRow[]) => {
-    const { columnHeaderHeight, height, rowHeight, showAllRows, tableHeaderHeight } = this.props;
+  private getTableHeight = (expandedDataList: ExpandedRow[]) => {
+    const { height, rowHeight, showAllRows } = this.props;
 
     return showAllRows
-      ? expandedDataList.length * getHeight(rowHeight) +
-          getHeight(columnHeaderHeight) +
-          getHeight(rowHeight, tableHeaderHeight)
+      ? expandedDataList.length * getHeight(rowHeight) + this.getColumnHeaderHeight()
       : height || 0;
   };
 
-  private shouldRenderHeader = () => {
+  private getColumnHeaderHeight = () => {
+    const { columnHeaderHeight, rowHeight } = this.props;
+
+    return getHeight(rowHeight, columnHeaderHeight);
+  };
+
+  private shouldRenderTableHeader = () => {
     const { editable, extraHeaderButtons, tableHeaderLabel } = this.props;
 
     return editable || extraHeaderButtons!.length > 0 || !!tableHeaderLabel;
@@ -361,14 +365,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     expandedDataList[index];
 
   render() {
-    const {
-      columnHeaderHeight,
-      expandable,
-      propagateRef,
-      rowHeight,
-      selectable,
-      styles,
-    } = this.props;
+    const { expandable, propagateRef, rowHeight, selectable, styles } = this.props;
 
     const {
       sortedDataList,
@@ -389,7 +386,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
     return (
       <div>
-        {this.shouldRenderHeader() && (
+        {this.shouldRenderTableHeader() && (
           <AutoSizer disableHeight>
             {({ width }: { width: number }) => this.renderTableHeader(width)}
           </AutoSizer>
@@ -400,7 +397,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
               <Table
                 height={this.getTableHeight(expandedDataList)}
                 width={this.props.width || width}
-                headerHeight={getHeight(rowHeight, columnHeaderHeight)}
+                headerHeight={this.getColumnHeaderHeight()}
                 ref={propagateRef}
                 rowCount={expandedDataList.length}
                 rowHeight={HEIGHT_TO_PX[rowHeight!]}

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -151,8 +151,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     }
   };
 
-  // Prettier throws a weird error here that cascades badly.
-  // eslint-disable-next-line
   private expandRow = (newExpandedRowIndex: number) => (
     event: React.SyntheticEvent<EventTarget>,
   ) => {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -1,6 +1,8 @@
 import React from 'react';
-import { SortDirectionType } from 'react-virtualized';
+import { SortDirectionType, Table } from 'react-virtualized';
 import { WithStylesProps } from '../../composers/withStyles';
+
+export type TableRef = React.RefObject<Table>;
 
 export type RowHeightOptions = string;
 export type HeightOptions = RowHeightOptions | undefined;
@@ -52,7 +54,7 @@ export interface DataTableProps {
   data?: ParentRow[];
   /** When instant edit is disabled, callback on edit application. */
   defaultEditCallback?: EditCallback;
-  /** Specifies whether or not editMode can be enabled */
+  /** Specifies whether or not editMode can be enabled. */
   editable?: boolean;
   /** Callback overides for instant edit on specific keys. */
   editCallbacks?: { [key: string]: EditCallback };
@@ -68,6 +70,8 @@ export interface DataTableProps {
   instantEdit?: boolean;
   /** References row fields to render as columns, infered from data if not specified. */
   keys?: string[];
+  /** Propogated as the 'ref' prop to the underlying react-virtualized Table instance. */
+  propagateRef: TableRef;
   /** Custom renderers mapped to column keys. */
   renderers?: Renderers;
   /** Height of table rows, default for table header and column header height. */
@@ -76,6 +80,12 @@ export interface DataTableProps {
   selectable?: boolean;
   /** If enabled, clicking the row triggers the same function as click the selection checkbox. */
   selectOnRowClick?: boolean;
+  /**
+   * If true, will set Table height to accomodate showing _all_ rows.
+   * This effectively _disables_ virtualized row rendering and may have detrimental
++  * performance implications for rendering many rows.
+   * */
+  showAllRows?: boolean;
   /** If enabled, renders a border between each column. */
   showColumnDividers?: boolean;
   /** If enabled, renders a border between each row. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -71,7 +71,7 @@ export interface DataTableProps {
   /** References row fields to render as columns, infered from data if not specified. */
   keys?: string[];
   /** Propagated as the 'ref' prop to the underlying react-virtualized Table instance. */
-  propagateRef: TableRef;
+  propagateRef?: TableRef;
   /** Custom renderers mapped to column keys. */
   renderers?: Renderers;
   /** Height of table rows, default for table header and column header height. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -70,7 +70,7 @@ export interface DataTableProps {
   instantEdit?: boolean;
   /** References row fields to render as columns, infered from data if not specified. */
   keys?: string[];
-  /** Propogated as the 'ref' prop to the underlying react-virtualized Table instance. */
+  /** Propagated as the 'ref' prop to the underlying react-virtualized Table instance. */
   propagateRef: TableRef;
   /** Custom renderers mapped to column keys. */
   renderers?: Renderers;

--- a/packages/core/src/components/private/BaseCheckBox.tsx
+++ b/packages/core/src/components/private/BaseCheckBox.tsx
@@ -42,8 +42,6 @@ class BaseCheckBox extends React.Component<Props & WithStylesProps> {
       ...restProps
     } = this.props;
 
-    console.log(indeterminate);
-
     return (
       <label htmlFor={id} {...css(styles.checkbox, hideLabel && styles.checkbox_hideLabel)}>
         <FormInput

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -567,9 +567,9 @@ describe('<DataTable />', () => {
   });
 
   it('Propagates a ref to the underlying Table', () => {
-    const ref = jest.fn();
+    const ref = React.createRef<Table>();
     mount(<DataTable data={data} propagateRef={ref} />);
 
-    expect(ref).toHaveBeenCalledTimes(1);
+    expect(ref.current).toBeDefined();
   });
 });

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -362,7 +362,7 @@ describe('<DataTable /> renders column labels', () => {
     ).dive();
     const table = wrapper
       .find(AutoSizer)
-      .at(1)
+      .at(0)
       .dive()
       .find(Table)
       .dive();
@@ -540,5 +540,36 @@ describe('<DataTable /> does not break with weird props', () => {
     const table = mount(<DataTable />);
 
     expect(!!table).toBe(true);
+  });
+});
+
+describe('<DataTable />', () => {
+  it('Auto-computes height when showAllRows is `true`', () => {
+    const height = 50;
+    const wrapper = shallow(<DataTable data={data} height={height} />).dive();
+    let table = wrapper
+      .find(AutoSizer)
+      .at(0)
+      .dive()
+      .find(Table);
+
+    expect(table.prop('height')).toBe(height);
+
+    wrapper.setProps({ showAllRows: true });
+
+    table = wrapper
+      .find(AutoSizer)
+      .at(0)
+      .dive()
+      .find(Table);
+
+    expect(table.prop('height')).toBeGreaterThan(height);
+  });
+
+  it('Propagates a ref to the underlying Table', () => {
+    const ref = jest.fn();
+    mount(<DataTable data={data} propagateRef={ref} />);
+
+    expect(ref).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @schillerk

## Description

This PR adds a couple usability props to the `DataTable`:
- Adds `showAllRows` prop that will auto-compute and set the `height` of the table to show all rows (including expanded ones)
- Adds `propagateRef` prop that will set a ref to the underlying `react-virtualized` table. I've found this useful for e.g., calling `ref.forceUpdateGrid()` upon data loading with e.g., [`InfiniteLoader`](https://github.com/bvaughn/react-virtualized/blob/master/docs/InfiniteLoader.md)
- Updates the `TableHeader` styles to add a `theme` `background` and use `padding` over `margin` (so `background` takes up the full component background)

Added a storybook example for the `showAllRows` prop.

## Motivation and Context

Features improved usability in another app for me.

## Testing

- [x] functional / storybook
- [x] add unit test for `showAllRows`
- [x] add unit test for `propogateRef`

## Screenshots

**Before**  
(no `TableHeader` background, no `showAllRows`)
_note scroll / static `height`_
<img src="https://user-images.githubusercontent.com/4496521/57402223-b30edf80-718b-11e9-86c0-82541d2de9bf.gif" width="600" />

**After**
Storybook example for `showAllRows`
<img src="https://user-images.githubusercontent.com/4496521/57402222-b30edf80-718b-11e9-88e1-8939f4934b87.gif" width="600" />

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
