### PR TITLE
break(Autocomplete,Multicomplete): Rename onLoadOptions to onLoadItems. Add disableCache prop.

### DIFF
--- a/codemods/helpers.ts
+++ b/codemods/helpers.ts
@@ -1,0 +1,64 @@
+import { API, FileInfo, JSCodeshift, Options } from 'jscodeshift';
+import { Collection } from 'jscodeshift/src/Collection';
+
+export class Codemod {
+  api: API;
+
+  cs: JSCodeshift;
+
+  source: Collection<any>;
+
+  constructor(fileInfo: FileInfo, api: API) {
+    this.cs = api.jscodeshift;
+    this.source = this.cs(fileInfo.source);
+  }
+
+  createNode<T>(cb: (cs: JSCodeshift) => T): T {
+    return cb(this.cs);
+  }
+
+  findImports() {
+    return this.source.find(this.cs.ImportDeclaration);
+  }
+
+  getComponentNameFromDefaultImport(importPath: string | RegExp): string | null {
+    let name = '';
+
+    this.findImports()
+      .filter(({ node }) => !!String(node.source.value).match(importPath))
+      .forEach(({ node }) => {
+        node.specifiers.forEach(spec => {
+          if (spec.type === 'ImportDefaultSpecifier') {
+            name = spec.local.name;
+          }
+        });
+      });
+
+    return name || null;
+  }
+
+  getComponentNameFromNamedImports(importPath: string | RegExp, namesToFind: string[]): string[] {
+    const names = [];
+
+    this.findImports()
+      .filter(({ node }) => !!String(node.source.value).match(importPath))
+      .forEach(({ node }) => {
+        node.specifiers.forEach(spec => {
+          if (spec.type === 'ImportSpecifier' && namesToFind.includes(spec.imported.name)) {
+            names.push(spec.local.name);
+          }
+        });
+      });
+
+    return names;
+  }
+
+  toSource(options: Options) {
+    return this.source.toSource({
+      tabWidth: 2,
+      quote: 'single',
+      trailingComma: true,
+      ...options,
+    });
+  }
+}

--- a/codemods/v2/autocompleteProps.ts
+++ b/codemods/v2/autocompleteProps.ts
@@ -1,0 +1,46 @@
+import { FileInfo, API, Options } from 'jscodeshift';
+import { Codemod } from '../helpers';
+
+function renameOnLoadProp(mod: Codemod, name: string) {
+  mod.source.find(mod.cs.JSXOpeningElement, { name: { name } }).forEach(({ node }) => {
+    node.attributes.forEach(attr => {
+      if (
+        attr.type === 'JSXAttribute' &&
+        attr.name.type === 'JSXIdentifier' &&
+        attr.name.name === 'onLoadOptions'
+      ) {
+        attr.name.name = 'onLoadItems';
+      }
+    });
+  });
+}
+
+module.exports = function autocompleteProps(
+  fileInfo: FileInfo,
+  api: API,
+  options: Options,
+): string | null | undefined | void {
+  const mod = new Codemod(fileInfo, api);
+
+  // Rename `onLoadOptions` to `onLoadItems`
+  [
+    '@airbnb/lunar/lib/components/Autocomplete',
+    '@airbnb/lunar/lib/components/Multicomplete',
+    '@airbnb/lunar-forms/lib/components/Form/Autocomplete',
+    '@airbnb/lunar-forms/lib/components/Form/Multicomplete',
+  ].forEach(importPath => {
+    const compName = mod.getComponentNameFromDefaultImport(importPath);
+
+    if (compName) {
+      renameOnLoadProp(mod, compName);
+    }
+  });
+
+  mod
+    .getComponentNameFromNamedImports('@airbnb/lunar-forms', ['Autocomplete', 'Multicomplete'])
+    .forEach(compName => {
+      renameOnLoadProp(mod, compName);
+    });
+
+  return mod.toSource(options);
+};

--- a/packages/core/src/components/Autocomplete.story.tsx
+++ b/packages/core/src/components/Autocomplete.story.tsx
@@ -21,7 +21,7 @@ storiesOf('Core/Autocomplete', module)
       name="autocomplete"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value =>
+      onLoadItems={value =>
         Promise.resolve(
           items.filter(item => item.name.toLowerCase().match(value.toLowerCase())),
         ) as any
@@ -35,7 +35,7 @@ storiesOf('Core/Autocomplete', module)
       name="autocomplete-reject"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value => Promise.reject(new Error('Failed to load.'))}
+      onLoadItems={value => Promise.reject(new Error('Failed to load.'))}
     />
   ))
   .add('With an error message in an invalid state.', () => (
@@ -45,7 +45,7 @@ storiesOf('Core/Autocomplete', module)
       label="Label"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value => Promise.resolve([])}
+      onLoadItems={value => Promise.resolve([])}
       errorMessage="This field is required."
       invalid
     />
@@ -57,7 +57,7 @@ storiesOf('Core/Autocomplete', module)
       label="Label"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value => Promise.resolve([])}
+      onLoadItems={value => Promise.resolve([])}
       labelDescription="This is a small label description."
       disabled
     />
