### PR TITLE
break(Chip): Add beforeIcon and afterIcon props. Remove icon prop.

### DIFF
--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -35,7 +35,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
+        <Chip before={<IconCalendar size="1.2em" />}>Calendar</Chip>
       </Spacing>
     </>
   ))

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import IconCalendar from '@airbnb/lunar-icons/lib/general/IconCalendar';
 import IconCloseAlt from '@airbnb/lunar-icons/lib/interface/IconCloseAlt';
 import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import lunar from ':storybook/images/lunar-logo.png';
@@ -27,7 +28,17 @@ storiesOf('Core/Chip', module)
       </Spacing>
     </>
   ))
-  .add('With an icon.', () => <Chip icon={<IconCloseAlt decorative size="2em" />}>Chip</Chip>)
+  .add('With a icons before or after.', () => (
+    <>
+      <Spacing right={1} inline>
+        <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>
+      </Spacing>
+
+      <Spacing right={0} inline>
+        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
+      </Spacing>
+    </>
+  ))
   .add('With an icon button.', () => (
     <>
       <Spacing right={1} inline>

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import IconCalendar from '@airbnb/lunar-icons/lib/general/IconCalendar';
+import IconUser from '@airbnb/lunar-icons/lib/general/IconUser';
 import IconCloseAlt from '@airbnb/lunar-icons/lib/interface/IconCloseAlt';
 import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import lunar from ':storybook/images/lunar-logo.png';
@@ -13,10 +14,57 @@ storiesOf('Core/Chip', module)
     inspectComponents: [Chip],
   })
   .add('Simple chip.', () => <Chip>Chip</Chip>)
+  .add('With a icons before or after.', () => (
+    <>
+      <Spacing right={1} inline>
+        <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>
+      </Spacing>
+
+      <Spacing right={1} inline>
+        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
+      </Spacing>
+
+      <Spacing right={1} inline>
+        <Chip icon={<IconCloseAlt size="2em" />} beforeIcon={<IconUser size="1.2em" />}>
+          Calendar
+        </Chip>
+      </Spacing>
+
+      <Spacing right={0} inline>
+        <Chip icon={<IconCloseAlt size="2em" />} beforeIcon={<IconCalendar size="1.2em" />}>
+          Calendar
+        </Chip>
+      </Spacing>
+    </>
+  ))
   .add('Compact chip.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip compact onClick={action('onClick')}>
+        <Chip profileImageSrc={lunar} compact onClick={action('onClick')}>
+          Chip
+        </Chip>
+      </Spacing>
+
+      <Spacing right={1} inline>
+        <Chip beforeIcon={<IconUser size="1.2em" />} compact onClick={action('onClick')}>
+          Chip
+        </Chip>
+      </Spacing>
+
+      <Spacing right={1} inline>
+        <Chip afterIcon={<IconCalendar size="1.2em" />} compact onClick={action('onClick')}>
+          Chip
+        </Chip>
+      </Spacing>
+
+      <Spacing right={1} inline>
+        <Chip
+          active
+          beforeIcon={<IconUser size="1.2em" />}
+          afterIcon={<IconCalendar size="1.2em" />}
+          compact
+          onClick={action('onClick')}
+        >
           Chip
         </Chip>
       </Spacing>
@@ -25,17 +73,6 @@ storiesOf('Core/Chip', module)
         <Chip compact active onClick={action('onClick')}>
           Chip
         </Chip>
-      </Spacing>
-    </>
-  ))
-  .add('With a icons before or after.', () => (
-    <>
-      <Spacing right={1} inline>
-        <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>
-      </Spacing>
-
-      <Spacing right={0} inline>
-        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
       </Spacing>
     </>
   ))

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -8,6 +8,7 @@ import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import lunar from ':storybook/images/lunar-logo.png';
 import Spacing from './Spacing';
 import Chip from './Chip';
