### PR TITLE
fix(Pagination): Fix page count if label is empty

### DIFF
--- a/packages/core/src/components/Pagination.story.tsx
+++ b/packages/core/src/components/Pagination.story.tsx
@@ -40,8 +40,10 @@ storiesOf('Core/Pagination', module)
     <Pagination
       hasPrev
       hasNext
-      pageLabel=""
+      showBookends
       page={2}
+      pageLabel=""
+      pageCount={3}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}
     />

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -153,7 +153,7 @@ export class Pagination extends React.Component<Props & WithStylesProps> {
     let paginationText =
       showBookends && pageCount ? (
         <T
-          phrase={'%{pageNumber} of %{pageNumber}'}
+          phrase={'%{pageNumber} of %{pageCount}'}
           pageCount={pageCount}
           pageNumber={page}
           context="Showing the current page number and total page count"


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

I goofed. When `pageLabel=""` was passed in with `showBookends`, the text would display the number of pages as the page count. (example: 1 of 1, 2 of 2, 3 of 3...) This fixes the issue.

## Testing

- [x] Storybook

## Screenshots
Storybook code:
```
<Pagination
  hasPrev
  hasNext
  showBookends
  pageLabel=""
  page={2}
  pageCount={3}
  onNext={action('onNext')}
  onPrevious={action('onPrevious')}
/>
```


Before:
<img width="502" alt="Screen Shot 2019-06-11 at 1 19 59 PM" src="https://user-images.githubusercontent.com/6675771/59303735-ae868c80-8c4b-11e9-85e0-398e387e4054.png">

After:
<img width="501" alt="Screen Shot 2019-06-11 at 1 19 14 PM" src="https://user-images.githubusercontent.com/6675771/59303720-a6c6e800-8c4b-11e9-9c87-8a36337778e2.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
