### PR TITLE
docs(DataTable): update type descriptions

### DIFF
--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -52,11 +52,11 @@ export interface DataTableProps {
   columnMetadata?: ColumnMetadata;
   /** Array of data rows. */
   data?: ParentRow[];
-  /** When instant edit is disabled, callback on edit application. */
+  /** Default callback on all edits. */
   defaultEditCallback?: EditCallback;
   /** Specifies whether or not editMode can be enabled. */
   editable?: boolean;
-  /** Callback overides for instant edit on specific keys. */
+  /** Callback for any specific key, called on all edits. */
   editCallbacks?: { [key: string]: EditCallback };
   /** When instant edit is disabled, callback that gets trigged on edit application. */
   enactEditsCallback?: (changeLog: ChangeLog) => void;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
I realized while updating the design doc that the existing type descriptions were not actually accurate, `defaultEditCallback` and `editCallbacks` will be called regardless of whether or not `instantEdit` is enabled.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
