### PR TITLE
new(SidePanel): Add new collapsible side panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "lunar-root",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "React toolkit and design language for Airbnb open source and internal projects.",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -85,10 +85,16 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
+<<<<<<< HEAD
     "@types/enzyme": "^3.9.4",
     "@types/google.analytics": "0.0.40",
     "@types/jest": "^24.0.15",
     "@types/jscodeshift": "^0.6.1",
+=======
+    "@types/enzyme": "^3.9.1",
+    "@types/google.analytics": "0.0.40",
+    "@types/jest": "^24.0.11",
+>>>>>>> revert changes to package.json
     "@types/storybook__addon-a11y": "^5.0.0",
     "@types/storybook__addon-actions": "^3.4.3",
     "@types/storybook__react": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "lunar-root",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "description": "React toolkit and design language for Airbnb open source and internal projects.",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -85,15 +85,10 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-<<<<<<< HEAD
     "@types/enzyme": "^3.9.4",
     "@types/google.analytics": "0.0.40",
     "@types/jest": "^24.0.15",
     "@types/jscodeshift": "^0.6.1",
-=======
-    "@types/enzyme": "^3.9.1",
-    "@types/jest": "^24.0.11",
->>>>>>> revert changes to package.json
     "@types/storybook__addon-a11y": "^5.0.0",
     "@types/storybook__addon-actions": "^3.4.3",
     "@types/storybook__react": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@types/jscodeshift": "^0.6.1",
 =======
     "@types/enzyme": "^3.9.1",
-    "@types/google.analytics": "0.0.40",
     "@types/jest": "^24.0.11",
 >>>>>>> revert changes to package.json
     "@types/storybook__addon-a11y": "^5.0.0",

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -18,6 +18,7 @@
   },
   "peerDependencies": {
     "@airbnb/lunar": "^2.0.0",
+    "@airbnb/lunar-icons": "^2.0.0",
     "react": "^16.8.0"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
   },
   "dependencies": {
     "@types/airbnb-prop-types": "^2.13.1",
+    "@types/prop-types": "^15.7.1",
     "airbnb-prop-types": "^2.13.2",
     "utility-types": "^3.7.0"
   }

--- a/packages/layouts/src/components/SidePanel.story.tsx
+++ b/packages/layouts/src/components/SidePanel.story.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SidePanel from './SidePanel';
 import IconArrowLeft from '@airbnb/lunar-icons/lib/interface/IconArrowLeft';
 import IconArrowRight from '@airbnb/lunar-icons/lib/interface/IconArrowRight';
 import IconCaretRight from '@airbnb/lunar-icons/lib/interface/IconCaretRight';
 import IconCaretLeft from '@airbnb/lunar-icons/lib/interface/IconCaretLeft';
