### PR TITLE
update(Chip): Add new compact and active props

### DIFF
--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -12,6 +12,21 @@ storiesOf('Core/Chip', module)
     inspectComponents: [Chip],
   })
   .add('Simple chip.', () => <Chip>Chip</Chip>)
+  .add('Compact chip.', () => (
+    <>
+      <Spacing right={1} inline>
+        <Chip compact onClick={action('onClick')}>
+          Chip
+        </Chip>
+      </Spacing>
+
+      <Spacing right={0} inline>
+        <Chip compact active onClick={action('onClick')}>
+          Chip
+        </Chip>
+      </Spacing>
+    </>
+  ))
   .add('With an icon.', () => <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>)
   .add('With an icon button.', () => (
     <>

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -7,8 +7,12 @@ import ProfilePhoto from '../ProfilePhoto';
 import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
 export type Props = {
+  /** Renders with a primary background and white text */
+  active: boolean;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
+  /** Renders with less padding and sharper corners */
+  compact: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
   /** Icon to render to the right of the primary content. */
@@ -29,7 +33,17 @@ export class Chip extends React.Component<Props & WithStylesProps> {
   };
 
   render() {
-    const { children, disabled, icon, onClick, onIconClick, profileImageSrc, styles } = this.props;
+    const {
+      active,
+      children,
+      compact,
+      disabled,
+      icon,
+      onClick,
+      onIconClick,
+      profileImageSrc,
+      styles,
+    } = this.props;
 
     const Component = onClick ? 'button' : 'div';
     const props: React.HTMLProps<HTMLButtonElement> =
@@ -49,6 +63,9 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           onClick && styles.chip_button,
           !profileImageSrc && styles.chip_noBefore,
           !icon && styles.chip_noAfter,
+          active && styles.chip_active,
+          onClick && active && styles.chip_active_button,
+          compact && styles.chip_compact,
           disabled && styles.chip_disabled,
         )}
         {...props}
@@ -105,6 +122,38 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
 
   chip_noAfter: {
     paddingRight: unit,
+  },
+
+  chip_active: {
+    background: color.core.primary[3],
+    borderColor: color.core.primary[3],
+    color: color.accent.bg,
+  },
+
+  chip_active_button: {
+    cursor: 'pointer',
+    padding: 0,
+
+    '@selectors': {
+      ':not([disabled]):active': {
+        boxShadow: ui.boxShadow,
+      },
+
+      ':not([disabled]):hover': {
+        backgroundColor: color.core.primary[2],
+      },
+    },
+
+    ':focus': {
+      backgroundColor: color.accent.bgHover,
+      outline: 'none',
+    },
+  },
+
+  chip_compact: {
+    borderRadius: 2,
+    padding: `0 ${unit}`,
+    height: 3 * unit,
   },
 
   chip_disabled: {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -11,7 +11,7 @@ export type Props = {
   active?: boolean;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
-  /** Renders with less padding and sharper corners */
+  /** Renders with less padding and sharper corners. */
   compact?: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
@@ -133,7 +133,7 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
   chip_active_button: {
     '@selectors': {
       ':not([disabled]):hover': {
-        backgroundColor: color.core.primary[2],
+        backgroundColor: color.core.primary[4],
       },
     },
   },

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -8,11 +8,11 @@ import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
 export type Props = {
   /** Renders with a primary background and white text */
-  active: boolean;
+  active?: boolean;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
   /** Renders with less padding and sharper corners */
-  compact: boolean;
+  compact?: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
   /** Icon to render to the right of the primary content. */

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -131,22 +131,10 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
   },
 
   chip_active_button: {
-    cursor: 'pointer',
-    padding: 0,
-
     '@selectors': {
-      ':not([disabled]):active': {
-        boxShadow: ui.boxShadow,
-      },
-
       ':not([disabled]):hover': {
         backgroundColor: color.core.primary[2],
       },
-    },
-
-    ':focus': {
-      backgroundColor: color.accent.bgHover,
-      outline: 'none',
     },
   },
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @kenchendesign 

## Description
Is there any reason we don't use `defaultProps` for `Chip`?

Right now, I just use the existing hover state, but Ken's original design uses border color instead of background. I don't know how to make something like this configurable through props since `withStyles` doesn't have access to props and inline styles can't describe hover effects.

<!--- Describe your change in detail. -->

## Motivation and Context
See previous discussion here:
https://git.musta.ch/airbnb/solar/issues/824

<!--- Why is this change required? What problem does it solve? -->

## Testing
Tested in storybook.
<!--- Please describe in detail how you tested your change. -->

## Screenshots
![Screen Shot 2019-05-22 at 4 19 29 PM](https://user-images.githubusercontent.com/8676510/58215171-6a881380-7cad-11e9-8a21-c37b0176476b.png)

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
