### PR TITLE
fix: Remove Babel runtime setup

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -56,33 +56,5 @@ module.exports = async ({ config }) => {
     config.resolve.alias[`${name}/lib`] = `${name}/src`;
   });
 
-  // Temporary fix until Storybook supports core-js v3
-  delete config.resolve.alias['core-js'];
-
-  config.resolve.alias['core-js/modules/es.string.match$'] = path.resolve(
-    __dirname,
-    '../node_modules/core-js/modules/es.string.match',
-  );
-
-  config.resolve.alias['core-js/modules/es.string.replace$'] = path.resolve(
-    __dirname,
-    '../node_modules/core-js/modules/es.string.replace',
-  );
-
-  config.resolve.alias['core-js/modules/es.string.split$'] = path.resolve(
-    __dirname,
-    '../node_modules/core-js/modules/es.string.split',
-  );
-
-  config.resolve.alias['core-js/modules/web.dom-collections.iterator$'] = path.resolve(
-    __dirname,
-    '../node_modules/core-js/modules/web.dom-collections.iterator',
-  );
-
-  config.resolve.alias['core-js'] = path.resolve(
-    __dirname,
-    '../node_modules/@storybook/core/node_modules/core-js',
-  );
-
   return config;
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,13 +12,6 @@ const plugins = [
   '@babel/plugin-proposal-class-properties',
   '@babel/plugin-proposal-optional-catch-binding',
   '@babel/plugin-syntax-dynamic-import',
-  [
-    '@babel/plugin-transform-runtime',
-    {
-      corejs: 3,
-      regenerator: false,
-    },
-  ],
 ];
 
 if (process.env.NODE_ENV === 'test') {

--- a/babel.config.js
+++ b/babel.config.js
@@ -40,11 +40,11 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        corejs: 3,
+        // corejs: 3,
         loose: true,
         modules: ESM ? false : 'commonjs',
         shippedProposals: true,
-        useBuiltIns: 'usage',
+        // useBuiltIns: 'usage',
       },
     ],
     '@babel/preset-react',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6361,12 +6361,6 @@
         "toggle-selection": "^1.0.6"
       }
     },
-    "core-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-      "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
-      "dev": true
-    },
     "core-js-compat": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,18 +1025,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
-      "integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
-      }
-    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -1219,15 +1207,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
       "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.4.4.tgz",
-      "integrity": "sha512-9uYCgQvCVw4Jl5vVyTt6ZYIAgsLyAKx0CvBqOJW0D/bRx/jSOQS1A+31GiisgKhgyTt3/CWnbdGzFxxw8NOtlw==",
-      "requires": {
-        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "babel-plugin-transform-dev": "^2.0.1",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "conventional-changelog-beemo": "^1.2.1",
-    "core-js": "^3.0.1",
     "danger": "^7.1.3",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -30,7 +30,6 @@
     "react-test-renderer": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/graphql": "^14.2.0",
     "@types/lodash": "^4.14.123",
     "apollo-cache-inmemory": "^1.5.1",

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -24,7 +24,6 @@
     "react": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/shallowequal": "^1.1.1",
     "@types/uuid": "^3.4.4",
     "shallowequal": "^1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/airbnb-prop-types": "^2.11.0",
     "@types/hoist-non-react-statics": "^3.3.0",
     "@types/lodash": "^4.14.123",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -24,7 +24,6 @@
     "react": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/airbnb-prop-types": "^2.11.0",
     "@types/lodash": "^4.14.123",
     "@types/prop-types": "^15.7.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -24,7 +24,6 @@
     "react": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/react": "^16.8.15"
   }
 }

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -24,7 +24,6 @@
     "react": "^16.8.6"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/airbnb-prop-types": "^2.11.0",
     "airbnb-prop-types": "^2.12.0",
     "utility-types": "^3.5.0"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -20,7 +20,6 @@
     "@airbnb/lunar": "^1.0.0"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.4.3",
     "@types/new-relic-browser": "0.1072.1",
     "raven-js": "^3.27.0"
   }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

I initially setup Lunar to build with Babel runtime + CoreJS v3 for smaller file sizes, but this seems to cause many issues downstream, as using CoreJS v2 and CoreJS v3 in parallel can be quite problematic. It's also complicated to configure correctly (as seen by the storybook config).

While removing the runtime setup, I logged the before and after state of the entire "esm" folder for each package (kilobytes in the table below). While the runtime did have smaller file sizes, it wasn't that much savings in the grand scheme of things. 

| | With runtime | Without |
| ---  | --- | --- |
| apollo | 9,462 | 10,500 |
| app-shell | 8,855 | 9,564 |
| core | 545,207 | 572,108 |
| forms | 40,679 | 39,455 |
| icons | 98,953 | 139,280 |
| layouts | 10,673 | 13,356 |
| metrics | 3,928 | 3,671 |
| test-utils | 3,997 | 3,997 |

Once the community has adopted CoreJS v3 more, we can revisit this feature.

## Motivation and Context

Make downstream consumption much easier.

## Testing

Tests and lints pass. Storybook still renders correctly.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
