### PR TITLE
fix(Metrics): safely check for ga.

### DIFF
--- a/packages/metrics/src/utils/hasGoogleAnalytics.ts
+++ b/packages/metrics/src/utils/hasGoogleAnalytics.ts
@@ -1,3 +1,3 @@
 export default function hasGoogleAnalytics() {
-  return !!ga && typeof ga === 'function';
+  return typeof ga === 'function';
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Saw some errors locally using `Metrics.initialize` because `ReferenceError: ga is not defined`. This happened when I changed `global.ga` to `ga`.

## Motivation and Context

Fixes a reference error when `ga` is not present on `window`

## Testing

Tests still pass.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
