### PR TITLE
update(Pagination): Add pageLabel prop

### DIFF
--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import Pagination from './Pagination';
+import T from './Translate';
 
 storiesOf('Core/Pagination', module)
   .addParameters({
@@ -20,6 +21,16 @@ storiesOf('Core/Pagination', module)
     <Pagination
       hasPrev
       hasNext
+      page={2}
+      onNext={action('onNext')}
+      onPrevious={action('onPrevious')}
+    />
+  ))
+  .add('With label.', () => (
+    <Pagination
+      hasPrev
+      hasNext
+      label={T.phrase('Photo', {}, 'Label for photo pagination')}
       page={2}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}

--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -30,7 +30,17 @@ storiesOf('Core/Pagination', module)
     <Pagination
       hasPrev
       hasNext
-      label={T.phrase('Photo', {}, 'Label for photo pagination')}
+      pageLabel={T.phrase('Photo', {}, 'Label for photo pagination')}
+      page={2}
+      onNext={action('onNext')}
+      onPrevious={action('onPrevious')}
+    />
+  ))
+  .add('With no label.', () => (
+    <Pagination
+      hasPrev
+      hasNext
+      pageLabel=""
       page={2}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -134,6 +134,38 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       );
     }
 
+    let paginationText =
+      showBookends && pageCount ? (
+        <T
+          phrase={'%{pageNumber} of %{pageNumber}'}
+          pageCount={pageCount}
+          pageNumber={page}
+          context="Showing the current page number and total page count"
+        />
+      ) : (
+        <T phrase={'%{pageNumber}'} pageNumber={page} context="Showing the current page number" />
+      );
+
+    if (pageLabel) {
+      paginationText =
+        showBookends && pageCount ? (
+          <T
+            phrase={'%{pageLabel} %{pageNumber} of %{pageCount}'}
+            pageLabel={pageLabel}
+            pageCount={pageCount}
+            pageNumber={page}
+            context="Showing the current page number and total page count"
+          />
+        ) : (
+          <T
+            phrase={'%{pageLabel} %{pageNumber}'}
+            pageLabel={pageLabel}
+            pageNumber={page}
+            context="Showing the current page number"
+          />
+        );
+    }
+
     return (
       <Row
         before={
@@ -151,28 +183,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
         middleAlign
       >
         <div {...css(styles.centered)}>
-          <Text muted>
-            {showBookends && pageCount ? (
-              <T
-                phrase={
-                  pageLabel
-                    ? '%{pageLabel} %{pageNumber} of %{pageCount}'
-                    : '%{pageNumber} of %{pageNumber}'
-                }
-                pageLabel={pageLabel}
-                pageCount={pageCount}
-                pageNumber={page}
-                context="Showing the current page number and total page count"
-              />
-            ) : (
-              <T
-                phrase={pageLabel ? '%{pageLabel} %{pageNumber}' : '%{pageNumber}'}
-                pageLabel={pageLabel}
-                pageNumber={page}
-                context="Showing the current page number"
-              />
-            )}
-          </Text>
+          <Text muted>{paginationText}</Text>
         </div>
       </Row>
     );

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -154,7 +154,11 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
           <Text muted>
             {showBookends && pageCount ? (
               <T
-                phrase="%{pageLabel} %{pageNumber} of %{pageCount}"
+                phrase={
+                  pageLabel
+                    ? '%{pageLabel} %{pageNumber} of %{pageCount}'
+                    : '%{pageNumber} of %{pageNumber}'
+                }
                 pageLabel={pageLabel}
                 pageCount={pageCount}
                 pageNumber={page}
@@ -162,7 +166,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
               />
             ) : (
               <T
-                phrase="%{pageLabel} %{pageNumber}"
+                phrase={pageLabel ? '%{pageLabel} %{pageNumber}' : '%{pageNumber}'}
                 pageLabel={pageLabel}
                 pageNumber={page}
                 context="Showing the current page number"

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -18,10 +18,10 @@ export type Props = {
   hasNext?: boolean;
   /** Whether it has a previous page. */
   hasPrev?: boolean;
-  /** Content to label the pages. Default is "Page" */
-  label: string;
   /** Current page number. */
   page: number;
+  /** Content to label the pages. Default is "Page" */
+  pageLabel: string;
   /** Total page count. Required when `showBookends` is true. */
   pageCount?: number;
   /** Invoked when the first page button is pressed. */
@@ -42,7 +42,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
     fetching: false,
     hasNext: false,
     hasPrev: false,
-    label: T.phrase('Page', {}, 'Label for pages'),
+    pageLabel: T.phrase('Page', {}, 'Label for pages'),
     showBookends: false,
   };
 
@@ -57,7 +57,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       fetching,
       hasNext,
       hasPrev,
-      label,
+      pageLabel,
       onFirst,
       onLast,
       onNext,
@@ -154,16 +154,16 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
           <Text muted>
             {showBookends && pageCount ? (
               <T
-                phrase="%{label} %{pageNumber} of %{pageCount}"
-                label={label}
+                phrase="%{pageLabel} %{pageNumber} of %{pageCount}"
+                pageLabel={pageLabel}
                 pageCount={pageCount}
                 pageNumber={page}
                 context="Showing the current page number and total page count"
               />
             ) : (
               <T
-                phrase="%{label} %{pageNumber}"
-                label={label}
+                phrase="%{pageLabel} %{pageNumber}"
+                pageLabel={pageLabel}
                 pageNumber={page}
                 context="Showing the current page number"
               />

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -21,7 +21,7 @@ export type Props = {
   /** Current page number. */
   page: number;
   /** Content to label the pages. Default is "Page" */
-  pageLabel: string;
+  pageLabel?: string;
   /** Total page count. Required when `showBookends` is true. */
   pageCount?: number;
   /** Invoked when the first page button is pressed. */

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -18,6 +18,8 @@ export type Props = {
   hasNext?: boolean;
   /** Whether it has a previous page. */
   hasPrev?: boolean;
+  /** Content to label the pages. Default is "Page" */
+  label: string;
   /** Current page number. */
   page: number;
   /** Total page count. Required when `showBookends` is true. */
@@ -40,6 +42,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
     fetching: false,
     hasNext: false,
     hasPrev: false,
+    label: T.phrase('Page', {}, 'Label for pages'),
     showBookends: false,
   };
 
@@ -54,6 +57,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       fetching,
       hasNext,
       hasPrev,
+      label,
       onFirst,
       onLast,
       onNext,
@@ -150,14 +154,16 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
           <Text muted>
             {showBookends && pageCount ? (
               <T
-                phrase="Page %{pageNumber} of %{pageCount}"
+                phrase="%{label} %{pageNumber} of %{pageCount}"
+                label={label}
                 pageCount={pageCount}
                 pageNumber={page}
                 context="Showing the current page number and total page count"
               />
             ) : (
               <T
-                phrase="Page %{pageNumber}"
+                phrase="%{label} %{pageNumber}"
+                label={label}
                 pageNumber={page}
                 context="Showing the current page number"
               />

--- a/packages/core/test/components/Pagination.test.tsx
+++ b/packages/core/test/components/Pagination.test.tsx
@@ -93,6 +93,23 @@ describe('<Pagination />', () => {
       expect(wrapper.find(T).prop('pageNumber')).toBe(request.page);
       expect(wrapper.find(T).prop('pageCount')).toBe(pageCount);
     });
+
+    it('displays the page label', () => {
+      const request = {
+        ...baseRequest,
+        hasNext: true,
+        page: 3,
+      };
+
+      const wrapper = shallow(
+        <Pagination {...request} onNext={noop} onPrevious={noop} pageLabel="Photo" />,
+      )
+        .dive() // withStyles;
+        .dive() // Row
+        .dive();
+
+      expect(wrapper.find(T).prop('pageLabel')).toBe('Photo');
+    });
   });
 
   describe('the previous button', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add pageLabel prop so "Page" can be changed to a different text value.

## Motivation and Context

While working on the Lightbox I needed a pagination component without the word "Page". Not all pagination is strictly for pages - we may need to change the label from "Page" to "Photo" or "".
Example:
`pageLabel="Photo"` results in "Photo x" / "Photo x of x"
`pageLabel=""` results in "x" / "x of x"

## Testing

- Added to Storybook
- Tested locally

## Screenshots

<img width="888" alt="Screen Shot 2019-06-05 at 2 25 00 PM" src="https://user-images.githubusercontent.com/6675771/58991698-c2d70f00-879d-11e9-8884-e2a5f940be81.png">
<img width="889" alt="Screen Shot 2019-06-05 at 2 25 04 PM" src="https://user-images.githubusercontent.com/6675771/58991697-c23e7880-879d-11e9-82e3-473bc394d7e5.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
