### PR TITLE
update(withIcon): Throw dev error if an ally prop is missing.

### DIFF
--- a/.storybook/components/DataTable/DataTableRenderers/MenuRenderer.jsx
+++ b/.storybook/components/DataTable/DataTableRenderers/MenuRenderer.jsx
@@ -22,7 +22,7 @@ export class MenuRenderer extends React.Component {
     });
   }
 
-  toggleClick = (event) => {
+  toggleClick = event => {
     event.stopPropagation();
 
     this.setState({
@@ -57,7 +57,7 @@ export class MenuRenderer extends React.Component {
     return (
       <React.Fragment>
         <Button inverted small onClick={this.toggleClick}>
-          <IconMenuDots />
+          <IconMenuDots decorative />
         </Button>
         {menu}
       </React.Fragment>

--- a/packages/core/src/components/Chip.story.tsx
+++ b/packages/core/src/components/Chip.story.tsx
@@ -27,17 +27,21 @@ storiesOf('Core/Chip', module)
       </Spacing>
     </>
   ))
-  .add('With an icon.', () => <Chip icon={<IconCloseAlt size="2em" />}>Chip</Chip>)
+  .add('With an icon.', () => <Chip icon={<IconCloseAlt decorative size="2em" />}>Chip</Chip>)
   .add('With an icon button.', () => (
     <>
       <Spacing right={1} inline>
-        <Chip icon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
+        <Chip icon={<IconCloseAlt decorative size="2em" />} onIconClick={action('onIconClick')}>
           Close
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip disabled icon={<IconCloseAlt size="2em" />} onIconClick={action('onIconClick')}>
+        <Chip
+          disabled
+          icon={<IconCloseAlt decorative size="2em" />}
+          onIconClick={action('onIconClick')}
+        >
           Close
         </Chip>
       </Spacing>
@@ -45,7 +49,7 @@ storiesOf('Core/Chip', module)
   ))
   .add('With a profile photo.', () => <Chip profileImageSrc={lunar}>User</Chip>)
   .add('With both a profile photo and an icon.', () => (
-    <Chip icon={<IconSettings size="2em" />} profileImageSrc={lunar}>
+    <Chip icon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
       Settings
     </Chip>
   ))
@@ -56,13 +60,13 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={1} inline>
-        <Chip disabled icon={<IconSettings size="2em" />} profileImageSrc={lunar}>
+        <Chip disabled icon={<IconSettings decorative size="2em" />} profileImageSrc={lunar}>
           User
         </Chip>
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip disabled icon={<IconSettings size="2em" />}>
+        <Chip disabled icon={<IconSettings decorative size="2em" />}>
           Settings
         </Chip>
       </Spacing>
@@ -76,7 +80,7 @@ storiesOf('Core/Chip', module)
 
       <Spacing right={1} inline>
         <Chip
-          icon={<IconSettings size="2em" />}
+          icon={<IconSettings decorative size="2em" />}
           profileImageSrc={lunar}
           onClick={action('onClick')}
         >
@@ -85,7 +89,7 @@ storiesOf('Core/Chip', module)
       </Spacing>
 
       <Spacing right={0} inline>
-        <Chip icon={<IconSettings size="2em" />} onClick={action('onClick')}>
+        <Chip icon={<IconSettings decorative size="2em" />} onClick={action('onClick')}>
           Settings
         </Chip>
       </Spacing>

--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -56,7 +56,7 @@ export default class Copy extends React.Component<Props, State> {
     const element = children || (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <Link>
-        <IconCopy />
+        <IconCopy decorative />
       </Link>
     );
 

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -67,7 +67,7 @@ const columnToLabel = {
   tenureDays: (
     <span>
       ICON IN HEADER
-      <IconStar inline />
+      <IconStar decorative inline />
     </span>
   ),
 };

--- a/packages/core/src/components/DataTable/columns/ExpandableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/ExpandableColumn.tsx
@@ -28,7 +28,7 @@ export default function renderExpandableColumn(
           onKeyPress={expandRow(originalIndex)}
         >
           <Spacing left={1.5}>
-            <Chevron size="1.6em" />
+            <Chevron decorative size="1.6em" />
           </Spacing>
         </div>
       );

--- a/packages/core/src/components/GradientScroller/index.tsx
+++ b/packages/core/src/components/GradientScroller/index.tsx
@@ -221,7 +221,7 @@ export class GradientScroller extends React.Component<Props & WithStylesProps, S
               type="button"
               onClick={this.handleScrollLeft}
             >
-              <IconChevronLeft size="2em" decorative />
+              <IconChevronLeft decorative size="2em" />
             </button>
           ) : (
             <span
@@ -239,7 +239,7 @@ export class GradientScroller extends React.Component<Props & WithStylesProps, S
               type="button"
               onClick={this.handleScrollRight}
             >
-              <IconChevronRight size="2em" decorative />
+              <IconChevronRight decorative size="2em" />
             </button>
           ) : (
             <span

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
@@ -94,7 +94,7 @@ class HierarchyItem extends React.Component<Props & WithStylesProps> {
       <>
         {selected && (
           <span {...css(styles.checkmark)}>
-            <IconCheckmark color={theme!.color.core.primary[3]} size={ICON_SIZE} decorative />
+            <IconCheckmark decorative color={theme!.color.core.primary[3]} size={ICON_SIZE} />
           </span>
         )}
 
@@ -117,7 +117,7 @@ class HierarchyItem extends React.Component<Props & WithStylesProps> {
         tabIndex={focused ? 1 : 0} // this is needed to find a focused parent item in a vertically aligned list
       >
         {this.renderItem()}
-        {item.items && <IconChevronRight size="1.4em" decorative inline />}
+        {item.items && <IconChevronRight decorative inline size="1.4em" />}
       </div>
     );
   }

--- a/packages/core/src/components/IconButton.story.tsx
+++ b/packages/core/src/components/IconButton.story.tsx
@@ -11,27 +11,27 @@ storiesOf('Core/IconButton', module)
   .add('A standard button, with different sizes.', () => (
     <>
       <IconButton onClick={action('onClick')}>
-        <IconCheck />
+        <IconCheck decorative />
       </IconButton>
       <br />
       <br />
       <IconButton onClick={action('onClick')}>
-        <IconCheck size="2em" />
+        <IconCheck decorative size="2em" />
       </IconButton>
     </>
   ))
   .add('An anchor link when passing `href`.', () => (
     <IconButton onClick={action('onClick')} href="https://github.com/airbnb/lunar" openInNewWindow>
-      <IconCheck />
+      <IconCheck decorative />
     </IconButton>
   ))
   .add('Wrapped in a tooltip.', () => (
     <IconButton onClick={action('onClick')} tooltip="This does something cool.">
-      <IconCheck />
+      <IconCheck decorative />
     </IconButton>
   ))
   .add('With a disabled state.', () => (
     <IconButton onClick={action('onClick')} disabled>
-      <IconCheck />
+      <IconCheck decorative />
     </IconButton>
   ));

--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -88,7 +88,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
       tip,
     } = this.props;
     const { showSubmenu } = this.state;
-    const after = submenu ? <IconCaretRight size="1.5em" decorative /> : tip;
+    const after = submenu ? <IconCaretRight decorative size="1.5em" /> : tip;
 
     return (
       <li role="none" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>

--- a/packages/core/src/components/MessageItem.story.tsx
+++ b/packages/core/src/components/MessageItem.story.tsx
@@ -66,7 +66,7 @@ storiesOf('Core/MessageItem', module)
   .add('With an icon avatar.', () => (
     <MessageItem
       formattedTimestamp="2:45 AM"
-      icon={<IconBolt size="1.25em" />}
+      icon={<IconBolt decorative size="1.25em" />}
       imageDescription="Link"
       source="web"
       title="Some custom title"

--- a/packages/core/src/components/Multicomplete/private/Chip.tsx
+++ b/packages/core/src/components/Multicomplete/private/Chip.tsx
@@ -18,7 +18,7 @@ export default class MulticompleteChip extends React.Component<Props> {
     const { value } = this.props;
 
     return (
-      <Chip icon={<IconCloseAlt size="2em" />} onIconClick={this.handleClick}>
+      <Chip icon={<IconCloseAlt decorative size="2em" />} onIconClick={this.handleClick}>
         {value}
       </Chip>
     );

--- a/packages/core/src/components/SortCarets/index.tsx
+++ b/packages/core/src/components/SortCarets/index.tsx
@@ -35,7 +35,7 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
             enableUp ? styles.caret_active : styles.caret_inactive,
           )}
         >
-          <IconCaretUp size="2em" />
+          <IconCaretUp decorative size="2em" />
         </span>
       )
     );
@@ -53,7 +53,7 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
             enableDown ? styles.caret_active : styles.caret_inactive,
           )}
         >
-          <IconCaretDown size="2em" />
+          <IconCaretDown decorative size="2em" />
         </span>
       )
     );

