### PR TITLE
update(DataTable): Rerender when data updates

### DIFF
--- a/.storybook/components/DataTable/DataTableData.jsx
+++ b/.storybook/components/DataTable/DataTableData.jsx
@@ -1,7 +1,7 @@
 import { STATUS_OPTIONS } from '@airbnb/lunar/src/components/DataTable/constants';
 
 export function generateRandomData() {
-  return new Array(2000).fill(0).map(x => ({
+  return new Array(10).fill(0).map(x => ({
     data: {
       number: Math.random(),
       zero: x,

--- a/.storybook/components/DataTable/DataTableData.jsx
+++ b/.storybook/components/DataTable/DataTableData.jsx
@@ -1,5 +1,14 @@
 import { STATUS_OPTIONS } from '@airbnb/lunar/src/components/DataTable/constants';
 
+export function generateRandomData() {
+  return new Array(2000).fill(0).map(x => ({
+    data: {
+      number: Math.random(),
+      zero: x,
+    },
+  }));
+}
+
 export default function getData() {
   return [
     {

--- a/.storybook/components/DataTable/DataTableData.jsx
+++ b/.storybook/components/DataTable/DataTableData.jsx
@@ -1,7 +1,7 @@
 import { STATUS_OPTIONS } from '@airbnb/lunar/src/components/DataTable/constants';
 
 export function generateRandomData() {
-  return new Array(10).fill(0).map(x => ({
+  return new Array(1000).fill(0).map(x => ({
     data: {
       number: Math.random(),
       zero: x,

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -99,7 +99,7 @@ class NewDataDemo extends React.Component {
         <Spacing bottom={1}>
           <Button onClick={this.handleNewData}>New Data</Button>
         </Spacing>
-        <DataTable data={data} />
+        <DataTable data={data} selectable />
       </>
     );
   }

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import IconStar from '@airbnb/lunar-icons/lib/interface/IconStar';
-import getData from ':storybook/components/DataTable/DataTableData';
+import getData, { generateRandomData } from ':storybook/components/DataTable/DataTableData';
 import TenureRenderer from ':storybook/components/DataTable/DataTableRenderers/TenureRenderer';
 import ColSpanRenderer from ':storybook/components/DataTable/DataTableRenderers/ColSpanRenderer';
 import CatRenderer from ':storybook/components/DataTable/DataTableRenderers/CatRenderer';
 import MenuRenderer from ':storybook/components/DataTable/DataTableRenderers/MenuRenderer';
 
+import Button from './Button';
 import DataTable from './DataTable';
-import { SelectedRows, TableRow } from './DataTable/types';
+import Spacing from './Spacing';
+import { ParentRow, SelectedRows, TableRow } from './DataTable/types';
 
 const renderers = {
   colSpan: ColSpanRenderer,
@@ -82,11 +84,33 @@ const defaultEditCallback = (
   action('this callback has access to row, key, newVal and event');
 };
 
+class NewDataDemo extends React.Component<{ data: ParentRow[] }> {
+  state = {
+    data: generateRandomData(),
+  };
+
+  private newData = () => this.setState({ data: generateRandomData() });
+
+  render() {
+    const { data } = this.state;
+
+    return (
+      <>
+        <Spacing bottom={1}>
+          <Button onClick={this.newData}>New Data</Button>
+        </Spacing>
+        <DataTable data={data} />
+      </>
+    );
+  }
+}
+
 storiesOf('Core/DataTable', module)
   .addParameters({
     inspectComponents: [DataTable],
   })
   .add('A standard table.', () => <DataTable data={getData()} keys={['name', 'jobTitle']} />)
+  .add('A table that receives a large amount of new data and rerenders.', () => <NewDataDemo />)
   .add('A table with selectable and exandable rows.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
@@ -181,7 +205,7 @@ storiesOf('Core/DataTable', module)
       selectOnRowClick
       instantEdit={false}
       height={300}
-      width={1000}
+      width={2000}
       tableHeaderLabel="My Great Table"
       rowHeight="regular"
       columnHeaderHeight="micro"
@@ -189,7 +213,7 @@ storiesOf('Core/DataTable', module)
       defaultEditCallback={defaultEditCallback}
       enactEditsCallback={() => action('applying edits')}
       editCallbacks={editCallbacks}
-      keys={['name', 'cats', 'tenureDays']}
+      keys={['name', 'cats', 'tenureDays', 'menu']}
       editable
     />
   ));

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -11,7 +11,7 @@ import MenuRenderer from ':storybook/components/DataTable/DataTableRenderers/Men
 import Button from './Button';
 import DataTable from './DataTable';
 import Spacing from './Spacing';
-import { ParentRow, SelectedRows, TableRow } from './DataTable/types';
+import { SelectedRows, TableRow } from './DataTable/types';
 
 const renderers = {
   colSpan: ColSpanRenderer,
@@ -89,7 +89,7 @@ class NewDataDemo extends React.Component {
     data: generateRandomData(),
   };
 
-  private newData = () => this.setState({ data: generateRandomData() });
+  private handleNewData = () => this.setState({ data: generateRandomData() });
 
   render() {
     const { data } = this.state;
@@ -97,7 +97,7 @@ class NewDataDemo extends React.Component {
     return (
       <>
         <Spacing bottom={1}>
-          <Button onClick={this.newData}>New Data</Button>
+          <Button onClick={this.handleNewData}>New Data</Button>
         </Spacing>
         <DataTable data={data} />
       </>

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -84,7 +84,7 @@ const defaultEditCallback = (
   action('this callback has access to row, key, newVal and event');
 };
 
-class NewDataDemo extends React.Component<{ data: ParentRow[] }> {
+class NewDataDemo extends React.Component {
   state = {
     data: generateRandomData(),
   };

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -2,7 +2,14 @@ import startCase from 'lodash/startCase';
 
 import { WithStylesProps } from '../../composers/withStyles';
 import { STATUS_OPTIONS, HEIGHT_TO_PX } from './constants';
-import { ColumnLabelCase, HeightOptions, ExpandedRow, RowHeightOptions, Status } from './types';
+import {
+  ColumnLabelCase,
+  HeightOptions,
+  ExpandedRow,
+  ParentRow,
+  RowHeightOptions,
+  Status,
+} from './types';
 
 export function caseColumnLabel(label: string, casing: ColumnLabelCase) {
   if (casing === 'title') {
@@ -57,4 +64,20 @@ export function getHeight(defaultHeight?: RowHeightOptions, overrideHeight?: Hei
   }
 
   return defaultHeight ? HEIGHT_TO_PX[defaultHeight] : 0;
+}
+
+export function getKeys(keys: string[], data: ParentRow[]) {
+  return keys.length > 0
+    ? keys
+    : Array.from(
+        data!.reduce((keySet: Set<string>, row: ParentRow) => {
+          Object.keys(row.data).forEach(key => {
+            if (row.metadata === undefined || row.metadata.colSpanKey !== key) {
+              keySet.add(key);
+            }
+          });
+
+          return keySet;
+        }, new Set()),
+      );
 }

--- a/packages/core/src/components/DataTable/helpers.ts
+++ b/packages/core/src/components/DataTable/helpers.ts
@@ -66,6 +66,7 @@ export function getHeight(defaultHeight?: RowHeightOptions, overrideHeight?: Hei
   return defaultHeight ? HEIGHT_TO_PX[defaultHeight] : 0;
 }
 
+// Infers keys from data if they aren't explicitely defined
 export function getKeys(keys: string[], data: ParentRow[]) {
   return keys.length > 0
     ? keys

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import memoize from 'lodash/memoize';
 import { AutoSizer, SortDirection, SortDirectionType, Table } from 'react-virtualized';
 import sortList from './helpers/sortList';
 import expandDataList from './helpers/expandDataList';
@@ -97,19 +98,14 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   });
 
   static getDerivedStateFromProps(props: DataTableProps, state: State) {
-    const sortedDataList = sortList(
-      indexDataList(props.data!),
-      getKeys(props.keys!, props.data!),
-      state.sortBy,
-      state.sortDirection,
-    );
-    if (sortedDataList !== state.sortedDataList) {
-      return {
-        sortedDataList: sortedDataList,
-      };
-    }
-
-    return null;
+    return {
+      sortedDataList: sortList(
+        indexDataList(props.data!),
+        getKeys(props.keys!, props.data!),
+        state.sortBy,
+        state.sortDirection,
+      ),
+    };
   }
 
   private getTableHeight = (expandedDataList: ExpandedRow[]) => {

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -97,15 +97,15 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   });
 
   static getDerivedStateFromProps(props: DataTableProps, state: State) {
-    const indexedDataList = indexDataList(props.data!);
-    if (indexedDataList !== state.sortedDataList) {
+    const sortedDataList = sortList(
+      indexDataList(props.data!),
+      getKeys(props.keys!, props.data!),
+      state.sortBy,
+      state.sortDirection,
+    );
+    if (sortedDataList !== state.sortedDataList) {
       return {
-        sortedDataList: sortList(
-          indexedDataList,
-          getKeys(props.keys!, props.data!),
-          state.sortBy,
-          state.sortDirection,
-        ),
+        sortedDataList: sortedDataList,
       };
     }
 

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -9,7 +9,6 @@ import {
   DefaultDataTableProps,
   ExpandedRow,
   IndexedParentRow,
-  ParentRow,
   RowStyles,
   TableRow,
   SelectedRows,
@@ -108,6 +107,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
         ),
       };
     }
+
     return null;
   }
 

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -383,8 +383,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortDirection,
     );
 
-    console.log(this.state);
-
     return (
       <div>
         {this.shouldRenderTableHeader() && (

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import memoize from 'lodash/memoize';
 import { AutoSizer, SortDirection, SortDirectionType, Table } from 'react-virtualized';
 import sortList from './helpers/sortList';
 import expandDataList from './helpers/expandDataList';

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -117,6 +117,8 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
         sortedDataList: indexDataList(props.data!),
       };
     }
+
+    return null;
   }
 
   private getTableHeight = (expandedDataList: ExpandedRow[]) => {

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -97,10 +97,11 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   });
 
   static getDerivedStateFromProps(props: DataTableProps, state: State) {
-    if (indexDataList(props.data!) !== state.sortedDataList) {
+    const indexedDataList = indexDataList(props.data!);
+    if (indexedDataList !== state.sortedDataList) {
       return {
         sortedDataList: sortList(
-          indexDataList(props.data!),
+          indexedDataList,
           getKeys(props.keys!, props.data!),
           state.sortBy,
           state.sortDirection,

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -80,7 +80,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     zebra: false,
   };
 
-  // Infers keys from data if they aren't explicitely defined
   keys = getKeys(this.props.keys!, this.props.data!);
 
   rowStyles = (expandedDataList: ExpandedRow[]) => ({ index }: { index: number }): RowStyles => ({
@@ -99,7 +98,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   });
 
   static getDerivedStateFromProps(props: DataTableProps, state: State) {
-    // const { sortedDataList } = this.state;
     if (indexDataList(props.data!) !== state.sortedDataList) {
       return {
         sortedDataList: sortList(
@@ -111,19 +109,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       };
     }
     return null;
-  }
-
-  private shouldComponentUpdate(nextProps: DataTableProps, nextState: State) {
-    return true;
-    //   const { sortedDataList } = this.state;
-    //   if (indexDataList(nextProps.data!) !== sortedDataList) {
-    //     return true;
-    //     // return {
-    //     //   sortedDataList: indexDataList(props.data!),
-    //     // };
-    //   }
-    //   return false;
-    //   // return null;
   }
 
   private getTableHeight = (expandedDataList: ExpandedRow[]) => {

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -111,6 +111,14 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     outline: 'none',
   });
 
+  static getDerivedStateFromProps(props: DataTableProps, state: State) {
+    if (indexDataList(props.data!) != state.sortedDataList) {
+      return {
+        sortedDataList: indexDataList(props.data!),
+      };
+    }
+  }
+
   private getTableHeight = (expandedDataList: ExpandedRow[]) => {
     const { height, rowHeight, showAllRows } = this.props;
 

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -269,6 +269,16 @@ describe('<DataTable /> rows can be selected', () => {
 
     expect(getCheckbox(table, PARENT_ROW).props().checked).toBe(false);
   });
+
+  it('Selecting both children should select the parent', () => {
+    const table = mount(<DataTable {...simpleProps} />);
+
+    expandRow(table, PARENT_ROW);
+    selectRow(table, CHILD_ROW);
+    selectRow(table, CHILD_ROW + 1);
+
+    expect(getCheckbox(table, PARENT_ROW).props().checked).toBe(true);
+  });
 });
 
 describe('<DataTable /> renders and sorts data', () => {
@@ -298,7 +308,6 @@ describe('<DataTable /> renders and sorts data', () => {
     const table = mount(<DataTable {...simpleProps} />);
 
     const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').at(2);
-    console.log(nameHeader.debug());
     nameHeader.simulate('click');
     nameHeader.simulate('click');
     table.update();
@@ -565,6 +574,35 @@ describe('<DataTable /> handles edits', () => {
 
     const button = table.find(TableHeader).find(Button);
     button.simulate('click');
+  });
+
+  it('should be editable with instantEdit off', () => {
+    // @ts-ignore
+    const wrapper = mount(<DataTable {...props} instantEdit={false} />);
+    const button = wrapper.find(TableHeader).find(Button);
+    button.simulate('click');
+    const grid = wrapper.find(Grid);
+    const row = grid.find('[aria-rowindex=1]');
+    const col = row.find('[aria-colindex=1]');
+    const input = col.find(Input).find(FormInput);
+
+    const event = {
+      currentTarget: {
+        value: 'foo',
+      },
+    };
+
+    input.simulate('change', event);
+    input.simulate('click');
+
+    expect(
+      wrapper
+        .find(Grid)
+        .find('[aria-rowindex=1]')
+        .find('[aria-colindex=1]')
+        .find(Input)
+        .prop('value'),
+    ).toBe(data[0].data.name);
   });
 });
 

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -297,7 +297,8 @@ describe('<DataTable /> renders and sorts data', () => {
   it('should sort data in Ascending Order', () => {
     const table = mount(<DataTable {...simpleProps} />);
 
-    const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').at(NAME_COL);
+    const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').at(2);
+    console.log(nameHeader.debug());
     nameHeader.simulate('click');
     nameHeader.simulate('click');
     table.update();


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
There's currently a bug where DataTable does not re-render when it's passed new data. This is pretty critical since developers are often passing in data from an API call asynchronously (i.e. passing in an empty array, and then populating the table once the query resolves).

`getDerivedStateFromProps` is understandably controversial, but I think this is the proper use case.

https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
`getDerivedStateFromProps exists for only one purpose. It enables a component to update its internal state as the result of changes in props.`

In this case, the comparison conditional is
`if (indexDataList(props.data!) != state.sortedDataList) {`
indexDataList is a little bit slow, but I've tried it with 10,000 rows and seen very little latency. Of course it depends on how complex your table is, what renderers you're using, etc.

The alternative way to do this would be with some kind of data id/version prop that the parent is responsible for updating, which is described here:
https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#preferred-solutions

Of course the other issue here is that we have to run the check whenever any prop changes. I don't think we should be updating any of these props without updating the underlying data as well, but it's probably worth trying to document this somewhere more explicitly. Currently the best resource is the design doc:
https://docs.google.com/document/d/19aimBiXgzWEgECGuNPRrq_Cz4EzYIkXYlsyl_noGuS0/edit
But some kind of Readme might be helpful.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