-import Spacing from '@airbnb/lunar/src/components/Spacing';
+
+import SidePanel from './SidePanel';
 
 storiesOf('Layouts/SidePanel', module)
   .addParameters({

--- a/packages/layouts/src/components/SidePanel.story.tsx
+++ b/packages/layouts/src/components/SidePanel.story.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import LoremIpsum from ':storybook/components/LoremIpsum';
+import SidePanel from './SidePanel';
+import IconCaretRight from '@airbnb/lunar-icons/lib/interface/IconCaretRight';
+import IconCaretLeft from '@airbnb/lunar-icons/lib/interface/IconCaretLeft';
+
+storiesOf('Layouts/SidePanel', module)
+  .addParameters({
+    inspectComponents: [SidePanel],
+  })
+  .add('A side panel.', () => (
+    <SidePanel collapsible={false} sidePane={<LoremIpsum />} mainPane={<LoremIpsum />} />
+  ))
+  .add('A wide side panel.', () => (
+    <SidePanel
+      fixedWidth={600}
+      collapsible={false}
+      sidePane={<LoremIpsum />}
+      mainPane={<LoremIpsum />}
+    />
+  ))
+  .add('A side panel with dynamic width constrained by a min and max.', () => (
+    <SidePanel
+      percentWidth={25}
+      minWidth={300}
+      maxWidth={400}
+      collapsible={false}
+      sidePane={<LoremIpsum />}
+      mainPane={<LoremIpsum />}
+    />
+  ))
+  .add('A collapsible side panel.', () => (
+    <SidePanel sidePane={<LoremIpsum />} mainPane={<LoremIpsum />} />
+  ))
+  .add('A collapsible side panel with custom button offset.', () => (
+    <SidePanel sidePane={<LoremIpsum />} mainPane={<LoremIpsum />} buttonTop={435} />
+  ))
+  .add('A collapsible side panel with custom background color.', () => (
+    <SidePanel sidePane={<LoremIpsum />} mainPane={<LoremIpsum />} background="#fafafa" />
+  ))
+  .add('A right side side panel with custom icons.', () => (
+    <SidePanel
+      rightSide
+      sidePane={<LoremIpsum />}
+      mainPane={<LoremIpsum />}
+      iconOpen={IconCaretRight}
+      iconClosed={IconCaretLeft}
+    />
+  ));

--- a/packages/layouts/src/components/SidePanel.story.tsx
+++ b/packages/layouts/src/components/SidePanel.story.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import SidePanel from './SidePanel';
+import IconArrowLeft from '@airbnb/lunar-icons/lib/interface/IconArrowLeft';
+import IconArrowRight from '@airbnb/lunar-icons/lib/interface/IconArrowRight';
 import IconCaretRight from '@airbnb/lunar-icons/lib/interface/IconCaretRight';
 import IconCaretLeft from '@airbnb/lunar-icons/lib/interface/IconCaretLeft';
+import Spacing from '@airbnb/lunar/src/components/Spacing';
 
 storiesOf('Layouts/SidePanel', module)
   .addParameters({
@@ -46,5 +49,16 @@ storiesOf('Layouts/SidePanel', module)
       mainPane={<LoremIpsum />}
       iconOpen={IconCaretRight}
       iconClosed={IconCaretLeft}
+    />
+  ))
+  .add('A collapsible side panel with a customized button.', () => (
+    <SidePanel
+      compact={false}
+      iconSize="1.3rem"
+      iconColor="#008489"
+      sidePane={<LoremIpsum />}
+      mainPane={<LoremIpsum />}
+      iconOpen={IconArrowLeft}
+      iconClosed={IconArrowRight}
     />
   ));

--- a/packages/layouts/src/components/SidePanel.story.tsx
+++ b/packages/layouts/src/components/SidePanel.story.tsx
@@ -58,7 +58,7 @@ storiesOf('Layouts/SidePanel', module)
       iconColor="#008489"
       sidePane={<LoremIpsum />}
       mainPane={<LoremIpsum />}
-      iconOpen={IconArrowLeft}
-      iconClosed={IconArrowRight}
+      iconOpen={<IconArrowLeft />}
+      iconClosed={<IconArrowRight />}
     />
   ));

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import withStyles, { css, WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
+import PropTypes from 'prop-types';
+import { mutuallyExclusiveProps } from 'airbnb-prop-types';
 import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
@@ -11,10 +13,10 @@ export type SplitPaneProps = {
   mainPane: React.ReactNode;
   collapsible?: boolean;
   compact?: boolean;
-  minWidth?: string | number;
-  maxWidth?: string | number;
-  fixedWidth?: string | number;
-  percentWidth?: number;
+  minWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'fixedWidth');
+  maxWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'fixedWidth');
+  fixedWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'percentWidth', 'minWidth', 'maxWidth');
+  percentWidth?: mutuallyExclusiveProps(PropTypes.number, 'fixedWidth');;
   iconColor?: string;
   iconClosed?: iconComponent;
   iconOpen?: iconComponent;

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -7,7 +7,6 @@ import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
 
 import iconComponent from '@airbnb/lunar/lib/prop-types/iconComponent';