--- a/packages/core/src/components/private/BaseCheckBox.tsx
+++ b/packages/core/src/components/private/BaseCheckBox.tsx
@@ -68,13 +68,13 @@ class BaseCheckBox extends React.Component<Props & WithStylesProps> {
         >
           {checked && (
             <span {...css(styles.checkmark)}>
-              <IconCheck size="1.5em" decorative />
+              <IconCheck decorative size="1.5em" />
             </span>
           )}
 
           {indeterminate && (
             <span {...css(styles.indeterminate)}>
-              <IconRemove size="1.5em" decorative />
+              <IconRemove decorative size="1.5em" />
             </span>
           )}
         </span>

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -68,12 +68,12 @@ class BaseRadioButton extends React.Component<Props & WithStylesProps> {
         >
           {checked && (
             <span {...css(styles.bullet)}>
-              <IconRecord size="1em" decorative />
+              <IconRecord decorative size="1em" />
             </span>
           )}
           {indeterminate && (
             <span {...css(styles.indeterminate)}>
-              <IconRemove size="1.64em" decorative />
+              <IconRemove decorative size="1.64em" />
             </span>
           )}
         </span>

--- a/packages/core/src/components/private/BaseSwitch.tsx
+++ b/packages/core/src/components/private/BaseSwitch.tsx
@@ -51,7 +51,7 @@ class BaseSwitch extends React.Component<Props & WithStylesProps> {
           <span {...css(styles.toggle, checked && styles.toggle_checked)}>
             {checked && (
               <span {...css(styles.checkmark)}>
-                <IconCheck size="1.5em" decorative />
+                <IconCheck decorative size="1.5em" />
               </span>
             )}
           </span>

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -20,13 +20,13 @@ describe('<Chip />', () => {
   });
 
   it('renders an icon if provided', () => {
-    const icon = <IconCheck />;
+    const icon = <IconCheck decorative />;
     const wrapper = shallow(<Chip icon={icon}>Sour Cream and Onion</Chip>).dive();
     expect(wrapper.contains(icon)).toBe(true);
   });
 
   it('renders the icon as a button if `onIconClick` is provided', () => {
-    const icon = <IconCheck />;
+    const icon = <IconCheck decorative />;
     const onClick = () => {};
     const wrapper = shallow(
       <Chip icon={icon} onIconClick={onClick}>

--- a/packages/core/test/components/IconButton.test.tsx
+++ b/packages/core/test/components/IconButton.test.tsx
@@ -18,7 +18,7 @@ describe('<IconButton />', () => {
   it('renders disabled', () => {
     const wrapper = shallow(
       <IconButton disabled>
-        <IconCheck />
+        <IconCheck decorative />
       </IconButton>,
     ).dive();
 
@@ -28,7 +28,7 @@ describe('<IconButton />', () => {
   it('wraps in a tooltip', () => {
     const wrapper = shallow(
       <IconButton>
-        <IconCheck />
+        <IconCheck decorative />
       </IconButton>,
     ).dive();
 

--- a/packages/core/test/components/MenuToggle.test.tsx
+++ b/packages/core/test/components/MenuToggle.test.tsx
@@ -101,7 +101,11 @@ describe('<MenuToggle />', () => {
   it('can render an icon button', () => {
     const label = 'Foo';
     const wrapper = shallow(
-      <MenuToggle accessibilityLabel="Foo" toggleIcon={<IconCheck />} toggleLabel={label}>
+      <MenuToggle
+        accessibilityLabel="Foo"
+        toggleIcon={<IconCheck decorative />}
+        toggleLabel={label}
+      >
         <Item>Child</Item>
       </MenuToggle>,
     ).dive();

--- a/packages/core/test/components/MessageItem.test.tsx
+++ b/packages/core/test/components/MessageItem.test.tsx
@@ -151,7 +151,7 @@ describe('<MessageItem>', () => {
     const timestamp = '11:56 AM';
     const title = 'title';
     const wrapper = shallow(
-      <MessageItem formattedTimestamp={timestamp} title={title} icon={<IconCheck />}>
+      <MessageItem formattedTimestamp={timestamp} title={title} icon={<IconCheck decorative />}>
         Hello world
       </MessageItem>,
     ).dive();

--- a/packages/icons/src/withIcon.tsx
+++ b/packages/icons/src/withIcon.tsx
@@ -68,6 +68,11 @@ export default function withIcon(
         };
 
         if (__DEV__) {
+          if (!accessibilityLabel && !decorative) {
+            // eslint-disable-next-line no-console
+            console.error('Missing `accessibilityLabel` or `decorative` for accessibility.');
+          }
+
           if (accessibilityLabel && decorative) {
             // eslint-disable-next-line no-console
             console.error('Only one of `accessibilityLabel` or `decorative` may be used.');

--- a/packages/icons/test/withIcon.test.tsx
+++ b/packages/icons/test/withIcon.test.tsx
@@ -16,7 +16,7 @@ describe('withIcon()', () => {
 
   it('passes through props', () => {
     const Hoc = withIcon('IconTest')(Foo);
-    const wrapper = shallow(<Hoc inline size={16} color="white" />);
+    const wrapper = shallow(<Hoc decorative inline size={16} color="white" />);
     const style: React.CSSProperties = wrapper.find(Foo).prop('style');
 
     expect(style.width).toBe(16);
@@ -28,7 +28,7 @@ describe('withIcon()', () => {
 
   it('flips horizontally', () => {
     const Hoc = withIcon('IconTest')(Foo);
-    const wrapper = shallow(<Hoc flip />);
+    const wrapper = shallow(<Hoc decorative flip />);
     const style: React.CSSProperties = wrapper.find(Foo).prop('style');
 
     expect(style.transform).toBe('scale(-1, 1)');
@@ -36,7 +36,7 @@ describe('withIcon()', () => {
 
   it('flips vertically', () => {
     const Hoc = withIcon('IconTest')(Foo);
-    const wrapper = shallow(<Hoc flipVertical />);
+    const wrapper = shallow(<Hoc decorative flipVertical />);
     const style: React.CSSProperties = wrapper.find(Foo).prop('style');
 
     expect(style.transform).toBe('scale(1, -1)');
@@ -44,7 +44,7 @@ describe('withIcon()', () => {
 
   it('flips horizontally & vertically', () => {
     const Hoc = withIcon('IconTest')(Foo);
-    const wrapper = shallow(<Hoc flip flipVertical />);
+    const wrapper = shallow(<Hoc decorative flip flipVertical />);
     const style: React.CSSProperties = wrapper.find(Foo).prop('style');
 
     expect(style.transform).toBe('scale(-1, -1)');
@@ -60,5 +60,19 @@ describe('withIcon()', () => {
 
     expect(wrapperWithLabel.find(Foo).prop('role')).toBe('img');
     expect(wrapperWithLabel.find(Foo).prop('aria-label')).toBe('foobar');
+  });
+
+  it('errors when an a11y prop is missing', () => {
+    expect(() => {
+      const Hoc = withIcon('IconTest')(Foo);
+      shallow(<Hoc />);
+    }).toThrowError('Missing `accessibilityLabel` or `decorative` for accessibility.');
+  });
+
+  it('errors when both a11y props are added', () => {
+    expect(() => {
+      const Hoc = withIcon('IconTest')(Foo);
+      shallow(<Hoc decorative accessibilityLabel="foobar" />);
+    }).toThrowError('Only one of `accessibilityLabel` or `decorative` may be used.');
   });
 });

--- a/packages/layouts/test/components/SideBar.test.tsx
+++ b/packages/layouts/test/components/SideBar.test.tsx
@@ -17,7 +17,7 @@ describe('<SideBar />', () => {
   it('renders a nav with accessibility', () => {
     const wrapper = shallow(
       <SideBar accessibilityLabel="Test">
-        <Item icon={<IconAdd />} />
+        <Item icon={<IconAdd decorative />} />
       </SideBar>,
     ).dive();
 
@@ -29,9 +29,9 @@ describe('<SideBar />', () => {
   it('renders items', () => {
     const wrapper = shallow(
       <SideBar accessibilityLabel="Test">
-        <Item icon={<IconAdd />} />
-        <Item icon={<IconAdd />} />
-        <Item icon={<IconAdd />} />
+        <Item icon={<IconAdd decorative />} />
+        <Item icon={<IconAdd decorative />} />
+        <Item icon={<IconAdd decorative />} />
       </SideBar>,
     ).dive();
 

--- a/packages/layouts/test/components/SideBar/Item.test.tsx
+++ b/packages/layouts/test/components/SideBar/Item.test.tsx
@@ -12,7 +12,7 @@ describe('<SideBarItem />', () => {
   });
 
   it('renders a list item with accessibility', () => {
-    const wrapper = shallow(<SideBarItem icon={<IconAdd />} />).dive();
+    const wrapper = shallow(<SideBarItem icon={<IconAdd decorative />} />).dive();
 
     expect(wrapper.is('li')).toBe(true);
     expect(wrapper.prop('role')).toBe('none');
@@ -20,7 +20,9 @@ describe('<SideBarItem />', () => {
   });
 
   it('renders an icon and label', () => {
-    const wrapper = shallow(<SideBarItem icon={<IconAdd />} label={<i>Label</i>} />).dive();
+    const wrapper = shallow(
+      <SideBarItem icon={<IconAdd decorative />} label={<i>Label</i>} />,
+    ).dive();
 
     expect(wrapper.find(IconAdd)).toHaveLength(1);
     expect(wrapper.find('i')).toHaveLength(1);
@@ -28,7 +30,9 @@ describe('<SideBarItem />', () => {
 
   it('passes href and onClick', () => {
     const click = jest.fn();
-    const wrapper = shallow(<SideBarItem icon={<IconAdd />} href="/test" onClick={click} />).dive();
+    const wrapper = shallow(
+      <SideBarItem icon={<IconAdd decorative />} href="/test" onClick={click} />,
+    ).dive();
 
     expect(wrapper.find(ButtonOrLink).prop('href')).toBe('/test');
     expect(wrapper.find(ButtonOrLink).prop('onClick')).toBe(click);


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adding a dev error.
```
'Missing `accessibilityLabel` or `decorative` for accessibility.
```

## Motivation and Context

Seeing Icons in PRs without an a11y prop. This used to throw an error? Needs an error.

## Testing

Added tests.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
