### PR TITLE
new(Pagination): Add arrow startAlign, centerAlign, and endAlign properties

### DIFF
--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -49,52 +49,52 @@ storiesOf('Core/Pagination', module)
   .add('Bookends, first page.', () => (
     <Pagination
       hasNext
+      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={1}
       pageCount={3}
-      showBookends
     />
   ))
   .add('Bookends, last page.', () => (
     <Pagination
       hasPrev
+      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={3}
       pageCount={3}
-      showBookends
     />
   ))
   .add('Bookends, middle page.', () => (
     <Pagination
       hasNext
       hasPrev
+      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
-      showBookends
     />
   ))
   .add('Align arrows at the start', () => (
     <Pagination
       hasNext
       hasPrev
+      showBookends
+      startAlign
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
-      showBookends
-      startAlign
     />
   ))
   .add('Align arrows in the center', () => (
@@ -102,13 +102,13 @@ storiesOf('Core/Pagination', module)
       centerAlign
       hasNext
       hasPrev
+      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
-      showBookends
     />
   ))
   .add('Align arrows at the end', () => (
@@ -116,12 +116,12 @@ storiesOf('Core/Pagination', module)
       endAlign
       hasNext
       hasPrev
+      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
-      showBookends
     />
   ));

--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -49,52 +49,52 @@ storiesOf('Core/Pagination', module)
   .add('Bookends, first page.', () => (
     <Pagination
       hasNext
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={1}
       pageCount={3}
+      showBookends
     />
   ))
   .add('Bookends, last page.', () => (
     <Pagination
       hasPrev
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={3}
       pageCount={3}
+      showBookends
     />
   ))
   .add('Bookends, middle page.', () => (
     <Pagination
       hasNext
       hasPrev
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
+      showBookends
     />
   ))
   .add('Align arrows at the start', () => (
     <Pagination
-      startAlign
       hasNext
       hasPrev
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
+      showBookends
+      startAlign
     />
   ))
   .add('Align arrows in the center', () => (
@@ -102,13 +102,13 @@ storiesOf('Core/Pagination', module)
       centerAlign
       hasNext
       hasPrev
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
+      showBookends
     />
   ))
   .add('Align arrows at the end', () => (
@@ -116,12 +116,12 @@ storiesOf('Core/Pagination', module)
       endAlign
       hasNext
       hasPrev
-      showBookends
       onFirst={action('onFirst')}
       onLast={action('onLast')}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
       page={2}
       pageCount={3}
+      showBookends
     />
   ));

--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -82,4 +82,46 @@ storiesOf('Core/Pagination', module)
       page={2}
       pageCount={3}
     />