+import Text from './Text';
 
 storiesOf('Core/Chip', module)
   .addParameters({
@@ -16,14 +17,15 @@ storiesOf('Core/Chip', module)
   .add('Simple chip.', () => <Chip>Chip</Chip>)
   .add('With a icons before and/or after.', () => (
     <>
+      <Spacing bottom={1}>
+        <Text>Note that before/after padding is not symetrical</Text>
+      </Spacing>
       <Spacing right={1} inline>
         <Chip afterIcon={<IconCloseAlt size="2em" />}>Chip</Chip>
       </Spacing>
-
       <Spacing right={1} inline>
         <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
       </Spacing>
-
       <Spacing right={1} inline>
         <Chip afterIcon={<IconCalendar size="1.2em" />} beforeIcon={<IconCalendar size="1.2em" />}>
           Calendar
@@ -33,6 +35,10 @@ storiesOf('Core/Chip', module)
   ))
   .add('Compact chip.', () => (
     <>
+      <Spacing bottom={1}>
+        <Text>Note that before/after padding is not symetrical</Text>
+      </Spacing>
+
       <Spacing right={1} inline>
         <Chip beforeIcon={<IconUser size="1.2em" />} compact onClick={action('onClick')}>
           Chip
@@ -41,18 +47,6 @@ storiesOf('Core/Chip', module)
 
       <Spacing right={1} inline>
         <Chip afterIcon={<IconCalendar size="1.2em" />} compact onClick={action('onClick')}>
-          Chip
-        </Chip>
-      </Spacing>
-
-      <Spacing right={1} inline>
-        <Chip
-          active
-          beforeIcon={<IconUser size="1.2em" color="white" />}
-          afterIcon={<IconCalendar size="1.2em" color="white" />}
-          compact
-          onClick={action('onClick')}
-        >
           Chip
         </Chip>
       </Spacing>

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -21,13 +21,16 @@ storiesOf('Core/Chip', module)
         <Text>Note that before/after padding is not symetrical</Text>
       </Spacing>
       <Spacing right={1} inline>
-        <Chip afterIcon={<IconCloseAlt size="2em" />}>Chip</Chip>
+        <Chip afterIcon={<IconCloseAlt decorative size="2em" />}>Chip</Chip>
       </Spacing>
       <Spacing right={1} inline>
-        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
+        <Chip beforeIcon={<IconCalendar decorative size="1.2em" />}>Calendar</Chip>
       </Spacing>
       <Spacing right={1} inline>
-        <Chip afterIcon={<IconCalendar size="1.2em" />} beforeIcon={<IconCalendar size="1.2em" />}>
+        <Chip
+          afterIcon={<IconCalendar decorative size="1.2em" />}
+          beforeIcon={<IconCalendar decorative size="1.2em" />}
+        >
           Calendar
         </Chip>
       </Spacing>
@@ -40,13 +43,17 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip beforeIcon={<IconUser size="1.2em" />} compact onClick={action('onClick')}>
+        <Chip beforeIcon={<IconUser decorative size="1.2em" />} compact onClick={action('onClick')}>
           Chip
         </Chip>
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip afterIcon={<IconCalendar size="1.2em" />} compact onClick={action('onClick')}>
+        <Chip
+          afterIcon={<IconCalendar decorative size="1.2em" />}
+          compact
+          onClick={action('onClick')}
+        >
           Chip
         </Chip>
       </Spacing>
@@ -61,13 +68,20 @@ storiesOf('Core/Chip', module)
   .add('With an icon button.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip afterIcon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
+        <Chip
+          afterIcon={<IconCloseAlt decorative size="2em" />}
+          onIconClick={action('onIconClick')}
+        >
           Close
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip disabled afterIcon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
+        <Chip
+          disabled
+          afterIcon={<IconCloseAlt decorative size="2em" />}
+          onIconClick={action('onIconClick')}
+        >
           Close
         </Chip>
       </Spacing>
@@ -75,7 +89,7 @@ storiesOf('Core/Chip', module)
   ))
   .add('With a profile photo.', () => <Chip profileImageSrc={lunar}>User</Chip>)
   .add('With both a profile photo and an icon.', () => (
-    <Chip afterIcon={<IconSettings size="2em" />} profileImageSrc={lunar}>
+    <Chip afterIcon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
       Settings
     </Chip>
   ))
@@ -86,13 +100,13 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip disabled afterIcon={<IconSettings size="2em" />} profileImageSrc={lunar}>
+        <Chip disabled afterIcon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
           User
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip disabled afterIcon={<IconSettings size="2em" />}>
+        <Chip disabled afterIcon={<IconSettings decorative size="2em" />}>
           Settings
         </Chip>
       </Spacing>
@@ -106,7 +120,7 @@ storiesOf('Core/Chip', module)
 
       <Spacing right={1} inline>
         <Chip
-          afterIcon={<IconSettings size="2em" />}
+          afterIcon={<IconSettings decorative size="2em" />}
           profileImageSrc={lunar}
           onClick={action('onClick')}
         >
@@ -115,7 +129,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip afterIcon={<IconSettings size="2em" />} onClick={action('onClick')}>
+        <Chip afterIcon={<IconSettings decorative size="2em" />} onClick={action('onClick')}>
           Settings
         </Chip>
       </Spacing>

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -40,12 +40,6 @@ storiesOf('Core/Chip', module)
   .add('Compact chip.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip profileImageSrc={lunar} compact onClick={action('onClick')}>
-          Chip
-        </Chip>
-      </Spacing>
-
-      <Spacing right={1} inline>
         <Chip beforeIcon={<IconUser size="1.2em" />} compact onClick={action('onClick')}>
           Chip
         </Chip>
@@ -60,8 +54,8 @@ storiesOf('Core/Chip', module)
       <Spacing right={1} inline>
         <Chip
           active
-          beforeIcon={<IconUser size="1.2em" />}
-          afterIcon={<IconCalendar size="1.2em" />}
+          beforeIcon={<IconUser size="1.2em" color="white" />}
+          afterIcon={<IconCalendar size="1.2em" color="white" />}
           compact
           onClick={action('onClick')}
         >

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -35,7 +35,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip before={<IconCalendar size="1.2em" />}>Calendar</Chip>
+        <Chip beforeIcon={<IconCalendar size="1.2em" />}>Calendar</Chip>
       </Spacing>
     </>
   ))

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -14,10 +14,10 @@ storiesOf('Core/Chip', module)
     inspectComponents: [Chip],
   })
   .add('Simple chip.', () => <Chip>Chip</Chip>)
