### PR TITLE
break(Tabs): Rework active state. Add small, beforeIcon, and afterIcon props.

### DIFF
--- a/packages/core/src/components/Tabs.story.tsx
+++ b/packages/core/src/components/Tabs.story.tsx
@@ -12,56 +12,47 @@ storiesOf('Core/Tabs', module)
   })
   .add('Standard tabs with no body content.', () => (
     <Tabs>
-      <Tab key="a" label={<Text bold>Bruce W.</Text>} />
-      <Tab key="b" label={<Text bold>Clark K.</Text>} />
-      <Tab key="c" label={<Text bold>Peter P.</Text>} />
+      <Tab key="a" label="Bruce W." />
+      <Tab key="b" label="Clark K." />
+      <Tab key="c" label="Peter P." />
     </Tabs>
   ))
-  .add('Standard tabs stretched with no body content.', () => (
+  .add('Small tabs stretched.', () => (
     <Tabs stretched>
-      <Tab key="a" label={<Text bold>Bruce W.</Text>} />
-      <Tab key="b" label={<Text bold>Clark K.</Text>} />
-      <Tab key="c" label={<Text bold>Peter P.</Text>} />
+      <Tab key="a" label="Bruce W." small />
+      <Tab key="b" label="Clark K." small />
+      <Tab key="c" label="Peter P." small />
     </Tabs>
   ))
   .add('Borderless tabs with icons.', () => (
     <Tabs borderless>
-      <Tab
-        key="a"
-        label={<Text bold>Bruce W.</Text>}
-        beforeIcon={<IconAdd decorative size="1.25em" />}
-      />
-      <Tab key="b" label={<Text bold>Clark K.</Text>} />
-      <Tab
-        key="c"
-        disabled
-        label={<Text bold>Peter P.</Text>}
-        afterIcon={<IconRemove decorative size="1.25em" />}
-      />
+      <Tab key="a" label="Bruce W." beforeIcon={<IconAdd decorative size="1.25em" />} />
+      <Tab key="b" label="Clark K." />
+      <Tab key="c" disabled label="Peter P." afterIcon={<IconRemove decorative size="1.25em" />} />
     </Tabs>
   ))
   .add('Render anchor links when passing .', () => (
     <Tabs>
-      <Tab key="a" href="#mj" label={<Text bold>Bruce W.</Text>} />
-      <Tab key="b" href="#cp" label={<Text bold>Clark K.</Text>} />
-      <Tab key="c" href="#th" label={<Text bold>Peter P.</Text>} />
+      <Tab key="a" href="#mj" label="Bruce W." />
+      <Tab key="b" href="#cp" label="Clark K." />
+      <Tab key="c" href="#th" label="Peter P." />
     </Tabs>
   ))
   .add('With body content and a default selected index.', () => (
     <Tabs defaultKey="c">
-      <Tab key="a" label={<Text bold>Bruce W.</Text>}>
+      <Tab key="a" label="Bruce W.">
         <Text>
           <LoremIpsum />
         </Text>
       </Tab>
 
-      <Tab key="b" label={<Text bold>Clark K.</Text>} disabled>
+      <Tab key="b" label="Clark K." disabled>
         <Text>
           <LoremIpsum />
         </Text>
       </Tab>
 
-      <Tab key="c" label={<Text bold>Peter P.</Text>}>
+      <Tab key="c" label="Peter P.">
         <Text>
           <LoremIpsum />
         </Text>
@@ -74,26 +65,26 @@ storiesOf('Core/Tabs', module)
         <Tab
           key="a"
           label={
-            <Text bold>
+            <>
               Bruce
               <br />
               Wayne
-            </Text>
+            </>
           }
         />
-        <Tab key="b" label={<Text bold>Clark K.</Text>} />
+        <Tab key="b" label="Clark K." />
         <Tab
           key="c"
           label={
-            <Text bold>
+            <>
               Peter
               <br />
               Parker
-            </Text>
+            </>
           }
         />
-        <Tab key="d" label={<Text bold>Tony S.</Text>} />
-        <Tab key="e" label={<Text bold>Bruce B.</Text>} />
+        <Tab key="d" label="Tony S." />
+        <Tab key="e" label="Bruce B." />
       </Tabs>
     </div>
   ));

--- a/packages/core/src/components/Tabs.story.tsx
+++ b/packages/core/src/components/Tabs.story.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
+import IconAdd from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
+import IconRemove from '@airbnb/lunar-icons/lib/interface/IconRemoveAlt';
 import Text from './Text';
 import Tabs, { Tab } from './Tabs';
 
@@ -22,11 +24,20 @@ storiesOf('Core/Tabs', module)
       <Tab key="c" label={<Text bold>Peter P.</Text>} />
     </Tabs>
   ))