-import { WithIconWrapperProps } from '../../../../../packages/icons/src/withIcon';
 
 export type SplitPaneProps = {
   sidePane: React.ReactNode;
@@ -19,8 +18,9 @@ export type SplitPaneProps = {
   fixedWidth?: string | number;
   percentWidth?: number;
   iconColor?: string;
-  iconClosed?: React.ComponentClass<WithIconWrapperProps>;
-  iconOpen?: React.ComponentClass<WithIconWrapperProps>;
+  // @ts-ignore
+  iconClosed?: any;
+  iconOpen?: any;
   iconSize?: string;
   buttonTop?: number;
   background?: string;
@@ -121,8 +121,6 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
         rightSide && collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
     };
 
-    const Icon: React.ComponentClass<WithIconWrapperProps> = collapsed ? iconClosed! : iconOpen!;
-
     const collapseButtonStyle = {
       top: buttonTop,
       background: buttonBackgroundColor,
@@ -150,7 +148,9 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
         onClick={this.handleToggleSidePane}
       >
         <Spacing vertical={1} horizontal={compact ? 0 : 1}>
-          <Icon color={iconColor} size={iconSize} />
+          {collapsed
+            ? React.cloneElement(iconClosed, { size: iconSize, color: iconColor })
+            : React.cloneElement(iconOpen, { size: iconSize, color: iconColor })}
         </Spacing>
       </button>
     );

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import withStyles, { css, WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
+import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
+import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
+import Spacing from '@airbnb/lunar/lib/components/Spacing';
+
+export type SplitPaneProps = {
+  sidePane: React.ReactNode;
+  mainPane: React.ReactNode;
+  collapsible?: boolean;
+  minWidth?: string | number;
+  maxWidth?: string | number;
+  fixedWidth?: string | number;
+  percentWidth?: number;
+  iconOpen?: any;
+  iconClosed?: any;
+  buttonTop?: number;
+  background?: string;
+  rightSide?: boolean;
+};
+
+export type SplitPaneState = {
+  collapsed: boolean;
+};
+
+/** A symmetrical two-column layout with optional top and side navigation. */
+class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitPaneState> {
+  public static defaultProps = {
+    background: 'white',
+    buttonTop: 16,
+    collapsible: true,
+    iconOpen: IconChevronLeft,
+    iconClosed: IconChevronRight,
+    maxWidth: Infinity,
+    minWidth: 0,
+    rightSide: false,
+  };
+
+  constructor(props: SplitPaneProps & WithStylesProps) {
+    super(props);
+
+    this.state = {
+      collapsed: false,
+    };
+  }
+
+  private toggleSidePane = () => {
+    this.setState(({ collapsed }) => ({
+      collapsed: !collapsed,
+    }));
+  };
+
+  public render() {
+    const {
+      background,
+      buttonTop,
+      collapsible,
+      iconOpen,
+      iconClosed,
+      sidePane,
+      mainPane,
+      styles,
+      theme,
+      percentWidth,
+      minWidth,
+      maxWidth,
+      fixedWidth,
+      rightSide,
+    } = this.props;
+    const { collapsed } = this.state;
+
+    const defaultWidth = percentWidth ? `${percentWidth}%` : `${40 * theme!.unit}px`;
+
+    const buttonBackgroundColor = collapsed ? theme!.color.accent.bg : background;
+
+    const sidePanelStyle = {
+      width: collapsed ? 0 : fixedWidth || defaultWidth,
+      maxWidth,
+      minWidth: collapsed ? 0 : minWidth,
+      flex: fixedWidth
+        ? `0 0 ${collapsed ? 0 : fixedWidth}px`
+        : `0 0 ${collapsed ? 0 : defaultWidth}`,
+      padding: collapsed ? 0 : 3 * theme!.unit,
+      borderRightColor:
+        !rightSide && collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
+      borderLeftColor:
+        rightSide && collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
+    };
+
+    const Icon = collapsed ? iconClosed : iconOpen;
+
+    const collapseButtonStyle = {
+      top: buttonTop,
+      background: buttonBackgroundColor,
+      borderRightColor:
+        !rightSide && !collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
+      borderLeftColor:
+        rightSide && !collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
+    };
+
+    const mainPanelColorStyle = {
+      background: background || theme!.color.accent.bg,
+    };
+
+    const collapseButton = (
+      <button
+        type="button"
+        {...css(
+          collapseButtonStyle,
+          styles.collapseButton,
+          collapsed && !rightSide && styles.collapseButtonHiddenLeft,
+          collapsed && rightSide && styles.collapseButtonHiddenRight,
+          !collapsed && !rightSide && styles.collapseButtonVisibleLeft,
+          !collapsed && rightSide && styles.collapseButtonVisibleRight,
+        )}
+        onClick={this.toggleSidePane}
+      >
+        <Spacing vertical={1}>
+          <Icon color={theme!.color.core.neutral[5]} size="1.1rem" />
+        </Spacing>
+      </button>
+    );
+
+    return (
+      <div {...css(styles.splitPane)}>
+        {rightSide && <div {...css(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
+        <div
+          {...css(
+            styles.sidePanel,
+            rightSide && styles.sidePanelRight,
+            !rightSide && styles.sidePanelLeft,
+            sidePanelStyle,
+          )}
+        >
+          {collapsible && collapseButton}
+          <div {...css(styles.sidePanelInner)}>{!collapsed && sidePane}</div>
+        </div>
+        {!rightSide && <div {...css(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
+      </div>
+    );
+  }
+}
+
+export default withStyles(
+  ({ unit, color }) => ({
+    splitPane: {
+      display: 'inline-flex',
+      minHeight: `calc(100vh - ${8 * unit}px)`,
+      width: '100%',
+    },
+    mainPanel: {
+      padding: unit * 4,
+      overflow: 'auto',
+      flexGrow: 1,
+    },
+    sidePanel: {
+      wordBreak: 'break-word',
+      background: color.accent.bg,
+      height: `calc(100vh - ${8 * unit}px)`,
+      position: 'sticky',
+      top: 8 * unit,
+    },
+
+    sidePanelLeft: {
+      borderRight: '1px solid',
+    },
+
+    sidePanelRight: {
+      borderLeft: '1px solid',
+    },
+
+    sidePanelInner: {
+      height: '100%',
+      overflow: 'auto',
+      zIndex: 100,
+    },
+
+    collapseButton: {
+      cursor: 'pointer',
+      position: 'absolute',
+      border: `1px solid ${color.core.neutral[1]}`,
+      padding: 0,
+      borderRadius: 0,
+    },
+
+    collapseButtonVisibleRight: {
+      left: -1,
+      borderBottomRightRadius: 4,
+      borderTopRightRadius: 4,
+      borderLeft: '1px solid',
+    },
+    collapseButtonHiddenRight: {
+      right: 0,
+      borderBottomLeftRadius: 4,
+      borderTopLeftRadius: 4,
+      borderRight: '1px solid',
+    },
+
+    collapseButtonVisibleLeft: {
+      right: -1,
+      borderBottomLeftRadius: 4,
+      borderTopLeftRadius: 4,
+      borderRight: '1px solid',
+    },
+    collapseButtonHiddenLeft: {
+      left: 0,
+      borderBottomRightRadius: 4,
+      borderTopRightRadius: 4,
+      borderLeft: '1px solid',
+    },
+  }),
+  {
+    passThemeProp: true,
+  },
+)(SidePanel);

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -13,10 +13,10 @@ export type SplitPaneProps = {
   mainPane: React.ReactNode;
   collapsible?: boolean;
   compact?: boolean;
-  minWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'fixedWidth');
-  maxWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'fixedWidth');
-  fixedWidth?: mutuallyExclusiveProps(PropTypes.string | PropTypes.number, 'percentWidth', 'minWidth', 'maxWidth');
-  percentWidth?: mutuallyExclusiveProps(PropTypes.number, 'fixedWidth');;
+  minWidth?: string | number;
+  maxWidth?: string | number;
+  fixedWidth?: string | number;
+  percentWidth?: number;
   iconColor?: string;
   iconClosed?: iconComponent;
   iconOpen?: iconComponent;
@@ -32,6 +32,24 @@ export type SplitPaneState = {
 
 /** A symmetrical two-column layout with optional top and side navigation. */
 class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitPaneState> {
+  static propTypes = {
+    minWidth: mutuallyExclusiveProps(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      'fixedWidth',
+    ),
+    maxWidth: mutuallyExclusiveProps(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      'fixedWidth',
+    ),
+    fixedWidth: mutuallyExclusiveProps(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      'maxWidth',
+      'minWidth',
+      'percentWidth',
+    ),
+    percentWidth: mutuallyExclusiveProps(PropTypes.number, 'fixedWidth'),
+  };
+
   public static defaultProps = {
     background: 'white',
     buttonTop: 16,

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -58,8 +58,8 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     buttonTop: 16,
     collapsible: true,
     compact: true,
-    iconColor: '#484848', // core.neutral[5]
     iconClosed: IconChevronRight,
+    iconColor: '#484848', // core.neutral[5]
     iconOpen: IconChevronLeft,
     iconSize: '1.1rem',
     maxWidth: Infinity,

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -6,7 +6,7 @@ import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
 
-import iconComponent from '../../prop-types/iconComponent';
+import iconComponent from '../../../../core/src/prop-types/iconComponent';
 
 export type SplitPaneProps = {
   sidePane: React.ReactNode;
@@ -18,8 +18,8 @@ export type SplitPaneProps = {
   fixedWidth?: string | number;
   percentWidth?: number;
   iconColor?: string;
-  iconClosed?: iconComponent;
-  iconOpen?: iconComponent;
+  iconClosed?: React.ReactNode;
+  iconOpen?: React.ReactNode;
   iconSize?: string;
   buttonTop?: number;
   background?: string;
@@ -33,6 +33,8 @@ export type SplitPaneState = {
 /** A symmetrical two-column layout with optional top and side navigation. */
 class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitPaneState> {
   static propTypes = {
+    iconOpen: iconComponent,
+    iconClosed: iconComponent,
     minWidth: mutuallyExclusiveProps(
       PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       'fixedWidth',

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -7,6 +7,7 @@ import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
 
 import iconComponent from '../../../../core/src/prop-types/iconComponent';
+import { WithIconWrapperProps } from '../../../../../packages/icons/src/withIcon';
 
 export type SplitPaneProps = {
   sidePane: React.ReactNode;
@@ -17,9 +18,9 @@ export type SplitPaneProps = {
   maxWidth?: string | number;
   fixedWidth?: string | number;
   percentWidth?: number;
+  iconClosed?: React.ComponentClass<WithIconWrapperProps>;
   iconColor?: string;
-  iconClosed?: React.ReactNode;
-  iconOpen?: React.ReactNode;
+  iconOpen?: React.ComponentClass<WithIconWrapperProps>;
   iconSize?: string;
   buttonTop?: number;
   background?: string;
@@ -33,21 +34,21 @@ export type SplitPaneState = {
 /** A symmetrical two-column layout with optional top and side navigation. */
 class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitPaneState> {
   static propTypes = {
-    iconOpen: iconComponent,
-    iconClosed: iconComponent,
-    minWidth: mutuallyExclusiveProps(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      'fixedWidth',
-    ),
-    maxWidth: mutuallyExclusiveProps(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      'fixedWidth',
-    ),
     fixedWidth: mutuallyExclusiveProps(
       PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       'maxWidth',
       'minWidth',
       'percentWidth',
+    ),
+    iconClosed: iconComponent,
+    iconOpen: iconComponent,
+    maxWidth: mutuallyExclusiveProps(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      'fixedWidth',
+    ),
+    minWidth: mutuallyExclusiveProps(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      'fixedWidth',
     ),
     percentWidth: mutuallyExclusiveProps(PropTypes.number, 'fixedWidth'),
   };
@@ -57,8 +58,8 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     buttonTop: 16,
     collapsible: true,
     compact: true,
-    iconColor: '#484848', //core.neutral[5]
     iconClosed: IconChevronRight,
+    iconColor: '#484848', // core.neutral[5]
     iconOpen: IconChevronLeft,
     iconSize: '1.1rem',
     maxWidth: Infinity,
@@ -74,7 +75,7 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     };
   }
 
-  private toggleSidePane = () => {
+  private handleToggleSidePane = () => {
     this.setState(({ collapsed }) => ({
       collapsed: !collapsed,
     }));
@@ -120,7 +121,7 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
         rightSide && collapsed ? buttonBackgroundColor : theme!.color.core.neutral[1],
     };
 
-    const Icon = collapsed ? iconClosed : iconOpen;
+    const Icon: React.ComponentClass<WithIconWrapperProps> = collapsed ? iconClosed! : iconOpen!;
 
     const collapseButtonStyle = {
       top: buttonTop,
@@ -146,7 +147,7 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
           !collapsed && !rightSide && styles.collapseButtonVisibleLeft,
           !collapsed && rightSide && styles.collapseButtonVisibleRight,
         )}
-        onClick={this.toggleSidePane}
+        onClick={this.handleToggleSidePane}
       >
         <Spacing vertical={1} horizontal={compact ? 0 : 1}>
           <Icon color={iconColor} size={iconSize} />

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -4,16 +4,21 @@ import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
 
+import iconComponent from '../../prop-types/iconComponent';
+
 export type SplitPaneProps = {
   sidePane: React.ReactNode;
   mainPane: React.ReactNode;
   collapsible?: boolean;
+  compact?: boolean;
   minWidth?: string | number;
   maxWidth?: string | number;
   fixedWidth?: string | number;
   percentWidth?: number;
-  iconOpen?: any;
-  iconClosed?: any;
+  iconColor?: string;
+  iconClosed?: iconComponent;
+  iconOpen?: iconComponent;
+  iconSize?: string;
   buttonTop?: number;
   background?: string;
   rightSide?: boolean;
@@ -29,8 +34,11 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     background: 'white',
     buttonTop: 16,
     collapsible: true,
-    iconOpen: IconChevronLeft,
+    compact: true,
+    iconColor: '#484848', //core.neutral[5]
     iconClosed: IconChevronRight,
+    iconOpen: IconChevronLeft,
+    iconSize: '1.1rem',
     maxWidth: Infinity,
     minWidth: 0,
     rightSide: false,
@@ -55,8 +63,11 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
       background,
       buttonTop,
       collapsible,
-      iconOpen,
+      compact,
+      iconColor,
       iconClosed,
+      iconOpen,
+      iconSize,
       sidePane,
       mainPane,
       styles,
@@ -115,8 +126,8 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
         )}
         onClick={this.toggleSidePane}
       >
-        <Spacing vertical={1}>
-          <Icon color={theme!.color.core.neutral[5]} size="1.1rem" />
+        <Spacing vertical={1} horizontal={compact ? 0 : 1}>
+          <Icon color={iconColor} size={iconSize} />
         </Spacing>
       </button>
     );

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import withStyles, { css, WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
+import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
 import PropTypes from 'prop-types';
 import { mutuallyExclusiveProps } from 'airbnb-prop-types';
 import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
@@ -87,6 +87,7 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
       buttonTop,
       collapsible,
       compact,
+      cx,
       iconColor,
       iconClosed,
       iconOpen,
@@ -137,7 +138,7 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     const collapseButton = (
       <button
         type="button"
-        {...css(
+        className={cx(
           collapseButtonStyle,
           styles.collapseButton,
           collapsed && !rightSide && styles.collapseButtonHiddenLeft,
@@ -156,10 +157,10 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     );
 
     return (
-      <div {...css(styles.splitPane)}>
-        {rightSide && <div {...css(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
+      <div className={cx(styles.splitPane)}>
+        {rightSide && <div className={cx(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
         <div
-          {...css(
+          className={cx(
             styles.sidePanel,
             rightSide && styles.sidePanelRight,
             !rightSide && styles.sidePanelLeft,
@@ -167,9 +168,9 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
           )}
         >
           {collapsible && collapseButton}
-          <div {...css(styles.sidePanelInner)}>{!collapsed && sidePane}</div>
+          <div className={cx(styles.sidePanelInner)}>{!collapsed && sidePane}</div>
         </div>
-        {!rightSide && <div {...css(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
+        {!rightSide && <div className={cx(styles.mainPanel, mainPanelColorStyle)}>{mainPane}</div>}
       </div>
     );
   }

--- a/packages/layouts/src/components/SidePanel/index.tsx
+++ b/packages/layouts/src/components/SidePanel/index.tsx
@@ -6,7 +6,7 @@ import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import Spacing from '@airbnb/lunar/lib/components/Spacing';
 
-import iconComponent from '../../../../core/src/prop-types/iconComponent';
+import iconComponent from '@airbnb/lunar/lib/prop-types/iconComponent';
 import { WithIconWrapperProps } from '../../../../../packages/icons/src/withIcon';
 
 export type SplitPaneProps = {
@@ -18,8 +18,8 @@ export type SplitPaneProps = {
   maxWidth?: string | number;
   fixedWidth?: string | number;
   percentWidth?: number;
-  iconClosed?: React.ComponentClass<WithIconWrapperProps>;
   iconColor?: string;
+  iconClosed?: React.ComponentClass<WithIconWrapperProps>;
   iconOpen?: React.ComponentClass<WithIconWrapperProps>;
   iconSize?: string;
   buttonTop?: number;
@@ -31,7 +31,7 @@ export type SplitPaneState = {
   collapsed: boolean;
 };
 
-/** A symmetrical two-column layout with optional top and side navigation. */
+/** A two-column layout with a collapsible side bar that can scale with screen width. */
 class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitPaneState> {
   static propTypes = {
     fixedWidth: mutuallyExclusiveProps(
@@ -58,8 +58,8 @@ class SidePanel extends React.Component<SplitPaneProps & WithStylesProps, SplitP
     buttonTop: 16,
     collapsible: true,
     compact: true,
-    iconClosed: IconChevronRight,
     iconColor: '#484848', // core.neutral[5]
+    iconClosed: IconChevronRight,
     iconOpen: IconChevronLeft,
     iconSize: '1.1rem',
     maxWidth: Infinity,

--- a/packages/layouts/src/components/SplitLayout.story.tsx
+++ b/packages/layouts/src/components/SplitLayout.story.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import LoremIpsum from ':storybook/components/LoremIpsum';
 import Aside from './Aside';
 import SplitLayout from './SplitLayout';
+import LoremIpsum from ':storybook/components/LoremIpsum';
+import { storiesOf } from '@storybook/react';
 
 storiesOf('Layouts/SplitLayout', module)
   .addParameters({

--- a/packages/layouts/src/components/SplitLayout/index.tsx
+++ b/packages/layouts/src/components/SplitLayout/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { elementType } from 'airbnb-prop-types';
-import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
 import Aside from '../Aside';
 import Layout, { Props as LayoutProps, AsideProps } from '../Layout';
+import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
+import { elementType } from 'airbnb-prop-types';
 
 export type Props = Required<AsideProps> & Pick<LayoutProps, 'fluid'>;
 

--- a/packages/layouts/test/components/SidePanel.test.tsx
+++ b/packages/layouts/test/components/SidePanel.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SidePanel from '../../src/components/SidePanel';
+import IconChevronLeft from '@airbnb/lunar-icons/lib/interface/IconChevronLeft';
+
+describe('<SidePanel />', () => {
+  it('renders the collapsible button icon', () => {
+    const wrapper = shallow(<SidePanel collapsible sidePane={<div />} mainPane={<div />} />).dive();
+    const icon = <IconChevronLeft color="#484848" size="1.1rem" inline={false} />;
+
+    expect(wrapper.contains(icon)).toBe(true);
+  });
+});


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This adds a new SidePanel component to Layouts, most of the code is pulled directly from Bighead, but we would like to reuse it across DX projects.

There's some overlap in functionality between this and the TwoColumnLayout. The two main additions are:
- Collapsibility
- Percent width constrained by min/max values

There are props to modify the size, color, top offset and compactness of the collapse button.

It would be more flexible to let developers pass in an arbitrary node as icon, but we're designing for the most common use cases, and this allows us to use the more stringent `iconComponent` type check.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
![Screen Shot 2019-06-11 at 11 05 00 AM](https://user-images.githubusercontent.com/8676510/59295532-caccfe00-8c38-11e9-9205-2792a20745a9.png)

![Screen Shot 2019-06-11 at 12 01 23 PM](https://user-images.githubusercontent.com/8676510/59299053-a6751f80-8c40-11e9-8498-ae173a25d9e2.png)

Collapsed:
![Screen Shot 2019-06-11 at 12 05 24 PM](https://user-images.githubusercontent.com/8676510/59299315-387d2800-8c41-11e9-8bf3-1b51ce558b0c.png)



<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