-  .add('With a icons before or after.', () => (
+  .add('With a icons before and/or after.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>
+        <Chip afterIcon={<IconCloseAlt size="2em" />}>Chip</Chip>
       </Spacing>
 
       <Spacing right={1} inline>
@@ -25,13 +25,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip icon={<IconCloseAlt size="2em" />} beforeIcon={<IconUser size="1.2em" />}>
-          Calendar
-        </Chip>
-      </Spacing>
-
-      <Spacing right={0} inline>
-        <Chip icon={<IconCloseAlt size="2em" />} beforeIcon={<IconCalendar size="1.2em" />}>
+        <Chip afterIcon={<IconCalendar size="1.2em" />} beforeIcon={<IconCalendar size="1.2em" />}>
           Calendar
         </Chip>
       </Spacing>
@@ -73,17 +67,13 @@ storiesOf('Core/Chip', module)
   .add('With an icon button.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip icon={<IconCloseAlt decorative size="2em" />} onIconClick={action('onIconClick')}>
+        <Chip afterIcon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
           Close
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip
-          disabled
-          icon={<IconCloseAlt decorative size="2em" />}
-          onIconClick={action('onIconClick')}
-        >
+        <Chip disabled afterIcon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
           Close
         </Chip>
       </Spacing>
@@ -91,7 +81,7 @@ storiesOf('Core/Chip', module)
   ))
   .add('With a profile photo.', () => <Chip profileImageSrc={lunar}>User</Chip>)
   .add('With both a profile photo and an icon.', () => (
-    <Chip icon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
+    <Chip afterIcon={<IconSettings size="2em" />} profileImageSrc={lunar}>
       Settings
     </Chip>
   ))
@@ -102,13 +92,13 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip disabled icon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
+        <Chip disabled afterIcon={<IconSettings size="2em" />} profileImageSrc={lunar}>
           User
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip disabled icon={<IconSettings decorative size="2em" />}>
+        <Chip disabled afterIcon={<IconSettings size="2em" />}>
           Settings
         </Chip>
       </Spacing>
@@ -122,7 +112,7 @@ storiesOf('Core/Chip', module)
 
       <Spacing right={1} inline>
         <Chip
-          icon={<IconSettings decorative size="2em" />}
+          afterIcon={<IconSettings size="2em" />}
           profileImageSrc={lunar}
           onClick={action('onClick')}
         >
@@ -131,7 +121,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip icon={<IconSettings decorative size="2em" />} onClick={action('onClick')}>
+        <Chip afterIcon={<IconSettings size="2em" />} onClick={action('onClick')}>
           Settings
         </Chip>
       </Spacing>

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -30,7 +30,6 @@ export type Props = {
 /** Compact component that represents a snippet of information, such as a filter. */
 export class Chip extends React.Component<Props & WithStylesProps> {
   static propTypes = {
-    // icon: requiredBy('onIconClick', iconComponent),
     afterIcon: requiredBy('onIconClick', iconComponent),
     beforeIcon: mutuallyExclusiveProps(iconComponent, 'beforeIcon', 'profileImageSrc'),
     onClick: mutuallyExclusiveProps(PropTypes.func, 'onIconClick'),
@@ -95,7 +94,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
               )}
             >
               {profileImageSrc && <ProfilePhoto imageSrc={profileImageSrc} title="" size={4} />}
-              {beforeIcon && beforeIcon}
+              {beforeIcon}
             </div>
           </div>
         )}
@@ -107,7 +106,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
             >
               {onIconClick ? (
                 <ButtonOrLink
-                  className={(styles.iconButton, disabled && styles.iconButton_disabled)}
+                  className={cx(styles.iconButton, disabled && styles.iconButton_disabled)}
                   disabled={disabled}
                   onClick={onIconClick}
                 >

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -99,10 +99,12 @@ export class Chip extends React.Component<Props & WithStylesProps> {
             </div>
           </div>
         )}
-        <div {...css(styles.chipItem, styles.content)}>{children}</div>
+        <div className={cx(styles.chipItem, styles.content)}>{children}</div>
         {afterIcon && (
-          <div {...css(styles.chipItem, styles.sideContent)}>
-            <div {...css(styles.sideContentInner, styles.iconWrapper, styles.iconWrapperAfter)}>
+          <div className={cx(styles.chipItem, styles.sideContent)}>
+            <div
+              className={cx(styles.sideContentInner, styles.iconWrapper, styles.iconWrapperAfter)}
+            >
               {onIconClick ? (
                 <ButtonOrLink
                   className={(styles.iconButton, disabled && styles.iconButton_disabled)}

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -85,8 +85,8 @@ export class Chip extends React.Component<Props & WithStylesProps> {
         className={cx(
           styles.chip,
           onClick && styles.chip_button,
-          !profileImageSrc && styles.chip_noBefore,
-          !icon && styles.chip_noAfter,
+          !shouldRenderBefore && styles.chip_noBefore,
+          !shouldRenderAfter && styles.chip_noAfter,
           active && styles.chip_active,
           onClick && active && styles.chip_active_button,
           compact && styles.chip_compact,
@@ -96,7 +96,13 @@ export class Chip extends React.Component<Props & WithStylesProps> {
       >
         {shouldRenderBefore && (
           <div className={cx(styles.chipItem, styles.sideContent)}>
-            <div className={cx(styles.sideContentInner)}>
+            <div
+              className={cx(
+                styles.sideContentInner,
+                !!beforeIcon && styles.iconWrapper,
+                !!beforeIcon && styles.iconWrapperBefore,
+              )}
+            >
               {profileImageSrc && <ProfilePhoto imageSrc={profileImageSrc} title="" size={4} />}
               {beforeIcon && beforeIcon}
             </div>
@@ -107,7 +113,9 @@ export class Chip extends React.Component<Props & WithStylesProps> {
 
         {shouldRenderAfter && (
           <div className={cx(styles.chipItem, styles.sideContent)}>
-            <div className={cx(styles.sideContentInner, styles.iconWrapper)}>
+            <div
+              className={cx(styles.sideContentInner, styles.iconWrapper, styles.iconWrapperAfter)}
+            >
               {onIconClick ? (
                 <ButtonOrLink
                   className={(styles.iconButton, disabled && styles.iconButton_disabled)}
@@ -210,8 +218,15 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
   },
 
   iconWrapper: {
-    padding: `${unit * 0.5}px ${unit * 0.5}px ${unit * 0.5}px 0`,
     color: color.core.neutral[3],
+  },
+
+  iconWrapperAfter: {
+    padding: `${unit * 0.5}px ${unit * 0.5}px ${unit * 0.5}px 0`,
+  },
+
+  iconWrapperBefore: {
+    padding: `${unit * 0.5}px 0 ${unit * 0.5}px ${unit * 0.5}px`,
   },
 
   iconButton: {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { mutuallyExclusiveProps, requiredBy } from 'airbnb-prop-types';
+import { mutuallyExclusiveProps, mutuallyExclusiveTrueProps, requiredBy } from 'airbnb-prop-types';
 import iconComponent from '../../prop-types/iconComponent';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import ProfilePhoto from '../ProfilePhoto';
@@ -9,6 +9,8 @@ import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 export type Props = {
   /** Renders with a primary background and white text. */
   active?: boolean;
+  /** Icon to render to the left of the primary content. */
+  beforeIcon?: React.ReactNode;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
   /** Renders with less padding and sharper corners. */
@@ -25,17 +27,22 @@ export type Props = {
   profileImageSrc?: string;
 };
 
+const beforePropType = mutuallyExclusiveTrueProps('beforeIcon', 'profileImageSrc');
+
 /** Compact component that represents a snippet of information, such as a filter. */
 export class Chip extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     icon: requiredBy('onIconClick', iconComponent),
     onClick: mutuallyExclusiveProps(PropTypes.func, 'onIconClick'),
+    beforeIcon: beforePropType,
+    profileImageSrc: beforePropType,
   };
 
   render() {
     const {
       cx,
       active,
+      beforeIcon,
       children,
       compact,
       disabled,
@@ -71,10 +78,11 @@ export class Chip extends React.Component<Props & WithStylesProps> {
         )}
         {...props}
       >
-        {profileImageSrc && (
+        {(beforeIcon || profileImageSrc) && (
           <div className={cx(styles.chipItem, styles.sideContent)}>
             <div className={cx(styles.sideContentInner)}>
-              <ProfilePhoto imageSrc={profileImageSrc} title="" size={4} />
+              {profileImageSrc && <ProfilePhoto imageSrc={profileImageSrc} title="" size={4} />}
+              {beforeIcon && beforeIcon}
             </div>
           </div>
         )}

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -74,6 +74,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
         : {};
 
     const shouldRenderAfter = afterIcon || icon;
+    const shouldRenderBefore = beforeIcon || profileImageSrc;
 
     return (
       // @ts-ignore [ts] JSX element type 'Component' does not have any construct or call signatures. [2604]
@@ -90,7 +91,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
         )}
         {...props}
       >
-        {(beforeIcon || profileImageSrc) && (
+        {shouldRenderBefore && (
           <div className={cx(styles.chipItem, styles.sideContent)}>
             <div className={cx(styles.sideContentInner)}>
               {profileImageSrc && <ProfilePhoto imageSrc={profileImageSrc} title="" size={4} />}

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -57,6 +57,12 @@ export class Chip extends React.Component<Props & WithStylesProps> {
       styles,
     } = this.props;
 
+    if (__DEV__) {
+      if (icon) {
+        console.log('Chip: `icon` prop is deprecated, please use `afterIcon` instead.');
+      }
+    }
+
     const Component = onClick ? 'button' : 'div';
     const props: React.HTMLProps<HTMLButtonElement> =
       Component === 'button'
@@ -66,6 +72,8 @@ export class Chip extends React.Component<Props & WithStylesProps> {
             type: 'button',
           }
         : {};
+
+    const shouldRenderAfter = afterIcon || icon;
 
     return (
       // @ts-ignore [ts] JSX element type 'Component' does not have any construct or call signatures. [2604]

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -6,6 +6,8 @@ import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import ProfilePhoto from '../ProfilePhoto';
 import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
+const beforePropType = mutuallyExclusiveProps(PropTypes.any, 'before', 'profileImageSrc');
+
 export type Props = {
   /** Renders with a primary background and white text. */
   active?: boolean;
@@ -26,12 +28,6 @@ export type Props = {
   /** Profile photo to render to the left of the primary content. */
   profileImageSrc?: string;
 };
-
-const beforePropType = mutuallyExclusiveProps(
-  PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-  'before',
-  'profileImageSrc',
-);
 
 /** Compact component that represents a snippet of information, such as a filter. */
 export class Chip extends React.Component<Props & WithStylesProps> {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -102,25 +102,24 @@ export class Chip extends React.Component<Props & WithStylesProps> {
 
         <div className={cx(styles.chipItem, styles.content)}>{children}</div>
 
-        {afterIcon ||
-          (icon && (
-            <div className={cx(styles.chipItem, styles.sideContent)}>
-              <div className={cx(styles.sideContentInner, styles.iconWrapper)}>
-                {onIconClick ? (
-                  <ButtonOrLink
-                    className={(styles.iconButton, disabled && styles.iconButton_disabled)}
-                    disabled={disabled}
-                    onClick={onIconClick}
-                  >
-                    {afterIcon}
-                    {icon}
-                  </ButtonOrLink>
-                ) : (
-                  icon
-                )}
-              </div>
+        {shouldRenderAfter && (
+          <div className={cx(styles.chipItem, styles.sideContent)}>
+            <div className={cx(styles.sideContentInner, styles.iconWrapper)}>
+              {onIconClick ? (
+                <ButtonOrLink
+                  className={(styles.iconButton, disabled && styles.iconButton_disabled)}
+                  disabled={disabled}
+                  onClick={onIconClick}
+                >
+                  {afterIcon}
+                  {icon}
+                </ButtonOrLink>
+              ) : (
+                icon
+              )}
             </div>
-          ))}
+          </div>
+        )}
       </Component>
     );
   }

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -7,7 +7,7 @@ import ProfilePhoto from '../ProfilePhoto';
 import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
 export type Props = {
-  /** Renders with a primary background and white text */
+  /** Renders with a primary background and white text. */
   active?: boolean;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -10,7 +10,7 @@ export type Props = {
   /** Renders with a primary background and white text. */
   active?: boolean;
   /** Icon to render to the left of the primary content. */
-  beforeIcon?: React.ReactNode;
+  before?: React.ReactNode;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
   /** Renders with less padding and sharper corners. */

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -6,13 +6,16 @@ import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import ProfilePhoto from '../ProfilePhoto';
 import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
-const beforePropType = mutuallyExclusiveProps(PropTypes.any, 'before', 'profileImageSrc');
+const beforePropType = mutuallyExclusiveProps(PropTypes.any, 'beforeIcon', 'profileImageSrc');
+const afterPropType = mutuallyExclusiveProps(PropTypes.node, 'afterIcon', 'icon');
 
 export type Props = {
   /** Renders with a primary background and white text. */
   active?: boolean;
+  /** Icon to render to the right of the primary content. */
+  afterIcon?: React.ReactNode;
   /** Icon to render to the left of the primary content. */
-  before?: React.ReactNode;
+  beforeIcon?: React.ReactNode;
   /** Primary chip contents. */
   children: NonNullable<React.ReactNode>;
   /** Renders with less padding and sharper corners. */
@@ -42,6 +45,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
     const {
       cx,
       active,
+      afterIcon,
       beforeIcon,
       children,
       compact,
@@ -89,23 +93,25 @@ export class Chip extends React.Component<Props & WithStylesProps> {
 
         <div className={cx(styles.chipItem, styles.content)}>{children}</div>
 
-        {icon && (
-          <div className={cx(styles.chipItem, styles.sideContent)}>
-            <div className={cx(styles.sideContentInner, styles.iconWrapper)}>
-              {onIconClick ? (
-                <ButtonOrLink
-                  className={cx(styles.iconButton, disabled && styles.iconButton_disabled)}
-                  disabled={disabled}
-                  onClick={onIconClick}
-                >
-                  {icon}
-                </ButtonOrLink>
-              ) : (
-                icon
-              )}
+        {afterIcon ||
+          (icon && (
+            <div className={cx(styles.chipItem, styles.sideContent)}>
+              <div className={cx(styles.sideContentInner, styles.iconWrapper)}>
+                {onIconClick ? (
+                  <ButtonOrLink
+                    className={(styles.iconButton, disabled && styles.iconButton_disabled)}
+                    disabled={disabled}
+                    onClick={onIconClick}
+                  >
+                    {afterIcon}
+                    {icon}
+                  </ButtonOrLink>
+                ) : (
+                  icon
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          ))}
       </Component>
     );
   }

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -112,7 +112,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
                   {afterIcon}
                 </ButtonOrLink>
               ) : (
-                { afterIcon }
+                afterIcon
               )}
             </div>
           </div>
@@ -212,7 +212,7 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
   },
 
   iconWrapperBefore: {
-    padding: `${unit * 0.5}px ${unit * 0.5}px ${unit * 0.5}px ${unit * 1}px`,
+    padding: `${unit * 0.5}px ${unit * 0.5}px ${unit * 0.5}px ${unit}px`,
   },
 
   iconButton: {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { mutuallyExclusiveProps, mutuallyExclusiveTrueProps, requiredBy } from 'airbnb-prop-types';
+import { mutuallyExclusiveProps, requiredBy } from 'airbnb-prop-types';
 import iconComponent from '../../prop-types/iconComponent';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import ProfilePhoto from '../ProfilePhoto';
@@ -27,7 +27,11 @@ export type Props = {
   profileImageSrc?: string;
 };
 
-const beforePropType = mutuallyExclusiveTrueProps('beforeIcon', 'profileImageSrc');
+const beforePropType = mutuallyExclusiveProps(
+  PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  'before',
+  'profileImageSrc',
+);
 
 /** Compact component that represents a snippet of information, such as a filter. */
 export class Chip extends React.Component<Props & WithStylesProps> {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -19,8 +19,6 @@ export type Props = {
   compact?: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
-  /** Icon to render to the right of the primary content. */
-  icon?: React.ReactNode;
   /** Callback fired when the element is clicked. */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Callback fired when the icon is clicked (requires an icon). */
@@ -32,9 +30,10 @@ export type Props = {
 /** Compact component that represents a snippet of information, such as a filter. */
 export class Chip extends React.Component<Props & WithStylesProps> {
   static propTypes = {
-    icon: requiredBy('onIconClick', iconComponent),
+    // icon: requiredBy('onIconClick', iconComponent),
+    afterIcon: requiredBy('onIconClick', iconComponent),
+    beforeIcon: mutuallyExclusiveProps(iconComponent, 'beforeIcon', 'profileImageSrc'),
     onClick: mutuallyExclusiveProps(PropTypes.func, 'onIconClick'),
-    beforeIcon: mutuallyExclusiveProps(PropTypes.any, 'beforeIcon', 'profileImageSrc'),
     profileImageSrc: mutuallyExclusiveProps(
       PropTypes.any,
       'beforeIcon',
@@ -53,18 +52,11 @@ export class Chip extends React.Component<Props & WithStylesProps> {
       children,
       compact,
       disabled,
-      icon,
       onClick,
       onIconClick,
       profileImageSrc,
       styles,
     } = this.props;
-
-    if (__DEV__) {
-      if (icon) {
-        console.log('Chip: `icon` prop is deprecated, please use `afterIcon` instead.');
-      }
-    }
 
     const Component = onClick ? 'button' : 'div';
     const props: React.HTMLProps<HTMLButtonElement> =
@@ -76,7 +68,6 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           }
         : {};
 
-    const shouldRenderAfter = afterIcon || icon;
     const shouldRenderBefore = beforeIcon || profileImageSrc;
 
     return (
@@ -86,7 +77,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           styles.chip,
           onClick && styles.chip_button,
           !shouldRenderBefore && styles.chip_noBefore,
-          !shouldRenderAfter && styles.chip_noAfter,
+          !afterIcon && styles.chip_noAfter,
           active && styles.chip_active,
           onClick && active && styles.chip_active_button,
           compact && styles.chip_compact,
@@ -108,14 +99,10 @@ export class Chip extends React.Component<Props & WithStylesProps> {
             </div>
           </div>
         )}
-
-        <div className={cx(styles.chipItem, styles.content)}>{children}</div>
-
-        {shouldRenderAfter && (
-          <div className={cx(styles.chipItem, styles.sideContent)}>
-            <div
-              className={cx(styles.sideContentInner, styles.iconWrapper, styles.iconWrapperAfter)}
-            >
+        <div {...css(styles.chipItem, styles.content)}>{children}</div>
+        {afterIcon && (
+          <div {...css(styles.chipItem, styles.sideContent)}>
+            <div {...css(styles.sideContentInner, styles.iconWrapper, styles.iconWrapperAfter)}>
               {onIconClick ? (
                 <ButtonOrLink
                   className={(styles.iconButton, disabled && styles.iconButton_disabled)}
@@ -123,10 +110,9 @@ export class Chip extends React.Component<Props & WithStylesProps> {
                   onClick={onIconClick}
                 >
                   {afterIcon}
-                  {icon}
                 </ButtonOrLink>
               ) : (
-                icon
+                { afterIcon }
               )}
             </div>
           </div>
@@ -226,7 +212,7 @@ export default withStyles(({ color, font, pattern, transition, ui, unit }) => ({
   },
 
   iconWrapperBefore: {
-    padding: `${unit * 0.5}px 0 ${unit * 0.5}px ${unit * 0.5}px`,
+    padding: `${unit * 0.5}px ${unit * 0.5}px ${unit * 0.5}px ${unit * 1}px`,
   },
 
   iconButton: {

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -6,9 +6,6 @@ import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import ProfilePhoto from '../ProfilePhoto';
 import ButtonOrLink, { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
-const beforePropType = mutuallyExclusiveProps(PropTypes.any, 'beforeIcon', 'profileImageSrc');
-const afterPropType = mutuallyExclusiveProps(PropTypes.node, 'afterIcon', 'icon');
-
 export type Props = {
   /** Renders with a primary background and white text. */
   active?: boolean;
@@ -37,8 +34,14 @@ export class Chip extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     icon: requiredBy('onIconClick', iconComponent),
     onClick: mutuallyExclusiveProps(PropTypes.func, 'onIconClick'),
-    beforeIcon: beforePropType,
-    profileImageSrc: beforePropType,
+    beforeIcon: mutuallyExclusiveProps(PropTypes.any, 'beforeIcon', 'profileImageSrc'),
+    profileImageSrc: mutuallyExclusiveProps(
+      PropTypes.any,
+      'beforeIcon',
+      'profileImageSrc',
+      'compact',
+    ),
+    compact: mutuallyExclusiveProps(PropTypes.any, 'profileImageSrc', 'compact'),
   };
 
   render() {

--- a/packages/core/src/components/Multicomplete/private/Chip.tsx
+++ b/packages/core/src/components/Multicomplete/private/Chip.tsx
@@ -18,7 +18,7 @@ export default class MulticompleteChip extends React.Component<Props> {
     const { value } = this.props;
 
     return (
-      <Chip icon={<IconCloseAlt decorative size="2em" />} onIconClick={this.handleClick}>
+      <Chip afterIcon={<IconCloseAlt size="2em" />} onIconClick={this.handleClick}>
         {value}
       </Chip>
     );

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -19,9 +19,15 @@ describe('<Chip />', () => {
     expect(wrapper.prop('onClick')).toBe(onClick);
   });
 
-  it('renders an icon if provided', () => {
+  it('renders an after icon if provided', () => {
     const icon = <IconCheck />;
     const wrapper = shallow(<Chip afterIcon={icon}>Sour Cream and Onion</Chip>).dive();
+    expect(wrapper.contains(icon)).toBe(true);
+  });
+
+  it('renders a before icon if provided', () => {
+    const icon = <IconCheck />;
+    const wrapper = shallow(<Chip beforeIcon={icon}>Sour Cream and Onion</Chip>).dive();
     expect(wrapper.contains(icon)).toBe(true);
   });
 

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -20,8 +20,8 @@ describe('<Chip />', () => {
   });
 
   it('renders an icon if provided', () => {
-    const icon = <IconCheck decorative />;
-    const wrapper = shallow(<Chip icon={icon}>Sour Cream and Onion</Chip>).dive();
+    const icon = <IconCheck />;
+    const wrapper = shallow(<Chip afterIcon={icon}>Sour Cream and Onion</Chip>).dive();
     expect(wrapper.contains(icon)).toBe(true);
   });
 
@@ -29,7 +29,7 @@ describe('<Chip />', () => {
     const icon = <IconCheck decorative />;
     const onClick = () => {};
     const wrapper = shallow(
-      <Chip icon={icon} onIconClick={onClick}>
+      <Chip afterIcon={icon} onIconClick={onClick}>
         Sour Cream and Onion
       </Chip>,
     ).dive();


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Adds a prop for `before` to `Chip`, allowing developers to pass in an `ReactNode` to render on the left side of the `Chip`.

We could remove `profileImageSrc` since it's now possible to pass in a `ProfilePhoto` directly, but this would be a breaking change. For now, I'm just using `mutuallyExclusiveTrueProps` since passing in both would break formatting.

Could also make sense to rename `icon` to `after`, or even just implement the whole thing as a wrapped `Row`, but again, all breaking changes we'll probably want to avoid for now.

<!--- Describe your change in detail. -->

## Motivation and Context
https://git.musta.ch/airbnb/solar/issues/826

<!--- Why is this change required? What problem does it solve? -->

## Testing
Tested in storybook.
<!--- Please describe in detail how you tested your change. -->

## Screenshots
![Screen Shot 2019-05-22 at 5 26 38 PM](https://user-images.githubusercontent.com/8676510/58217244-c60acf00-7cb6-11e9-8a01-a09088ed372e.png)

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
