### PR TITLE
update(withIcon): Add new icon props to flip horizontally and/or vertically.

### DIFF
--- a/packages/core/test/components/__snapshots__/Alert.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Alert.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`<Alert /> renders close button 1`] = `
         <IconClose
           accessibilityLabel="Close"
           color="currentColor"
+          flip={false}
+          flipVertical={false}
           inline={false}
           size={24}
         />
@@ -55,6 +57,8 @@ exports[`<Alert /> renders statuses renders danger alert 1`] = `
       <IconError
         color="#DF2323"
         decorative={true}
+        flip={false}
+        flipVertical={false}
         inline={false}
         size={24}
       />
@@ -79,6 +83,8 @@ exports[`<Alert /> renders statuses renders info alert 1`] = `
       <IconInfo
         color="#6f44ff"
         decorative={true}
+        flip={false}
+        flipVertical={false}
         inline={false}
         size={24}
       />
@@ -120,6 +126,8 @@ exports[`<Alert /> renders statuses renders notice alert 1`] = `
       <IconFlag
         color="#1561B2"
         decorative={true}
+        flip={false}
+        flipVertical={false}
         inline={false}
         size={24}
       />
@@ -144,6 +152,8 @@ exports[`<Alert /> renders statuses renders success alert 1`] = `
       <IconCheckAlt
         color="#4AA83E"
         decorative={true}
+        flip={false}
+        flipVertical={false}
         inline={false}
         size={24}
       />
@@ -168,6 +178,8 @@ exports[`<Alert /> renders statuses renders warning alert 1`] = `
       <IconWarning
         color="#FFB400"
         decorative={true}
+        flip={false}
+        flipVertical={false}
         inline={false}
         size={24}
       />

--- a/packages/icons/src/FakeIcon.tsx
+++ b/packages/icons/src/FakeIcon.tsx
@@ -12,6 +12,8 @@ FakeIcon.defaultProps = {
   accessibilityLabel: '',
   color: 'currentColor',
   decorative: false,
+  flip: false,
+  flipVertical: false,
   inline: false,
   size: '1em',
 };

