### PR TITLE
update(Modal): Adding a fitContent prop

### DIFF
--- a/packages/core/src/components/Modal.story.tsx
+++ b/packages/core/src/components/Modal.story.tsx
@@ -10,7 +10,7 @@ import Text from './Text';
 import Modal from './Modal';
 
 class ModalDemo extends React.Component<
-  { large?: boolean; noTitle?: boolean; image?: 'center' | 'cover' },
+  { large?: boolean; noTitle?: boolean; fitContent?: boolean; image?: 'center' | 'cover' },
   { visible: boolean }
 > {
   state = { visible: false };
@@ -21,7 +21,7 @@ class ModalDemo extends React.Component<
 
   render() {
     const { visible } = this.state;
-    const { image, large, noTitle } = this.props;
+    const { image, fitContent, large, noTitle } = this.props;
 
     return (
       <div>
@@ -36,6 +36,7 @@ class ModalDemo extends React.Component<
               }
             }
             large={large}
+            fitContent={fitContent}
             footer={
               <ButtonGroup>
                 <Button onClick={this.handleToggle}>OK</Button>
@@ -76,4 +77,5 @@ storiesOf('Core/Modal', module)
   .add('A large modal.', () => <ModalDemo large />)
   .add('With no title.', () => <ModalDemo noTitle />)
   .add('With a centered image.', () => <ModalDemo image="center" />)
-  .add('With a right cover image.', () => <ModalDemo image="cover" />);
+  .add('With a right cover image.', () => <ModalDemo image="cover" />)
+  .add('Sized to fit content.', () => <ModalDemo fitContent />);

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -10,6 +10,8 @@ export const MODAL_MAX_WIDTH_SMALL = 568;
 export type Props = ModalInnerContentProps & {
   /** Image configuration to be used as the right pane in a dual pane layout. If provided, will force the modal to a `large` layout. */
   image?: ModalImageConfig;
+  /** True to show a version of the dialog that scales to the content size */
+  fitContent?: boolean;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
@@ -66,8 +68,8 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
   };
 
   render() {
-    const { children, footer, image, large, styles, title } = this.props;
-    const showLargeContent = large || !!image;
+    const { children, footer, image, large, fitContent, styles, title } = this.props;
+    const showLargeContent = large || fitContent || !!image;
 
     const innerContent = (
       <ModalInnerContent
@@ -85,7 +87,11 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
         aria-modal
         role="dialog"
         ref={this.dialogRef}
-        {...css(styles.content, showLargeContent && styles.responsiveContent)}
+        {...css(
+          styles.content,
+          showLargeContent && styles.responsiveContent,
+          fitContent && styles.fitContent,
+        )}
       >
         <FocusTrap>
           {image ? <ModalImageLayout {...image}>{innerContent}</ModalImageLayout> : innerContent}
@@ -117,5 +123,10 @@ export default withStyles(({ color, responsive, ui }) => ({
         maxWidth: MODAL_MAX_WIDTH_SMALL,
       },
     },
+  },
+
+  fitContent: {
+    maxWidth: '100%',
+    width: 'auto',
   },
 }))(ModalInner);


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adding a `fitContent` prop to the modal that will scale the modal automatically to fit the content up to 100% of the available width (there's still padding thanks to the spacing around the portal)

## Motivation and Context

Need a modal of the maximum possible size for a lightbox

## Testing

This is a CSS change, the modal scales to fit various sizes of content

## Screenshots

<img width="1080" alt="Screen Shot 2019-05-20 at 2 14 19 PM" src="https://user-images.githubusercontent.com/320562/58052408-9a96b180-7b09-11e9-8edc-7c12c8ff5bc6.png">
<img width="2267" alt="Screen Shot 2019-05-20 at 2 14 33 PM" src="https://user-images.githubusercontent.com/320562/58052412-9cf90b80-7b09-11e9-94dd-2be559cb0e06.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