-  .add('Borderless tabs with no body content.', () => (
+  .add('Borderless tabs with icons.', () => (
     <Tabs borderless>
-      <Tab key="a" label={<Text bold>Bruce W.</Text>} />
+      <Tab
+        key="a"
+        label={<Text bold>Bruce W.</Text>}
+        beforeIcon={<IconAdd decorative size="1.25em" />}
+      />
       <Tab key="b" label={<Text bold>Clark K.</Text>} />
-      <Tab key="c" disabled label={<Text bold>Peter P.</Text>} />
+      <Tab
+        key="c"
+        disabled
+        label={<Text bold>Peter P.</Text>}
+        afterIcon={<IconRemove decorative size="1.25em" />}
+      />
     </Tabs>
   ))
   .add('Render anchor links when passing .', () => (

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -23,6 +23,8 @@ export type Props = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'disabl
   onSelected?: () => void;
   /** Whether the tab is selected or not. */
   selected?: boolean;
+  /** Decrease font size to small. */
+  small?: boolean;
   /** Stretch tabs to fill the full width. */
   stretched?: boolean;
 };
@@ -33,6 +35,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
     borderless: false,
     children: null,
     selected: false,
+    small: false,
     stretched: false,
   };
 
@@ -59,6 +62,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
       keyName,
       label,
       selected,
+      small,
       stretched,
       styles,
     } = this.props;
@@ -74,19 +78,25 @@ export class Tab extends React.Component<Props & WithStylesProps> {
           stretched && styles.tab_stretched,
         )}
       >
-        <ButtonOrLink
-          flexAlign
-          aria-selected={selected}
-          afterIcon={afterIcon}
-          beforeIcon={beforeIcon}
-          disabled={disabled}
-          href={href}
-          role="tab"
-          onClick={disabled ? undefined : this.handleClick}
-          className={cx(styles.tabButton)}
-        >
-          {label}
-        </ButtonOrLink>
+        <TrackingBoundary name={trackingName}>
+          <ButtonOrLink
+            flexAlign
+            aria-selected={selected}
+            afterIcon={afterIcon}
+            beforeIcon={beforeIcon}
+            disabled={disabled}
+            href={href}
+            role="tab"
+            onClick={disabled ? undefined : this.handleClick}
+            className={cx(
+              styles.tabButton,
+              small && styles.tabButton_small,
+              selected && styles.tabButton_active,
+            )}
+          >
+            {label}
+          </ButtonOrLink>
+        </TrackingBoundary>
       </span>
     );
   }
@@ -112,10 +122,10 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   },
 
   tab_selected: {
-    borderColor: color.accent.borderFocus,
+    borderColor: color.accent.borderActive,
 
     ':hover': {
-      borderColor: color.accent.borderFocus,
+      borderColor: color.accent.borderActive,
     },
   },
 
@@ -134,8 +144,10 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
   tabButton: {
     ...font.textReset,
+    ...font.textRegular,
     ...transition.box,
     background: color.accent.bg,
+    color: color.accent.text,
     display: 'flex',
     alignItems: 'center',
     paddingTop: unit,
@@ -146,7 +158,16 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     textDecoration: 'none',
     whiteSpace: 'nowrap',
     width: '100%',
+    fontWeight: font.weights.bold,
     borderTopLeftRadius: ui.borderRadius,
     borderTopRightRadius: ui.borderRadius,
+  },
+
+  tabButton_small: {
+    ...font.textSmall,
+  },
+
+  tabButton_active: {
+    color: color.accent.textActive,
   },
 }))(Tab);

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
-import ButtonOrLink from '../private/ButtonOrLink';
+import ButtonOrLink, { Props as ButtonOrLinkProps } from '../private/ButtonOrLink';
 import TrackingBoundary from '../TrackingBoundary';
 