--- a/packages/icons/src/Icons.story.tsx
+++ b/packages/icons/src/Icons.story.tsx
@@ -36,13 +36,15 @@ context.keys().forEach(file => {
 
 class IconGrid extends React.Component<{
   category: string;
-  title: string;
-  icons: IconSet['icons'];
   color: string;
+  flip: boolean;
+  flipVertical: boolean;
+  icons: IconSet['icons'];
   size: string;
+  title: string;
 }> {
   render() {
-    const { category, title, icons, color, size } = this.props;
+    const { category, title, icons, color, size, flip, flipVertical } = this.props;
 
     return (
       <div style={{ marginBottom: 16 }}>
@@ -71,7 +73,14 @@ class IconGrid extends React.Component<{
                 width: 90,
               }}
             >
-              <Icon inline decorative size={size} color={color || undefined} />
+              <Icon
+                inline
+                decorative
+                size={size}
+                color={color || undefined}
+                flip={flip}
+                flipVertical={flipVertical}
+              />
 
               <div style={{ fontSize: 11, marginTop: 4 }}>{Icon.displayName!.slice(4)}</div>
             </button>
@@ -82,9 +91,14 @@ class IconGrid extends React.Component<{
   }
 }
 
-class IconList extends React.Component<{}, { color: string; size: string }> {
+class IconList extends React.Component<
+  {},
+  { color: string; flipX: boolean; flipY: boolean; size: string }
+> {
   state = {
     color: '',
+    flipX: false,
+    flipY: false,
     size: '2em',
   };
 
@@ -94,6 +108,18 @@ class IconList extends React.Component<{}, { color: string; size: string }> {
     });
   };
 
+  handleFlipXChange = () => {
+    this.setState(prevState => ({
+      flipX: !prevState.flipX,
+    }));
+  };
+
+  handleFlipYChange = () => {
+    this.setState(prevState => ({
+      flipY: !prevState.flipY,
+    }));
+  };
+
   handleSizeChange = (event: ChangeEvent<HTMLSelectElement>) => {
     this.setState({
       size: event.currentTarget.value,
@@ -101,11 +127,11 @@ class IconList extends React.Component<{}, { color: string; size: string }> {
   };
 
   render() {
-    const { color, size } = this.state;
+    const { color, flipX, flipY, size } = this.state;
 
     return (
       <div style={{ position: 'relative' }}>
-        <div style={{ display: 'flex', position: 'absolute', top: 0, right: 0 }}>
+        <div style={{ display: 'flex', fontSize: '12px', position: 'absolute', top: 0, right: 0 }}>
           <select name="color" value={color} onChange={this.handleColorChange}>
             <option value="">No Color</option>
             <option value="red">Red</option>
@@ -123,6 +149,16 @@ class IconList extends React.Component<{}, { color: string; size: string }> {
             <option value="2em">2x</option>
             <option value="3em">3x</option>
           </select>
+
+          <div style={{ marginLeft: 16 }}>
+            Flip X{' '}
+            <input checked={flipX} type="checkbox" name="flipx" onChange={this.handleFlipXChange} />
+          </div>
+
+          <div style={{ marginLeft: 8 }}>
+            Flip Y{' '}
+            <input checked={flipY} type="checkbox" name="flipy" onChange={this.handleFlipYChange} />
+          </div>
         </div>
 
         {Object.keys(iconData).map(category => (
@@ -133,6 +169,8 @@ class IconList extends React.Component<{}, { color: string; size: string }> {
             icons={iconData[category].icons}
             color={color}
             size={size}
+            flip={flipX}
+            flipVertical={flipY}
           />
         ))}
       </div>

--- a/packages/icons/src/withIcon.tsx
+++ b/packages/icons/src/withIcon.tsx
@@ -5,6 +5,10 @@ export type WithIconWrapperProps = {
   accessibilityLabel?: string;
   /** Mark as decorative only and avoid accessibility. Required if `accessibilityLabel` not defined. */
   decorative?: boolean;
+  /** Flip the icon on the horizontal axis. */
+  flip?: boolean;
+  /** Flip the icon on the vertical axis. */
+  flipVertical?: boolean;
   /** Size of the icon. */
   size?: number | string;
   /** Color the icon using a CSS hexcode. */
@@ -30,12 +34,23 @@ export default function withIcon(
 
       static defaultProps = {
         color: 'currentColor',
+        flip: false,
+        flipVertical: false,
         inline: false,
         size: '1em',
       };
 
       render() {
-        const { accessibilityLabel, decorative, color, size, inline } = this.props;
+        const {
+          accessibilityLabel,
+          color,
+          decorative,
+          flip,
+          flipVertical,
+          inline,
+          size,
+        } = this.props;
+
         const props: any = {
           focusable: 'false',
           role: decorative ? 'presentation' : 'img',
@@ -44,6 +59,11 @@ export default function withIcon(
             width: size,
             display: inline ? 'inline' : 'block',
             fill: color,
+            transform:
+              flip || flipVertical
+                ? `scale(${flip ? -1 : 1}, ${flipVertical ? -1 : 1})`
+                : 'scale(1)', // keep scale(1) for transition flipping
+            transition: 'transform 300ms ease-out',
           },
         };
 

--- a/packages/icons/test/withIcon.test.tsx
+++ b/packages/icons/test/withIcon.test.tsx
@@ -16,13 +16,38 @@ describe('withIcon()', () => {
 
   it('passes through props', () => {
     const Hoc = withIcon('IconTest')(Foo);
-    const wrapper = shallow(<Hoc size={16} color="white" inline />);
+    const wrapper = shallow(<Hoc inline size={16} color="white" />);
     const style: React.CSSProperties = wrapper.find(Foo).prop('style');
 
     expect(style.width).toBe(16);
     expect(style.height).toBe(16);
     expect(style.fill).toBe('white');
     expect(style.display).toBe('inline');
+    expect(style.transform).toBe('scale(1)');
+  });
+
+  it('flips horizontally', () => {
+    const Hoc = withIcon('IconTest')(Foo);
+    const wrapper = shallow(<Hoc flip />);
+    const style: React.CSSProperties = wrapper.find(Foo).prop('style');
+
+    expect(style.transform).toBe('scale(-1, 1)');
+  });
+
+  it('flips vertically', () => {
+    const Hoc = withIcon('IconTest')(Foo);
+    const wrapper = shallow(<Hoc flipVertical />);
+    const style: React.CSSProperties = wrapper.find(Foo).prop('style');
+
+    expect(style.transform).toBe('scale(1, -1)');
+  });
+
+  it('flips horizontally & vertically', () => {
+    const Hoc = withIcon('IconTest')(Foo);
+    const wrapper = shallow(<Hoc flip flipVertical />);
+    const style: React.CSSProperties = wrapper.find(Foo).prop('style');
+
+    expect(style.transform).toBe('scale(-1, -1)');
   });
 
   it('passes through a11y props', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Recently had to flip an icon. We chatted and thought this would be nice to bring into Lunar!

Can flip an icon horizontally and/or vertically. There's a transition for an animation.

## Testing

locally and with storybook

## Screenshots

![screencast 2019-05-30 14-57-42](https://user-images.githubusercontent.com/306275/58667760-cb39d080-82eb-11e9-87ec-3e3850991d07.gif)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