+  ))
+  .add('Align arrows at the start', () => (
+    <Pagination
+      startAlign
+      hasNext
+      hasPrev
+      showBookends
+      onFirst={action('onFirst')}
+      onLast={action('onLast')}
+      onNext={action('onNext')}
+      onPrevious={action('onPrevious')}
+      page={2}
+      pageCount={3}
+    />
+  ))
+  .add('Align arrows in the center', () => (
+    <Pagination
+      centerAlign
+      hasNext
+      hasPrev
+      showBookends
+      onFirst={action('onFirst')}
+      onLast={action('onLast')}
+      onNext={action('onNext')}
+      onPrevious={action('onPrevious')}
+      page={2}
+      pageCount={3}
+    />
+  ))
+  .add('Align arrows at the end', () => (
+    <Pagination
+      endAlign
+      hasNext
+      hasPrev
+      showBookends
+      onFirst={action('onFirst')}
+      onLast={action('onLast')}
+      onNext={action('onNext')}
+      onPrevious={action('onPrevious')}
+      page={2}
+      pageCount={3}
+    />
   ));

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -23,6 +23,10 @@ export type Props = {
   hasNext?: boolean;
   /** Whether it has a previous page. */
   hasPrev?: boolean;
+  /** Show the first and last page buttons. */
+  showBookends?: boolean;
+  /** Align arrows to the start */
+  startAlign?: boolean;
   /** Current page number. */
   page: number;
   /** Content to label the pages. Default is "Page" */
@@ -37,10 +41,6 @@ export type Props = {
   onNext: () => void;
   /** Invoked when the previous page button is pressed. */
   onPrevious: () => void;
-  /** Show the first and last page buttons. */
-  showBookends?: boolean;
-  /** Align arrows to the start */
-  startAlign?: boolean;
 };
 
 /** Pagination controls. */
@@ -59,10 +59,10 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     centerAlign: alignProp,
     endAlign: alignProp,
+    startAlign: alignProp,
     onFirst: requiredBy('showBookends', PropTypes.func),
     onLast: requiredBy('showBookends', PropTypes.func),
     pageCount: requiredBy('showBookends', PropTypes.number),
-    startAlign: alignProp,
   };
 
   render() {
@@ -72,6 +72,8 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       fetching,
       hasNext,
       hasPrev,
+      showBookends,
+      startAlign,
       pageLabel,
       onFirst,
       onLast,
@@ -79,8 +81,6 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       onPrevious,
       page,
       pageCount,
-      showBookends,
-      startAlign,
       styles,
       theme,
     } = this.props;

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { requiredBy } from 'airbnb-prop-types';
+import { requiredBy, mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import IconFirst from '@airbnb/lunar-icons/lib/interface/IconFirst';
@@ -9,6 +9,8 @@ import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 import IconButton from '../IconButton';
 import Text from '../Text';
 import T from '../Translate';
+
+const alignProp = mutuallyExclusiveTrueProps('centerAlign', 'endAlign', 'startAlign');
 
 export type Props = {
   /** Align arrows in the center */
@@ -57,6 +59,9 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
   };
 
   static propTypes = {
+    centerAlign: alignProp,
+    endAlign: alignProp,
+    startAlign: alignProp,
     onFirst: requiredBy('showBookends', PropTypes.func),
     onLast: requiredBy('showBookends', PropTypes.func),
     pageCount: requiredBy('showBookends', PropTypes.number),

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -8,10 +8,13 @@ import IconLast from '@airbnb/lunar-icons/lib/interface/IconLast';
 import withStyles, { css, WithStylesProps } from '../../composers/withStyles';
 import IconButton from '../IconButton';
 import Text from '../Text';
-import Row from '../Row';
 import T from '../Translate';
 
 export type Props = {
+  /** Align arrows in the center */
+  centerAlign?: boolean;
+  /** Align arrows to the end */
+  endAlign?: boolean;
   /** Show fetching state. */
   fetching?: boolean;
   /** Whether it has a next page. */
@@ -24,6 +27,10 @@ export type Props = {
   pageLabel?: string;
   /** Total page count. Required when `showBookends` is true. */
   pageCount?: number;
+  /** Render the pagination as 100% width. */
+  renderFullWidth?: boolean;
+  /** Align arrows to the start */
+  startAlign?: boolean;
   /** Invoked when the first page button is pressed. */
   onFirst?: () => void;
   /** Invoked when the last page button is pressed. */
@@ -39,11 +46,14 @@ export type Props = {
 /** Pagination controls. */
 export class Pagination extends React.Component<Props & WithStylesProps> {
   static defaultProps = {
+    centerAlign: false,
+    endAlign: false,
     fetching: false,
     hasNext: false,
     hasPrev: false,
     pageLabel: T.phrase('Page', {}, 'Label for pages'),
     showBookends: false,
+    startAlign: false,
   };
 
   static propTypes = {
@@ -54,6 +64,8 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
 
   render() {
     const {
+      centerAlign,
+      endAlign,
       fetching,
       hasNext,
       hasPrev,
@@ -65,6 +77,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       page,
       pageCount,
       showBookends,
+      startAlign,
       styles,
       theme,
     } = this.props;
@@ -167,34 +180,62 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
     }
 
     return (
-      <Row
-        before={
-          <>
-            {firstPage}
-            {previousPage}
-          </>
-        }
-        after={
-          <>
-            {nextPage}
-            {lastPage}
-          </>
-        }
-        middleAlign
+      <div
+        {...css(
+          styles.wrapper,
+          endAlign && styles.end_align,
+          centerAlign && styles.center_align,
+          startAlign && styles.start_align,
+        )}
       >
-        <div {...css(styles.centered)}>
+        <div {...css(styles.previous)}>
+          {firstPage}
+          {previousPage}
+        </div>
+        <div {...css(styles.page)}>
           <Text muted>{paginationText}</Text>
         </div>
-      </Row>
+        <div {...css(styles.next)}>
+          {nextPage}
+          {lastPage}
+        </div>
+      </div>
     );
   }
 }
 
 export default withStyles(
-  () => ({
-    centered: {
-      width: '100%',
-      textAlign: 'center',
+  ({ unit }) => ({
+    wrapper: {
+      display: 'grid',
+      gridTemplateAreas: '"previous page next"',
+      gridTemplateColumns: 'auto 1fr auto',
+      gridColumnGap: unit * 2,
+      alignItems: 'center',
+      justifyItems: 'center',
+    },
+    page: {
+      gridArea: 'page',
+    },
+    previous: {
+      gridArea: 'previous',
+    },
+    next: {
+      gridArea: 'next',
+    },
+    end_align: {
+      gridTemplateAreas: '"page previous next"',
+      gridTemplateColumns: 'auto',
+      justifyContent: 'end',
+    },
+    center_align: {
+      gridTemplateColumns: 'auto',
+      justifyContent: 'center',
+    },
+    start_align: {
+      gridTemplateAreas: '"previous next page"',
+      gridTemplateColumns: 'auto',
+      justifyContent: 'start',
     },
   }),
   {

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -159,7 +159,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
           context="Showing the current page number and total page count"
         />
       ) : (
-        <T phrase={page} context="Showing the current page number" />
+        page
       );
 
     if (pageLabel) {

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -29,8 +29,6 @@ export type Props = {
   pageLabel?: string;
   /** Total page count. Required when `showBookends` is true. */
   pageCount?: number;
-  /** Align arrows to the start */
-  startAlign?: boolean;
   /** Invoked when the first page button is pressed. */
   onFirst?: () => void;
   /** Invoked when the last page button is pressed. */
@@ -41,6 +39,8 @@ export type Props = {
   onPrevious: () => void;
   /** Show the first and last page buttons. */
   showBookends?: boolean;
+  /** Align arrows to the start */
+  startAlign?: boolean;
 };
 
 /** Pagination controls. */
@@ -59,10 +59,10 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     centerAlign: alignProp,
     endAlign: alignProp,
-    startAlign: alignProp,
     onFirst: requiredBy('showBookends', PropTypes.func),
     onLast: requiredBy('showBookends', PropTypes.func),
     pageCount: requiredBy('showBookends', PropTypes.number),
+    startAlign: alignProp,
   };
 
   render() {
@@ -186,9 +186,9 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
       <div
         {...css(
           styles.wrapper,
-          endAlign && styles.end_align,
-          centerAlign && styles.center_align,
-          startAlign && styles.start_align,
+          endAlign && styles.wrapper_endAlign,
+          centerAlign && styles.wrapper_centerAlign,
+          startAlign && styles.wrapper_startAlign,
         )}
       >
         <div {...css(styles.previous)}>
@@ -217,28 +217,34 @@ export default withStyles(
       alignItems: 'center',
       justifyItems: 'center',
     },
-    page: {
-      gridArea: 'page',
-    },
-    previous: {
-      gridArea: 'previous',
-    },
-    next: {
-      gridArea: 'next',
-    },
-    end_align: {
+
+    wrapper_endAlign: {
       gridTemplateAreas: '"page previous next"',
       gridTemplateColumns: 'auto',
       justifyContent: 'end',
     },
-    center_align: {
+
+    wrapper_centerAlign: {
       gridTemplateColumns: 'auto',
       justifyContent: 'center',
     },
-    start_align: {
+
+    wrapper_startAlign: {
       gridTemplateAreas: '"previous next page"',
       gridTemplateColumns: 'auto',
       justifyContent: 'start',
+    },
+
+    page: {
+      gridArea: 'page',
+    },
+
+    previous: {
+      gridArea: 'previous',
+    },
+
+    next: {
+      gridArea: 'next',
     },
   }),
   {

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -159,7 +159,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
           context="Showing the current page number and total page count"
         />
       ) : (
-        <T phrase={'%{pageNumber}'} pageNumber={page} context="Showing the current page number" />
+        <T phrase={page} context="Showing the current page number" />
       );
 
     if (pageLabel) {

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -29,8 +29,6 @@ export type Props = {
   pageLabel?: string;
   /** Total page count. Required when `showBookends` is true. */
   pageCount?: number;
-  /** Render the pagination as 100% width. */
-  renderFullWidth?: boolean;
   /** Align arrows to the start */
   startAlign?: boolean;
   /** Invoked when the first page button is pressed. */

--- a/packages/core/test/components/Pagination.test.tsx
+++ b/packages/core/test/components/Pagination.test.tsx
@@ -28,10 +28,7 @@ describe('<Pagination />', () => {
         hasNext: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles;
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(wrapper.find(IconButton)).toHaveLength(2);
     });
@@ -43,10 +40,7 @@ describe('<Pagination />', () => {
         page: 2,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles;
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(wrapper.find(IconButton)).toHaveLength(2);
     });
@@ -58,10 +52,7 @@ describe('<Pagination />', () => {
         page: 3,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles;
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(wrapper.find(T).prop('pageNumber')).toBe(request.page);
     });
@@ -85,10 +76,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles;
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(wrapper.find(T).prop('pageNumber')).toBe(request.page);
       expect(wrapper.find(T).prop('pageCount')).toBe(pageCount);
@@ -120,10 +108,7 @@ describe('<Pagination />', () => {
         page: 1,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -141,10 +126,7 @@ describe('<Pagination />', () => {
         fetching: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -161,10 +143,9 @@ describe('<Pagination />', () => {
       };
 
       const onPrevious = jest.fn();
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={onPrevious} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(
+        <Pagination {...request} onNext={noop} onPrevious={onPrevious} />,
+      ).dive();
 
       wrapper
         .find(IconButton)
@@ -181,10 +162,7 @@ describe('<Pagination />', () => {
         hasPrev: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -203,10 +181,7 @@ describe('<Pagination />', () => {
         hasPrev: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -224,10 +199,7 @@ describe('<Pagination />', () => {
         fetching: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -243,10 +215,7 @@ describe('<Pagination />', () => {
         hasNext: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(
         wrapper
@@ -263,10 +232,7 @@ describe('<Pagination />', () => {
       };
 
       const onNext = jest.fn();
-      const wrapper = shallow(<Pagination {...request} onNext={onNext} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={onNext} onPrevious={noop} />).dive();
 
       wrapper
         .find(IconButton)
@@ -284,10 +250,7 @@ describe('<Pagination />', () => {
         hasNext: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(wrapper.find(IconButton)).toHaveLength(2);
     });
@@ -310,10 +273,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper
@@ -343,10 +303,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper
@@ -375,10 +332,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       wrapper
         .find(IconButton)
@@ -408,10 +362,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper
@@ -429,10 +380,7 @@ describe('<Pagination />', () => {
         hasNext: true,
       };
 
-      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />)
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      const wrapper = shallow(<Pagination {...request} onNext={noop} onPrevious={noop} />).dive();
 
       expect(wrapper.find(IconButton)).toHaveLength(2);
     });
@@ -455,10 +403,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper
@@ -488,10 +433,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper
@@ -520,10 +462,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       wrapper
         .find(IconButton)
@@ -552,10 +491,7 @@ describe('<Pagination />', () => {
           pageCount={pageCount}
           showBookends
         />,
-      )
-        .dive() // withStyles
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(
         wrapper

--- a/packages/core/test/components/Pagination.test.tsx
+++ b/packages/core/test/components/Pagination.test.tsx
@@ -91,10 +91,7 @@ describe('<Pagination />', () => {
 
       const wrapper = shallow(
         <Pagination {...request} onNext={noop} onPrevious={noop} pageLabel="Photo" />,
-      )
-        .dive() // withStyles;
-        .dive() // Row
-        .dive();
+      ).dive();
 
       expect(wrapper.find(T).prop('pageLabel')).toBe('Photo');
     });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds `startAlign`, `centerAlign`, and `endAlign` properties. These props change the placement of the pagination arrows. See screenshots below!

**Note:** Since there's no request for `startAlign` at this time, let me know if I should take it out of this PR.

## Motivation and Context

The Lightbox designs have pagination with arrows aligned around the center of the "Page x of x" text. The designs for table pagination is right aligned with "Page x of x" repositioned to the left of the arrows. This PR adds three options for the arrows - `startAlign`, `centerAlign`, and `endAlign`.

## Testing

- Added to Storybook
- Tested locally

## Screenshots

Design Screenshots:
<img width="873" alt="Screen Shot 2019-06-05 at 4 24 41 PM" src="https://user-images.githubusercontent.com/6675771/58996895-f66e6500-87ae-11e9-8375-176f8928066b.png">
<img width="855" alt="Screen Shot 2019-06-05 at 4 35 35 PM" src="https://user-images.githubusercontent.com/6675771/58997137-fe7ad480-87af-11e9-8ea9-be591ed49271.png">

Storybook Screenshots:
<img width="810" alt="Screen Shot 2019-06-05 at 4 22 44 PM" src="https://user-images.githubusercontent.com/6675771/58996904-fcfcdc80-87ae-11e9-9817-4290f7c66c42.png">
<img width="818" alt="Screen Shot 2019-06-05 at 4 22 40 PM" src="https://user-images.githubusercontent.com/6675771/58996905-fcfcdc80-87ae-11e9-870f-095c2223bce5.png">
<img width="819" alt="Screen Shot 2019-06-05 at 4 22 33 PM" src="https://user-images.githubusercontent.com/6675771/58996906-fcfcdc80-87ae-11e9-8cfd-aa7e159f6a5b.png">

Default:
<img width="1088" alt="Screen Shot 2019-06-05 at 4 31 05 PM" src="https://user-images.githubusercontent.com/6675771/58996997-59f89280-87af-11e9-855f-568915d3ad03.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