-export type Props = {
+export type Props = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'disabled' | 'href'> & {
   /** Hide bottom border of Tab when unselected. */
   borderless?: boolean;
   /** Content to render if the tab is selected. */
   children?: React.ReactNode;
-  /** Disable the tab button. */
-  disabled?: boolean;
-  /** Render an anchor link with a URL instead of a button. */
-  href?: string;
   /**
    * Unique key name for this tab.
    * @ignore
@@ -36,8 +32,6 @@ export class Tab extends React.Component<Props & WithStylesProps> {
   static defaultProps = {
     borderless: false,
     children: null,
-    disabled: false,
-    href: '',
     selected: false,
     stretched: false,
   };
@@ -57,6 +51,8 @@ export class Tab extends React.Component<Props & WithStylesProps> {
   render() {
     const {
       cx,
+      afterIcon,
+      beforeIcon,
       borderless,
       disabled,
       href,
@@ -78,18 +74,19 @@ export class Tab extends React.Component<Props & WithStylesProps> {
           stretched && styles.tab_stretched,
         )}
       >
-        <TrackingBoundary name={trackingName}>
-          <ButtonOrLink
-            aria-selected={selected}
-            disabled={disabled}
-            href={href}
-            role="tab"
-            onClick={disabled ? undefined : this.handleClick}
-            className={cx(styles.tabButton)}
-          >
-            {label}
-          </ButtonOrLink>
-        </TrackingBoundary>
+        <ButtonOrLink
+          flexAlign
+          aria-selected={selected}
+          afterIcon={afterIcon}
+          beforeIcon={beforeIcon}
+          disabled={disabled}
+          href={href}
+          role="tab"
+          onClick={disabled ? undefined : this.handleClick}
+          className={cx(styles.tabButton)}
+        >
+          {label}
+        </ButtonOrLink>
       </span>
     );
   }
@@ -139,7 +136,8 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     ...font.textReset,
     ...transition.box,
     background: color.accent.bg,
-    display: 'inline-block',
+    display: 'flex',
+    alignItems: 'center',
     paddingTop: unit,
     paddingBottom: unit,
     border: 0,

--- a/packages/core/src/components/private/BaseAffix.tsx
+++ b/packages/core/src/components/private/BaseAffix.tsx
@@ -15,6 +15,8 @@ export type Props = {
   compact?: boolean;
   /** Mark the affix as disabled. */
   disabled?: boolean;
+  /** Align using flexbox. */
+  flex?: boolean;
 };
 
 export default class BaseAffix extends React.PureComponent<Props & WithStylesProps> {
@@ -28,10 +30,11 @@ export default class BaseAffix extends React.PureComponent<Props & WithStylesPro
     before: false,
     compact: false,
     disabled: false,
+    flex: false,
   };
 
   render() {
-    const { cx, after, before, children, compact, disabled, styles } = this.props;
+    const { cx, after, before, children, compact, disabled, flex, styles } = this.props;
 
     return (
       <div
@@ -41,6 +44,7 @@ export default class BaseAffix extends React.PureComponent<Props & WithStylesPro
           before && styles.affix_before,
           after && styles.affix_after,
           disabled && styles.affix_disabled,
+          flex && styles.affix_flex,
         )}
       >
         {children}

--- a/packages/core/src/components/private/ButtonOrLink.tsx
+++ b/packages/core/src/components/private/ButtonOrLink.tsx
@@ -14,6 +14,8 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Whether the element is disabled. */
   disabled?: boolean;
+  /** Apply flexbox styles to icons. */
+  flexAlign?: boolean;
   /** Render as an anchor link with a URL. */
   href?: string;
   /** Whether the element is loading. */
@@ -35,6 +37,7 @@ export default class ButtonOrLink extends React.Component<Props> {
     afterIcon: null,
     beforeIcon: null,
     disabled: false,
+    flexAlign: false,
     href: '',
     loading: false,
     openInNewWindow: false,
@@ -65,6 +68,7 @@ export default class ButtonOrLink extends React.Component<Props> {
       beforeIcon,
       children,
       disabled,
+      flexAlign,
       href,
       loading,
       openInNewWindow,
@@ -95,11 +99,19 @@ export default class ButtonOrLink extends React.Component<Props> {
     return (
       // @ts-ignore [ts] JSX element type 'Component' does not have any construct or call signatures. [2604]
       <Tag {...restProps} {...props} onClick={this.handleClick} onMouseUp={this.handleMouseUp}>
-        {!loading && beforeIcon && <IconAffix before>{beforeIcon}</IconAffix>}
+        {!loading && beforeIcon && (
+          <IconAffix before flex={flexAlign}>
+            {beforeIcon}
+          </IconAffix>
+        )}
 
         <span>{children}</span>
 
-        {!loading && afterIcon && <IconAffix after>{afterIcon}</IconAffix>}
+        {!loading && afterIcon && (
+          <IconAffix after flex={flexAlign}>
+            {afterIcon}
+          </IconAffix>
+        )}
       </Tag>
     );
   }

--- a/packages/core/src/components/private/IconAffix.tsx
+++ b/packages/core/src/components/private/IconAffix.tsx
@@ -26,4 +26,10 @@ export default withStyles(({ unit, pattern }) => ({
   affix_disabled: {
     ...pattern.disabled,
   },
+
+  affix_flex: {
+    flexShrink: 0,
+    flexGrow: 0,
+    marginTop: 0,
+  },
 }))(BaseAffix);

--- a/packages/core/src/themes/buildInputStyles.ts
+++ b/packages/core/src/themes/buildInputStyles.ts
@@ -42,7 +42,7 @@ export default function buildInputStyles({
 
     '@selectors': {
       ':hover, :focus': {
-        borderColor: color.accent.borderFocus,
+        borderColor: color.accent.borderActive,
       },
     },
   };
@@ -67,7 +67,7 @@ export default function buildInputStyles({
 
     '@selectors': {
       ':hover, :focus': {
-        borderColor: color.accent.borderFocus,
+        borderColor: color.accent.borderActive,
       },
     },
   };

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -32,10 +32,11 @@ export default function buildTheme(
     bgHover: color.neutral[0],
     bgError: color.danger[0],
     border: color.neutral[2],
+    borderActive: color.primary[3], // Also focus/selected
     borderHover: color.neutral[3],
     borderError: color.danger[3],
-    borderFocus: color.primary[3], // Also active/selected
     text: color.neutral[5],
+    textActive: color.primary[3],
     textError: color.danger[3],
     ...accents,
   };
@@ -79,7 +80,7 @@ export default function buildTheme(
         cursor: 'normal',
       },
       focused: {
-        borderColor: accent.borderFocus,
+        borderColor: accent.borderActive,
         outline: 'none',
       },
       invalid: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,10 +92,11 @@ export type Theme = {
       bgHover: Hexcode;
       bgError: Hexcode;
       border: Hexcode;
+      borderActive: Hexcode;
       borderHover: Hexcode;
       borderError: Hexcode;
-      borderFocus: Hexcode;
       text: Hexcode;
+      textActive: Hexcode;
       textError: Hexcode;
     };
     base: Hexcode;

--- a/packages/core/test/components/Tab.test.tsx
+++ b/packages/core/test/components/Tab.test.tsx
@@ -1,13 +1,33 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import IconCheck from '@airbnb/lunar-icons/lib/interface/IconCheck';
 import Tab from '../../src/components/Tabs/Tab';
 import TrackingBoundary from '../../src/components/TrackingBoundary';
+import ButtonOrLink from '../../src/components/private/ButtonOrLink';
 
 describe('<Tab/>', () => {
   it('renders a button', () => {
     const wrapper = shallow(<Tab keyName="default" label="Tab" onClick={() => {}} />).dive();
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a before icon', () => {
+    const icon = <IconCheck decorative />;
+    const wrapper = shallow(
+      <Tab keyName="default" label="Tab" onClick={() => {}} disabled beforeIcon={icon} />,
+    ).dive();
+
+    expect(wrapper.find(ButtonOrLink).prop('beforeIcon')).toBe(icon);
+  });
+
+  it('renders a after icon', () => {
+    const icon = <IconCheck decorative />;
+    const wrapper = shallow(
+      <Tab keyName="default" label="Tab" onClick={() => {}} disabled afterIcon={icon} />,
+    ).dive();
+
+    expect(wrapper.find(ButtonOrLink).prop('afterIcon')).toBe(icon);
   });
 
   it('renders disabled', () => {

--- a/packages/core/test/components/__snapshots__/Tab.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Tab.test.tsx.snap
@@ -9,7 +9,8 @@ exports[`<Tab/> renders a button 1`] = `
   >
     <ButtonOrLink
       aria-selected={false}
-      className="tabButton_17c4m1l"
+      className="tabButton_1yhh4o0"
+      flexAlign={true}
       onClick={[Function]}
       role="tab"
     >
@@ -28,8 +29,9 @@ exports[`<Tab/> renders disabled 1`] = `
   >
     <ButtonOrLink
       aria-selected={false}
-      className="tabButton_17c4m1l"
+      className="tabButton_1yhh4o0"
       disabled={true}
+      flexAlign={true}
       role="tab"
     >
       Tab
@@ -47,7 +49,8 @@ exports[`<Tab/> renders selected 1`] = `
   >
     <ButtonOrLink
       aria-selected={true}
-      className="tabButton_17c4m1l"
+      className="tabButton_1yhh4o0-o_O-tabButton_active_13z9huf"
+      flexAlign={true}
       onClick={[Function]}
       role="tab"
     >
@@ -66,7 +69,8 @@ exports[`<Tab/> renders stretched 1`] = `
   >
     <ButtonOrLink
       aria-selected={false}
-      className="tabButton_17c4m1l"
+      className="tabButton_1yhh4o0"
+      flexAlign={true}
       onClick={[Function]}
       role="tab"
     >

--- a/packages/core/test/components/private/ButtonOrLink.test.tsx
+++ b/packages/core/test/components/private/ButtonOrLink.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ButtonOrLink from '../../../src/components/private/ButtonOrLink';
+import IconAffix from '../../../src/components/private/IconAffix';
 import removeFocusOnMouseUp from '../../../src/utils/removeFocusOnMouseUp';
 
 jest.mock('../../../src/utils/removeFocusOnMouseUp');
@@ -157,5 +158,28 @@ describe('<ButtonOrLink />', () => {
 
     expect(wrapper.contains(beforeIcon)).toBe(false);
     expect(wrapper.contains(afterIcon)).toBe(false);
+  });
+
+  it('sets flex alignment on icons', () => {
+    const beforeIcon = <div>Icon</div>;
+    const afterIcon = <div>Icon</div>;
+    const wrapper = shallow(
+      <ButtonOrLink beforeIcon={beforeIcon} afterIcon={afterIcon} flexAlign>
+        Default
+      </ButtonOrLink>,
+    );
+
+    expect(
+      wrapper
+        .find(IconAffix)
+        .at(0)
+        .prop('flex'),
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(IconAffix)
+        .at(1)
+        .prop('flex'),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds an active state that colors text to our primary blurple. This technically isn't a breaking change (except the theme changes below) as the API is the same, but the active state will be broken in consumers based on what label they are passing to `Tab`.

- [x] Add support for icons.
- [x] Add support for small text.
- [x] Add an active state.

### Migration Guide

- If you were relying on `Text` for font sizing and color, you should remove them and simply pass a string. Otherwise the active state color will not be used.

```ts
// Before
<Tab key="key" label={<Text>Label</Text>} />
<Tab key="key" label={<Text small>Label</Text>} />

// After
<Tab key="key" label="Label" />
<Tab key="key" label="Label" small />
```

- The theme `borderFocus` accent property has been renamed.

```ts
// Before
theme.color.accent.borderFocus;

// After
theme.color.accent.borderActive;
```

## Motivation and Context

We've been wanting a true active state for a while now, so this is it.

## Testing

Unit tests and storybook.

## Screenshots

<img width="321" alt="Screen Shot 2019-06-12 at 12 44 52 PM" src="https://user-images.githubusercontent.com/143744/59382645-0f2ccc80-8d13-11e9-9c17-ed2e523d67a8.png">
<img width="662" alt="Screen Shot 2019-06-12 at 12 58 11 PM" src="https://user-images.githubusercontent.com/143744/59382646-0fc56300-8d13-11e9-9b92-2a8e03f2267b.png">
<img width="341" alt="Screen Shot 2019-06-12 at 12 58 15 PM" src="https://user-images.githubusercontent.com/143744/59382647-0fc56300-8d13-11e9-8158-74a4f928f897.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