@@ -69,7 +69,7 @@ storiesOf('Core/Autocomplete', module)
       label="Label"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value => Promise.resolve(items) as any}
+      onLoadItems={value => Promise.resolve(items) as any}
       labelDescription="Load some items on focus."
       loadItemsOnFocus
     />
@@ -81,7 +81,7 @@ storiesOf('Core/Autocomplete', module)
       name="autocomplete"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value =>
+      onLoadItems={value =>
         Promise.resolve(items.filter(item => item.name.toLowerCase().match(value.toLowerCase())))
       }
       isItemSelectable={(item, selected) => !selected}
@@ -95,7 +95,7 @@ storiesOf('Core/Autocomplete', module)
         label="Error"
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
-        onLoadOptions={value => Promise.reject(new Error('Failed to load.'))}
+        onLoadItems={value => Promise.reject(new Error('Failed to load.'))}
         renderError={error => <div>{error.message}</div>}
         loadItemsOnMount
         compact
@@ -107,7 +107,7 @@ storiesOf('Core/Autocomplete', module)
         label="Loading"
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
-        onLoadOptions={value => new Promise(() => {})}
+        onLoadItems={value => new Promise(() => {})}
         renderLoading={() => <div>Loading...</div>}
         loadItemsOnMount
         compact
@@ -119,7 +119,7 @@ storiesOf('Core/Autocomplete', module)
         label="No results"
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
-        onLoadOptions={value => Promise.resolve([])}
+        onLoadItems={value => Promise.resolve([])}
         renderNoResults={() => <div>Nothing to see here!</div>}
         loadItemsOnMount
         compact

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -50,7 +50,7 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     isItemSelectable?: (item: T, selected?: boolean) => boolean;
     /** Determine if an item is selected. Will compare values by default if not defined. */
     isItemSelected?: (item: T, value: string) => boolean;
-    /** Whether to invoke onLoadOptions with the current value when focused. */
+    /** Load and show items with the current value when focused. */
     loadItemsOnFocus?: boolean;
     /** Load and show items on mount. */
     loadItemsOnMount?: boolean;
@@ -61,7 +61,7 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     /** Callback fired when the value changes. */
     onChange: (value: string, event: React.SyntheticEvent<any>) => void;
     /** Callback fired to load items. Must return a promise with an array of items. */
-    onLoadOptions: (value: string) => Promise<ItemResponseType<T>>;
+    onLoadItems: (value: string) => Promise<ItemResponseType<T>>;
     /** Callback fired when the display of the menu is toggled. */
     onMenuVisibilityChange?: (open: boolean) => void;
     /**
@@ -511,7 +511,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   }>(
     /* istanbul ignore next */
     (input: string) =>
