### PR TITLE
fix(Metrics): set ga userId as string.

### DIFF
--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -87,7 +87,7 @@ class Metrics {
 
   bootstrapGoogleAnalyticsUser() {
     if (hasGoogleAnalytics() && this.settings.userID) {
-      ga('set', 'userId', this.settings.userID);
+      ga('set', 'userId', `${this.settings.userID}`);
     }
   }
 }

--- a/packages/metrics/test/index.test.ts
+++ b/packages/metrics/test/index.test.ts
@@ -164,7 +164,7 @@ describe('Metrics', () => {
       Metrics.bootstrapGoogleAnalyticsUser();
 
       expect(global.ga).toBeCalledTimes(1);
-      expect(global.ga).toBeCalledWith('set', 'userId', 12355);
+      expect(global.ga).toBeCalledWith('set', 'userId', '12355');
     });
 
     it('does not attempt to set the google analytics user if the user ID is not present', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Some older Google Analytics docs mention the `USER_ID` should be a `string`, this changes it to that.

![image](https://user-images.githubusercontent.com/2336595/59068240-82909300-8868-11e9-8e71-0c945e8a540f.png)


## Motivation and Context

Follow best practice to setting Google Analytics `userId`

## Testing

Updated tests.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
