### PR TITLE
new(Autocomplete): Add `loadItemsOnFocus` functionality

### DIFF
--- a/packages/core/src/components/Autocomplete.story.tsx
+++ b/packages/core/src/components/Autocomplete.story.tsx
@@ -67,11 +67,11 @@ storiesOf('Core/Autocomplete', module)
       accessibilityLabel="Label"
       name="autocomplete-load-on-focus"
       label="Label"
-      loadItemsOnFocus
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
       onLoadOptions={value => Promise.resolve(items) as any}
       labelDescription="Load some items on focus."
+      loadItemsOnFocus
     />
   ))
   .add('Disable selected items with `isItemSelectable`.', () => (

--- a/packages/core/src/components/Autocomplete.story.tsx
+++ b/packages/core/src/components/Autocomplete.story.tsx
@@ -62,6 +62,18 @@ storiesOf('Core/Autocomplete', module)
       disabled
     />
   ))
+  .add('Load items on focus.', () => (
+    <Autocomplete
+      accessibilityLabel="Label"
+      name="autocomplete-load-on-focus"
+      label="Label"
+      loadItemsOnFocus
+      onChange={action('onChange')}
+      onSelectItem={action('onSelectItem')}
+      onLoadOptions={value => Promise.resolve(items) as any}
+      labelDescription="Load some items on focus."
+    />
+  ))
   .add('Disable selected items with `isItemSelectable`.', () => (
     <Autocomplete
       accessibilityLabel="Favorite color?"

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -50,6 +50,8 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     isItemSelectable?: (item: T, selected?: boolean) => boolean;
     /** Determine if an item is selected. Will compare values by default if not defined. */
     isItemSelected?: (item: T, value: string) => boolean;
+    /** */
+    loadItemsOnFocus?: boolean;
     /** Load and show items on mount. */
     loadItemsOnMount?: boolean;
     /** Max height of the results dropdown menu. */
@@ -105,6 +107,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
       return true;
     },
     isItemSelected() {},
+    loadItemsOnFocus: false,
     loadItemsOnMount: false,
     onMenuVisibilityChange() {},
     onSelectItem() {},
@@ -217,6 +220,10 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     if (this.props.onFocus) {
       this.props.onFocus(event);
+    }
+
+    if (this.props.loadItemsOnFocus) {
+      this.loadItems('', true);
     }
 
     this.setState({
@@ -600,7 +607,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
     const { error, loading, value } = this.state;
     const items = this.renderItems();
 
-    if (!value && items.length === 0) {
+    if (!loading && !value && items.length === 0) {
       return <div />;
     }
 

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -50,7 +50,7 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     isItemSelectable?: (item: T, selected?: boolean) => boolean;
     /** Determine if an item is selected. Will compare values by default if not defined. */
     isItemSelected?: (item: T, value: string) => boolean;
-    /** */
+    /** Whether to invoke onLoadOptions with an empty string when focused. */
     loadItemsOnFocus?: boolean;
     /** Load and show items on mount. */
     loadItemsOnMount?: boolean;
@@ -223,7 +223,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
     }
 
     if (this.props.loadItemsOnFocus) {
-      this.loadItems('', true);
+      this.loadItems('');
     }
 
     this.setState({
@@ -445,8 +445,10 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
       loading: true,
     });
 
+    const { loadItemsOnFocus } = this.props;
+
     // Exit early if no value
-    if (!value && !force) {
+    if (!value && !force && !loadItemsOnFocus) {
       this.props.onSelectItem!('', null);
 
       return Promise.resolve([]);

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -218,12 +218,14 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    const { value } = this.state;
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
 
     if (this.props.loadItemsOnFocus) {
-      this.loadItems('');
+      this.loadItems(value);
     }
 
     this.setState({

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -50,7 +50,7 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     isItemSelectable?: (item: T, selected?: boolean) => boolean;
     /** Determine if an item is selected. Will compare values by default if not defined. */
     isItemSelected?: (item: T, value: string) => boolean;
-    /** Whether to invoke onLoadOptions with an empty string when focused. */
+    /** Whether to invoke onLoadOptions with the current value when focused. */
     loadItemsOnFocus?: boolean;
     /** Load and show items on mount. */
     loadItemsOnMount?: boolean;

--- a/packages/core/src/components/Multicomplete.story.tsx
+++ b/packages/core/src/components/Multicomplete.story.tsx
@@ -48,4 +48,26 @@ storiesOf('Core/Multicomplete', module)
       renderItem={(item, highlighted, selected) => <Text bold={selected}>{item.name}</Text>}
       value={['red', 'green']}
     />
+  ))
+  .add('Load items on focus.', () => (
+    <Multicomplete
+      accessibilityLabel="Favorite color?"
+      label="Favorite color?"
+      name="autocomplete"
+      onChange={action('onChange')}
+      onSelectItem={action('onSelectItem')}
+      onLoadOptions={value =>
+        Promise.resolve(
+          [
+            { value: 'red', name: 'Red' },
+            { value: 'black', name: 'Black' },
+            { value: 'blue', name: 'Blue' },
+            { value: 'green', name: 'Green' },
+          ].filter(item => !value || item.name.toLowerCase().match(value.toLowerCase())),
+        )
+      }
+      renderItem={(item, highlighted, selected) => <Text bold={selected}>{item.name}</Text>}
+      value={['red', 'green']}
+      loadItemsOnFocus
+    />
   ));

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -165,7 +165,7 @@ describe('<Autocomplete />', () => {
       expect(wrapper.state('open')).toBe(true);
     });
 
-    it('calls loadItems if `loadItemsOnFocus` is `true`', () => {
+    it('calls `loadItems` if `loadItemsOnFocus` is `true`', () => {
       const spy = jest.spyOn(instance, 'loadItems');
 
       wrapper.setProps({

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -164,6 +164,18 @@ describe('<Autocomplete />', () => {
 
       expect(wrapper.state('open')).toBe(true);
     });
+
+    it('calls loadItems if `loadItemsOnFocus` is `true`', () => {
+      const spy = jest.spyOn(instance, 'loadItems');
+
+      wrapper.setProps({
+        loadItemsOnFocus: true,
+      });
+
+      wrapper.find(BaseInput).simulate('focus', {});
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('handleInputKeyDown()', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This PR adds a new `loadItemsOnFocus` prop to the `Autocomplete` (and thus `Multicomplete`) component(s). 

## Motivation and Context

The new `loadItemsOnFocus` partially addresses some component limitations described in #26 ([comment](https://github.com/airbnb/lunar/issues/26#issuecomment-496802807)), namely that it is impossible to fetch items upon which we've designed several user experiences around. 

We have tried using the `autoFocus` and `loadItemsOnMount` props, but they do not enable the same functionality and user experience.

## Testing

Functional (`@airbnb/lunar-core` `Autocomplete`, `Multicomplete`, and `@airbnb/lunar-form` `Autocomplete`) + new unit test.

## Screenshots

**Before** (must type to load)
<img src="https://user-images.githubusercontent.com/4496521/59218683-aa883b00-8b75-11e9-87c1-bef5cd090067.gif" width="350" />

**After** (load on focus)
<img src="https://user-images.githubusercontent.com/4496521/59218689-ad832b80-8b75-11e9-9f5d-fcba5c86b057.gif" width="350" />

Multicomplete
<img src="https://user-images.githubusercontent.com/4496521/59304086-703d9d00-8c4c-11e9-98dc-274b6b440a81.gif" width="350" />

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