-      Promise.resolve(this.props.onLoadOptions(input)).then(response => ({
+      Promise.resolve(this.props.onLoadItems(input)).then(response => ({
         input,
         response,
       })),

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -41,6 +41,8 @@ export type Props<T extends Item> = Omit<BaseInputProps, 'id'> &
     clearOnSelect?: boolean;
     /** Delay in which to load items. */
     debounce?: number;
+    /** Disable caching of loaded item responses. */
+    disableCache?: boolean;
     /**
      * Value to insert into the input field when an item is selected.
      * Defaults to the item's `value` or `id` property.
@@ -102,6 +104,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
     autoFocus: false,
     clearOnSelect: false,
     debounce: 250,
+    disableCache: false,
     getItemValue,
     isItemSelectable() {
       return true;
@@ -447,7 +450,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
       loading: true,
     });
 
-    const { loadItemsOnFocus } = this.props;
+    const { disableCache, loadItemsOnFocus } = this.props;
 
     // Exit early if no value
     if (!value && !force && !loadItemsOnFocus) {
@@ -479,10 +482,12 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
           items = response.results || response.items || [];
         }
 
-        this.cache[input] = {
-          items,
-          time: Date.now(),
-        };
+        if (!disableCache) {
+          this.cache[input] = {
+            items,
+            time: Date.now(),
+          };
+        }
 
         const nextState = {
           items,

--- a/packages/core/src/components/HierarchyPicker/Search/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/index.tsx
@@ -180,7 +180,7 @@ export class Search extends React.Component<Props & WithStylesProps> {
           name="autocomplete-search"
           noResultsText={noResultsLabel}
           onChange={onSearch}
-          onLoadOptions={this.handleAsyncSearch}
+          onLoadItems={this.handleAsyncSearch}
           onSelectItem={this.handleItemPicked}
           optional
           placeholder={placeholder}

--- a/packages/core/src/components/Multicomplete.story.tsx
+++ b/packages/core/src/components/Multicomplete.story.tsx
@@ -15,7 +15,7 @@ storiesOf('Core/Multicomplete', module)
       name="autocomplete"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value =>
+      onLoadItems={value =>
         Promise.resolve(
           [
             { value: 'red', name: 'Red' },
@@ -35,7 +35,7 @@ storiesOf('Core/Multicomplete', module)
       name="autocomplete"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value =>
+      onLoadItems={value =>
         Promise.resolve(
           [
             { value: 'red', name: 'Red' },
@@ -56,7 +56,7 @@ storiesOf('Core/Multicomplete', module)
       name="autocomplete"
       onChange={action('onChange')}
       onSelectItem={action('onSelectItem')}
-      onLoadOptions={value =>
+      onLoadItems={value =>
         Promise.resolve(
           [
             { value: 'red', name: 'Red' },

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -504,6 +504,16 @@ describe('<Autocomplete />', () => {
         );
       }));
 
+    it('doesnt cache if `disableCache` is set', () => {
+      wrapper.setProps({
+        disableCache: true,
+      });
+
+      return instance.loadItems('foo').then(() => {
+        expect(instance.cache.foo).toBeUndefined();
+      });
+    });
+
     it('handles success', () =>
       instance.loadItems('foo').then(() => {
         expect(wrapper.state()).toEqual(

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -17,7 +17,7 @@ describe('<Autocomplete />', () => {
     accessibilityLabel: 'Label',
     maxHeight: 400,
     onChange() {},
-    onLoadOptions: () => Promise.resolve([]),
+    onLoadItems: () => Promise.resolve([]),
   };
 
   let wrapper: Enzyme.ShallowWrapper<Props<any>, State<any>, Autocomplete<any>>;

--- a/packages/core/test/components/Multicomplete.test.tsx
+++ b/packages/core/test/components/Multicomplete.test.tsx
@@ -12,7 +12,7 @@ describe('<Multicomplete />', () => {
     accessibilityLabel: 'Label',
     maxHeight: 400,
     onChange() {},
-    onLoadOptions: () => Promise.resolve([]),
+    onLoadItems: () => Promise.resolve([]),
   };
 
   const event = {

--- a/packages/forms/src/components/Autocomplete.story.tsx
+++ b/packages/forms/src/components/Autocomplete.story.tsx
@@ -27,7 +27,7 @@ storiesOf('Forms/Autocomplete', module)
         name="field"
         label="Label"
         accessibilityLabel="Autocomplete"
-        onLoadOptions={value =>
+        onLoadItems={value =>
           Promise.resolve(
             items.filter(item => item.name.toLowerCase().match(value.toLowerCase())),
           ) as any

--- a/packages/forms/src/components/Form.story.tsx
+++ b/packages/forms/src/components/Form.story.tsx
@@ -192,7 +192,7 @@ storiesOf('Forms/Form', module)
         name="autocomplete"
         defaultValue="black"
         onChange={action('onChange')}
-        onLoadOptions={value =>
+        onLoadItems={value =>
           Promise.resolve(items.filter(item => item.name.toLowerCase().match(value))) as any
         }
         validator={isRequired}
@@ -206,7 +206,7 @@ storiesOf('Forms/Form', module)
         name="multicomplete"
         // defaultValue={['blue', 'red']}
         onChange={action('onChange')}
-        onLoadOptions={value =>
+        onLoadItems={value =>
           Promise.resolve(items.filter(item => item.name.toLowerCase().match(value))) as any
         }
         renderItem={(item: any, highlighted, selected) => <Text bold={selected}>{item.name}</Text>}

--- a/packages/forms/src/components/Multicomplete.story.tsx
+++ b/packages/forms/src/components/Multicomplete.story.tsx
@@ -27,7 +27,7 @@ storiesOf('Forms/Multicomplete', module)
         name="field"
         label="Label"
         accessibilityLabel="Multicomplete"
-        onLoadOptions={value =>
+        onLoadItems={value =>
           Promise.resolve(
             items.filter(item => item.name.toLowerCase().match(value.toLowerCase())),
           ) as any

--- a/packages/forms/test/components/Form/Autocomplete.test.tsx
+++ b/packages/forms/test/components/Form/Autocomplete.test.tsx
@@ -20,7 +20,7 @@ describe('<Autocomplete />', () => {
           accessibilityLabel="Label"
           name="foo"
           defaultValue="bar"
-          onLoadOptions={() => Promise.resolve([])}
+          onLoadItems={() => Promise.resolve([])}
           validator={() => {}}
         />,
       ),

--- a/packages/forms/test/components/Form/Multicomplete.test.tsx
+++ b/packages/forms/test/components/Form/Multicomplete.test.tsx
@@ -20,7 +20,7 @@ describe('<Multicomplete />', () => {
           accessibilityLabel="Label"
           name="foo"
           defaultValue="bar"
-          onLoadOptions={() => Promise.resolve([])}
+          onLoadItems={() => Promise.resolve([])}
           validator={() => {}}
         />,
       ),


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- Renames the `onLoadOptions` to `onLoadItems` (codemod available).
- Also adds a new `disableCache` prop to solve https://github.com/airbnb/lunar/issues/26.

### Migration Guide

Run the following codemod to migrate the breaking changes.

```
jscodeshift --extensions=js,jsx,ts,tsx --parser=tsx --transform=./path/to/lunar/codemods/v2/autocompleteProps.ts ./src
```

## Motivation and Context

We refer to autocomplete data as "items" not "options", so this was the weird outlier, most likely for legacy reasons with our old UI.

## Testing

Yes.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
