### PR TITLE
break(Layouts): Rework layout structuring. Add LayoutShell and Aside components.

### DIFF
--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import Content from './Content';
-import useStyles, { Theme } from '../../hooks/useStyles';
+import useStyles, { StyleSheet } from '../../hooks/useStyles';
 
 export { Content };
 
-const styleSheet = ({ color, pattern }: Theme) => ({
+const styleSheet: StyleSheet = ({ color, pattern }) => ({
   card: {
     ...pattern.box,
     background: color.accent.bg,

--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import Content from './Content';
-import useStyles from '../../hooks/useStyles';
-import { Theme } from '../../types';
+import useStyles, { Theme } from '../../hooks/useStyles';
 
 export { Content };
 

--- a/packages/core/src/composers/withStyles.tsx
+++ b/packages/core/src/composers/withStyles.tsx
@@ -1,8 +1,9 @@
 import { withStylesFactory, WithStylesWrappedProps } from 'aesthetic-react';
 import { NativeBlock, ParsedBlock } from 'aesthetic-adapter-aphrodite';
-import { Theme } from '../types';
+import { Theme as BaseTheme } from '../types';
 import Core from '..';
 
-export type WithStylesProps = WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock>;
+export type WithStylesProps = WithStylesWrappedProps<BaseTheme, NativeBlock, ParsedBlock>;
+export type Theme = BaseTheme;
 
 export default withStylesFactory(Core.aesthetic);

--- a/packages/core/src/composers/withTheme.tsx
+++ b/packages/core/src/composers/withTheme.tsx
@@ -1,7 +1,8 @@
 import { withThemeFactory, WithThemeWrappedProps } from 'aesthetic-react';
-import { Theme } from '../types';
+import { Theme as BaseTheme } from '../types';
 import Core from '..';
 
 export type WithThemeProps = WithThemeWrappedProps<Theme>;
+export type Theme = BaseTheme;
 
 export default withThemeFactory(Core.aesthetic);

--- a/packages/core/src/hooks/useStyles.ts
+++ b/packages/core/src/hooks/useStyles.ts
@@ -1,7 +1,9 @@
+import { StyleSheetDefinition } from 'aesthetic';
 import { useStylesFactory } from 'aesthetic-react';
 import { Theme as BaseTheme } from '../types';
 import Core from '..';
 
 export type Theme = BaseTheme;
+export type StyleSheet = StyleSheetDefinition<Theme, any>;
 
 export default useStylesFactory(Core.aesthetic);

--- a/packages/core/src/hooks/useStyles.ts
+++ b/packages/core/src/hooks/useStyles.ts
@@ -1,4 +1,7 @@
 import { useStylesFactory } from 'aesthetic-react';
+import { Theme as BaseTheme } from '../types';
 import Core from '..';
+
+export type Theme = BaseTheme;
 
 export default useStylesFactory(Core.aesthetic);

--- a/packages/core/src/hooks/useTheme.ts
+++ b/packages/core/src/hooks/useTheme.ts
@@ -1,4 +1,7 @@
 import { useThemeFactory } from 'aesthetic-react';
+import { Theme as BaseTheme } from '../types';
 import Core from '..';
+
+export type Theme = BaseTheme;
 
 export default useThemeFactory(Core.aesthetic);

--- a/packages/layouts/src/components/Aside.story.tsx
+++ b/packages/layouts/src/components/Aside.story.tsx
@@ -38,4 +38,14 @@ storiesOf('Layouts/Aside', module)
       <LoremIpsum />
       <LoremIpsum />
     </Aside>
+  ))
+  .add('As a scrollable container.', () => (
+    <div style={{ height: 500 }}>
+      <Aside scrollable width={300}>
+        <LoremIpsum />
+        <LoremIpsum />
+        <LoremIpsum />
+        <LoremIpsum />
+      </Aside>
+    </div>
   ));

--- a/packages/layouts/src/components/Aside.story.tsx
+++ b/packages/layouts/src/components/Aside.story.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import LoremIpsum from ':storybook/components/LoremIpsum';
+import Aside from './Aside';
+
+storiesOf('Layouts/Aside', module)
+  .addParameters({
+    inspectComponents: [Aside],
+  })
+  .add('Standard aside with a width', () => (
+    <Aside width={300}>
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </Aside>
+  ))
+  .add('With a before (left) border.', () => (
+    <Aside before width={300}>
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </Aside>
+  ))
+  .add('With an after (right) border.', () => (
+    <Aside after width={300}>
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </Aside>
+  ))
+  .add('With no padding.', () => (
+    <Aside noPadding width={300}>
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </Aside>
+  ));

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -16,24 +16,18 @@ const styleSheet = ({ ui, unit }: Theme) => ({
     borderRight: ui.border,
   },
 
-  aside_noBorder: {
-    border: 0,
-  },
-
   aside_noPadding: {
     padding: 0,
   },
 });
 
 export type Props = {
-  /** Column is rendered after content. */
+  /** Column is rendered after content. Applies a left border. */
   after?: boolean;
-  /** Column is rendered before content. */
+  /** Column is rendered before content. Applies a right border. */
   before?: boolean;
   /** Content within the column. */
   children: NonNullable<React.ReactNode>;
-  /** Remove border from column. */
-  noBorder?: boolean;
   /** Remove padding from column. */
   noPadding?: boolean;
   /** Width of the aside column. */
@@ -41,7 +35,7 @@ export type Props = {
 };
 
 /** An aside column within a layout. */
-export default function Aside({ after, before, children, noBorder, noPadding, width }: Props) {
+export default function Aside({ after, before, children, noPadding, width }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
@@ -50,7 +44,6 @@ export default function Aside({ after, before, children, noBorder, noPadding, wi
         styles.aside,
         after && styles.aside_after,
         before && styles.aside_before,
-        noBorder && styles.aside_noBorder,
         noPadding && styles.aside_noPadding,
         { width },
       )}

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -26,9 +26,9 @@ const styleSheet = ({ ui, unit }: Theme) => ({
 });
 
 export type Props = {
-  /** Render column before content. */
+  /** Column is rendered after content. */
   after?: boolean;
-  /** Render column before content. */
+  /** Column is rendered before content. */
   before?: boolean;
   /** Content within the column. */
   children: NonNullable<React.ReactNode>;

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -40,6 +40,7 @@ export type Props = {
   width?: number;
 };
 
+/** An aside column within a layout. */
 export default function Aside({ after, before, children, noBorder, noPadding, width }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -19,6 +19,11 @@ const styleSheet = ({ ui, unit }: Theme) => ({
   aside_noPadding: {
     padding: 0,
   },
+
+  aside_scrollable: {
+    overflowY: 'auto',
+    maxHeight: '100%',
+  },
 });
 
 export type Props = {
@@ -30,12 +35,14 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Remove padding from column. */
   noPadding?: boolean;
+  /** Convert column to a scrollable container. */
+  scrollable?: boolean;
   /** Width of the aside column. */
-  width?: number;
+  width?: number | string;
 };
 
 /** An aside column within a layout. */
-export default function Aside({ after, before, children, noPadding, width }: Props) {
+export default function Aside({ after, before, children, noPadding, scrollable, width }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
@@ -45,6 +52,7 @@ export default function Aside({ after, before, children, noPadding, width }: Pro
         after && styles.aside_after,
         before && styles.aside_before,
         noPadding && styles.aside_noPadding,
+        scrollable && styles.aside_scrollable,
         { width },
       )}
     >

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import useStyles, { Theme } from '@airbnb/lunar/lib/hooks/useStyles';
+import useStyles, { StyleSheet } from '@airbnb/lunar/lib/hooks/useStyles';
 
-const styleSheet = ({ ui, unit }: Theme) => ({
+const styleSheet: StyleSheet = ({ ui, unit }) => ({
   aside: {
     flexGrow: 0,
     flexShrink: 0,

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import useStyles, { Theme } from '@airbnb/lunar/lib/hooks/useStyles';
+
+const styleSheet = ({ ui, unit }: Theme) => ({
+  aside: {
+    flexGrow: 0,
+    flexShrink: 0,
+    padding: unit * 2,
+  },
+
+  aside_after: {
+    borderLeft: ui.border,
+  },
+
+  aside_before: {
+    borderRight: ui.border,
+  },
+
+  aside_noBorder: {
+    border: 0,
+  },
+
+  aside_noPadding: {
+    padding: 0,
+  },
+});
+
+export type Props = {
+  /** Render column before content. */
+  after?: boolean;
+  /** Render column before content. */
+  before?: boolean;
+  /** Content within the column. */
+  children: NonNullable<React.ReactNode>;
+  /** Remove border from column. */
+  noBorder?: boolean;
+  /** Remove padding from column. */
+  noPadding?: boolean;
+  /** Width of the aside column. */
+  width?: number;
+};
+
+export default function Aside({ after, before, children, noBorder, noPadding, width }: Props) {
+  const [styles, cx] = useStyles(styleSheet);
+
+  return (
+    <aside
+      className={cx(
+        styles.aside,
+        after && styles.aside_after,
+        before && styles.aside_before,
+        noBorder && styles.aside_noBorder,
+        noPadding && styles.aside_noPadding,
+        { width },
+      )}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/packages/layouts/src/components/Layout.story.tsx
+++ b/packages/layouts/src/components/Layout.story.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SideBar, { Item } from './SideBar';
+import Aside from './Aside';
 import Layout from './Layout';
 
 storiesOf('Layouts/Layout', module)
@@ -14,20 +13,41 @@ storiesOf('Layouts/Layout', module)
       <LoremIpsum />
     </Layout>
   ))
-  .add('With asides.', () => (
-    <Layout before={<LoremIpsum />} after={<LoremIpsum />}>
+  .add('With left side, and no padding.', () => (
+    <Layout
+      before={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
+      noPadding
+    >
       <LoremIpsum />
     </Layout>
   ))
-  .add('With side bar and no background color.', () => (
+  .add('With right side, and no background color.', () => (
     <Layout
+      after={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
       noBackground
-      before={<LoremIpsum />}
-      after={<LoremIpsum />}
-      sideBar={
-        <SideBar accessibilityLabel="Nav">
-          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
-        </SideBar>
+    >
+      <LoremIpsum />
+    </Layout>
+  ))
+  .add('With both sides.', () => (
+    <Layout
+      before={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
+      after={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
       }
     >
       <LoremIpsum />

--- a/packages/layouts/src/components/Layout.story.tsx
+++ b/packages/layouts/src/components/Layout.story.tsx
@@ -13,10 +13,10 @@ storiesOf('Layouts/Layout', module)
       <LoremIpsum />
     </Layout>
   ))
-  .add('With left side, and no padding.', () => (
+  .add('With left aside, and no main padding.', () => (
     <Layout
       before={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }
@@ -25,10 +25,10 @@ storiesOf('Layouts/Layout', module)
       <LoremIpsum />
     </Layout>
   ))
-  .add('With right side, and no background color.', () => (
+  .add('With right aside, and no main background color.', () => (
     <Layout
       after={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }
@@ -40,12 +40,12 @@ storiesOf('Layouts/Layout', module)
   .add('With both sides.', () => (
     <Layout
       before={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }
       after={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }

--- a/packages/layouts/src/components/Layout/index.tsx
+++ b/packages/layouts/src/components/Layout/index.tsx
@@ -31,7 +31,7 @@ export class Layout extends React.Component<Props & AsideProps & WithStylesProps
     const { cx, after, before, children, fluid, noBackground, noPadding, styles } = this.props;
 
     return (
-      <>
+      <div className={cx(styles.layout)}>
         {before}
 
         <main
@@ -46,12 +46,19 @@ export class Layout extends React.Component<Props & AsideProps & WithStylesProps
         </main>
 
         {after}
-      </>
+      </div>
     );
   }
 }
 
 export default withStyles(({ breakpoints, color, unit }) => ({
+  layout: {
+    display: 'flex',
+    width: '100%',
+    minHeight: '100vh',
+    justifyContent: 'space-between',
+  },
+
   main: {
     flexGrow: 1,
     padding: unit * 2,

--- a/packages/layouts/src/components/Layout/index.tsx
+++ b/packages/layouts/src/components/Layout/index.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { elementType } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
-import SideBar from '../SideBar';
 
 export type Props = {
-  /** Width of the aside columns. */
-  asideWidth?: number;
   /** The primary main content. */
   children: NonNullable<React.ReactNode>;
   /** Expand main content to full width of viewport. */
@@ -14,10 +10,6 @@ export type Props = {
   noBackground?: boolean;
   /** Remove padding from main content. */
   noPadding?: boolean;
-  /** Navigation side bar to display before the content. */
-  sideBar?: React.ReactNode;
-  /** Navigation top bar to display above the content. */
-  topBar?: React.ReactNode; // TODO
 };
 
 export type AsideProps = {
@@ -30,39 +22,17 @@ export type AsideProps = {
 /** Abstract layout manager that all other layouts extend from. */
 export class Layout extends React.Component<Props & AsideProps & WithStylesProps> {
   static defaultProps = {
-    asideWidth: 300,
     fluid: false,
     noBackground: false,
     noPadding: false,
   };
 
-  static propTypes = {
-    sideBar: elementType(SideBar),
-  };
-
   render() {
-    const {
-      cx,
-      after,
-      asideWidth,
-      before,
-      children,
-      fluid,
-      noBackground,
-      noPadding,
-      sideBar,
-      styles,
-    } = this.props;
+    const { cx, after, before, children, fluid, noBackground, noPadding, styles } = this.props;
 
     return (
-      <div className={cx(styles.layout)}>
-        {sideBar && <aside className={cx(styles.aside)}>{sideBar}</aside>}
-
-        {before && (
-          <aside className={cx(styles.aside, styles.aside_before, { width: asideWidth })}>
-            {before}
-          </aside>
-        )}
+      <>
+        {before}
 
         <main
           role="main"
@@ -75,25 +45,13 @@ export class Layout extends React.Component<Props & AsideProps & WithStylesProps
           <div className={cx(!fluid && styles.mainContent)}>{children}</div>
         </main>
 
-        {after && (
-          <aside className={cx(styles.aside, styles.aside_after, { width: asideWidth })}>
-            {after}
-          </aside>
-        )}
-      </div>
+        {after}
+      </>
     );
   }
 }
 
 export default withStyles(({ breakpoints, color, unit }) => ({
-  layout: {
-    display: 'flex',
-    width: '100%',
-    minHeight: '100vh',
-    background: color.accent.bg,
-    justifyContent: 'space-between',
-  },
-
   main: {
     flexGrow: 1,
     padding: unit * 2,
@@ -110,20 +68,5 @@ export default withStyles(({ breakpoints, color, unit }) => ({
 
   mainContent: {
     maxWidth: breakpoints.medium,
-  },
-
-  aside: {
-    flexGrow: 0,
-    flexShrink: 0,
-  },
-
-  aside_after: {
-    padding: unit * 2,
-    // borderLeft: ui.border,
-  },
-
-  aside_before: {
-    padding: unit * 2,
-    // borderRight: ui.border,
   },
 }))(Layout);

--- a/packages/layouts/src/components/LayoutShell.story.tsx
+++ b/packages/layouts/src/components/LayoutShell.story.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
+import LoremIpsum from ':storybook/components/LoremIpsum';
+import SideBar, { Item } from './SideBar';
+import LayoutShell from './LayoutShell';
+
+storiesOf('Layouts/LayoutShell', module)
+  .addParameters({
+    inspectComponents: [LayoutShell],
+  })
+  .add('Standard shell with no top or side bars.', () => (
+    <LayoutShell>
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </LayoutShell>
+  ))
+  .add('With side bar and no background color.', () => (
+    <LayoutShell
+      sideBar={
+        <SideBar accessibilityLabel="Nav">
+          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
+        </SideBar>
+      }
+    >
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+      <LoremIpsum />
+    </LayoutShell>
+  ));

--- a/packages/layouts/src/components/LayoutShell/index.tsx
+++ b/packages/layouts/src/components/LayoutShell/index.tsx
@@ -28,11 +28,12 @@ export type Props = {
   // topBar?: React.ReactNode;
 };
 
+/** Layout shell that wraps an entire application, providing optional side and top nav bars. */
 export default function LayoutShell({ children, sideBar }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
-    <div className={cx(styles.layout)}>
+    <div className={cx(styles.shell)}>
       {sideBar && <aside className={cx(styles.sideBar)}>{sideBar}</aside>}
 
       <div>{children}</div>

--- a/packages/layouts/src/components/LayoutShell/index.tsx
+++ b/packages/layouts/src/components/LayoutShell/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { elementType } from 'airbnb-prop-types';
+import useStyles, { Theme } from '@airbnb/lunar/lib/hooks/useStyles';
+import SideBar from '../SideBar';
+
+const styleSheet = ({ color }: Theme) => ({
+  shell: {
+    display: 'flex',
+    width: '100%',
+    minHeight: '100vh',
+    background: color.accent.bg,
+    justifyContent: 'space-between',
+  },
+
+  sideBar: {
+    flexGrow: 0,
+    flexShrink: 0,
+    width: 'auto',
+  },
+});
+
+export type Props = {
+  /** The page content. */
+  children: NonNullable<React.ReactNode>;
+  /** Navigation side bar to display before the content. */
+  sideBar?: React.ReactNode;
+  /** Navigation top bar to display above the content. */
+  // topBar?: React.ReactNode;
+};
+
+export default function LayoutShell({ children, sideBar }: Props) {
+  const [styles, cx] = useStyles(styleSheet);
+
+  return (
+    <div className={cx(styles.layout)}>
+      {sideBar && <aside className={cx(styles.sideBar)}>{sideBar}</aside>}
+
+      <div>{children}</div>
+    </div>
+  );
+}
+
+LayoutShell.propTypes = {
+  sideBar: elementType(SideBar),
+};

--- a/packages/layouts/src/components/LayoutShell/index.tsx
+++ b/packages/layouts/src/components/LayoutShell/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { elementType } from 'airbnb-prop-types';
-import useStyles, { Theme } from '@airbnb/lunar/lib/hooks/useStyles';
+import useStyles, { StyleSheet } from '@airbnb/lunar/lib/hooks/useStyles';
 import SideBar from '../SideBar';
 
-const styleSheet = ({ color }: Theme) => ({
+const styleSheet: StyleSheet = ({ color }) => ({
   shell: {
     display: 'flex',
     width: '100%',

--- a/packages/layouts/src/components/LayoutShell/index.tsx
+++ b/packages/layouts/src/components/LayoutShell/index.tsx
@@ -29,7 +29,7 @@ export type Props = {
 };
 
 /** Layout shell that wraps an entire application, providing optional side and top nav bars. */
-export default function LayoutShell({ children, sideBar }: Props) {
+function LayoutShell({ children, sideBar }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
@@ -44,3 +44,5 @@ export default function LayoutShell({ children, sideBar }: Props) {
 LayoutShell.propTypes = {
   sideBar: elementType(SideBar),
 };
+
+export default LayoutShell;

--- a/packages/layouts/src/components/OneColumnLayout.story.tsx
+++ b/packages/layouts/src/components/OneColumnLayout.story.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SideBar, { Item } from './SideBar';
 import OneColumnLayout from './OneColumnLayout';
 
 storiesOf('Layouts/OneColumnLayout', module)
@@ -11,20 +9,6 @@ storiesOf('Layouts/OneColumnLayout', module)
   })
   .add('A single column layout with no asides.', () => (
     <OneColumnLayout>
-      <LoremIpsum />
-      <LoremIpsum />
-      <LoremIpsum />
-      <LoremIpsum />
-    </OneColumnLayout>
-  ))
-  .add('A single column layout with a side navigation.', () => (
-    <OneColumnLayout
-      sideBar={
-        <SideBar accessibilityLabel="Nav">
-          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
-        </SideBar>
-      }
-    >
       <LoremIpsum />
       <LoremIpsum />
       <LoremIpsum />

--- a/packages/layouts/src/components/OneColumnLayout/index.tsx
+++ b/packages/layouts/src/components/OneColumnLayout/index.tsx
@@ -3,7 +3,7 @@ import Layout, { Props as LayoutProps } from '../Layout';
 
 export type Props = LayoutProps;
 
-/** A fluid one-column layout with optional top and side navigation. */
+/** A one-column layout. */
 export default class OneColumnLayout extends React.Component<Props> {
   render() {
     const { children, ...props } = this.props;

--- a/packages/layouts/src/components/SplitLayout.story.tsx
+++ b/packages/layouts/src/components/SplitLayout.story.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SideBar, { Item } from './SideBar';
+import Aside from './Aside';
 import SplitLayout from './SplitLayout';
 
 storiesOf('Layouts/SplitLayout', module)
@@ -10,16 +9,16 @@ storiesOf('Layouts/SplitLayout', module)
     inspectComponents: [SplitLayout],
   })
   .add('A split column layout with before and after aside.', () => (
-    <SplitLayout after={<LoremIpsum />} before={<LoremIpsum />} />
-  ))
-  .add('With side bar.', () => (
     <SplitLayout
-      after={<LoremIpsum />}
-      before={<LoremIpsum />}
-      sideBar={
-        <SideBar accessibilityLabel="Nav">
-          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
-        </SideBar>
+      after={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
+      before={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
       }
     />
   ));

--- a/packages/layouts/src/components/SplitLayout/index.tsx
+++ b/packages/layouts/src/components/SplitLayout/index.tsx
@@ -1,28 +1,33 @@
 import React from 'react';
-import { Omit } from 'utility-types';
+import { elementType } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
+import Aside from '../Aside';
 import Layout, { Props as LayoutProps, AsideProps } from '../Layout';
 
-export type Props = Required<AsideProps> &
-  Omit<LayoutProps, 'children' | 'fluid' | 'noBackground' | 'noPadding'>;
+export type Props = Required<AsideProps> & Pick<LayoutProps, 'fluid'>;
 
-/** A symmetrical two-column layout with optional top and side navigation. */
+/** A symmetrical two-column layout. */
 export class SplitLayout extends React.Component<Props & WithStylesProps> {
+  static propTypes = {
+    after: elementType(Aside).isRequired,
+    before: elementType(Aside).isRequired,
+  };
+
   render() {
-    const { cx, before, after, styles, ...props } = this.props;
+    const { after, before, cx, fluid, styles } = this.props;
 
     return (
-      <Layout {...props} noBackground noPadding>
+      <Layout noBackground noPadding fluid={fluid}>
         <div className={cx(styles.wrapper)}>
           <div className={cx(styles.column)}>{before}</div>
-          <div className={cx(styles.column, styles.column_after)}>{after}</div>
+          <div className={cx(styles.column)}>{after}</div>
         </div>
       </Layout>
     );
   }
 }
 
-export default withStyles(({ unit }) => ({
+export default withStyles(() => ({
   wrapper: {
     display: 'flex',
     height: '100%',
@@ -30,12 +35,5 @@ export default withStyles(({ unit }) => ({
 
   column: {
     width: '50%',
-    flexGrow: 0,
-    flexShrink: 0,
-    padding: unit * 2,
-  },
-
-  column_after: {
-    // borderLeft: ui.border,
   },
 }))(SplitLayout);

--- a/packages/layouts/src/components/ThreeColumnLayout.story.tsx
+++ b/packages/layouts/src/components/ThreeColumnLayout.story.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SideBar, { Item } from './SideBar';
+import Aside from './Aside';
 import ThreeColumnLayout from './ThreeColumnLayout';
 
 storiesOf('Layouts/ThreeColumnLayout', module)
@@ -10,21 +9,16 @@ storiesOf('Layouts/ThreeColumnLayout', module)
     inspectComponents: [ThreeColumnLayout],
   })
   .add('A three column layout.', () => (
-    <ThreeColumnLayout after={<LoremIpsum />} before={<LoremIpsum />}>
-      <LoremIpsum />
-      <LoremIpsum />
-      <LoremIpsum />
-      <LoremIpsum />
-    </ThreeColumnLayout>
-  ))
-  .add('A three column layout with a side navigation.', () => (
     <ThreeColumnLayout
-      after={<LoremIpsum />}
-      before={<LoremIpsum />}
-      sideBar={
-        <SideBar accessibilityLabel="Nav">
-          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
-        </SideBar>
+      after={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
+      before={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
       }
     >
       <LoremIpsum />

--- a/packages/layouts/src/components/ThreeColumnLayout.story.tsx
+++ b/packages/layouts/src/components/ThreeColumnLayout.story.tsx
@@ -11,12 +11,12 @@ storiesOf('Layouts/ThreeColumnLayout', module)
   .add('A three column layout.', () => (
     <ThreeColumnLayout
       after={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }
       before={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }

--- a/packages/layouts/src/components/ThreeColumnLayout/index.tsx
+++ b/packages/layouts/src/components/ThreeColumnLayout/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { elementType } from 'airbnb-prop-types';
 import Layout, { Props as LayoutProps } from '../Layout';
+import Aside from '../Aside';
 
 export type Props = LayoutProps & {
   /** The after aside content. */
@@ -8,8 +10,13 @@ export type Props = LayoutProps & {
   before: NonNullable<React.ReactNode>;
 };
 
-/** A fluid three-column layout with optional top and side navigation. */
+/** A three-column layout. */
 export default class ThreeColumnLayout extends React.Component<Props> {
+  static propTypes = {
+    after: elementType(Aside).isRequired,
+    before: elementType(Aside).isRequired,
+  };
+
   render() {
     const { children, ...props } = this.props;
 

--- a/packages/layouts/src/components/TwoColumnLayout.story.tsx
+++ b/packages/layouts/src/components/TwoColumnLayout.story.tsx
@@ -11,7 +11,7 @@ storiesOf('Layouts/TwoColumnLayout', module)
   .add('A two column layout with before (left) aside.', () => (
     <TwoColumnLayout
       aside={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }
@@ -26,7 +26,7 @@ storiesOf('Layouts/TwoColumnLayout', module)
   .add('A two column layout with after (right) aside.', () => (
     <TwoColumnLayout
       aside={
-        <Aside>
+        <Aside width={300}>
           <LoremIpsum />
         </Aside>
       }

--- a/packages/layouts/src/components/TwoColumnLayout.story.tsx
+++ b/packages/layouts/src/components/TwoColumnLayout.story.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconSettings from '@airbnb/lunar-icons/lib/interface/IconSettings';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import SideBar, { Item } from './SideBar';
+import Aside from './Aside';
 import TwoColumnLayout from './TwoColumnLayout';
 
 storiesOf('Layouts/TwoColumnLayout', module)
@@ -10,22 +9,28 @@ storiesOf('Layouts/TwoColumnLayout', module)
     inspectComponents: [TwoColumnLayout],
   })
   .add('A two column layout with before (left) aside.', () => (
-    <TwoColumnLayout aside={<LoremIpsum />} before>
+    <TwoColumnLayout
+      aside={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
+      }
+      before
+    >
       <LoremIpsum />
       <LoremIpsum />
       <LoremIpsum />
       <LoremIpsum />
     </TwoColumnLayout>
   ))
-  .add('A two column layout with after (right) aside and a side navigation.', () => (
+  .add('A two column layout with after (right) aside.', () => (
     <TwoColumnLayout
-      after
-      aside={<LoremIpsum />}
-      sideBar={
-        <SideBar accessibilityLabel="Nav">
-          <Item icon={<IconSettings accessibilityLabel="Settings" />} />
-        </SideBar>
+      aside={
+        <Aside>
+          <LoremIpsum />
+        </Aside>
       }
+      after
     >
       <LoremIpsum />
       <LoremIpsum />

--- a/packages/layouts/src/components/TwoColumnLayout/index.tsx
+++ b/packages/layouts/src/components/TwoColumnLayout/index.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
-import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
+import { elementType, mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import Layout, { Props as LayoutProps } from '../Layout';
+import Aside from '../Aside';
 
 const asidePropType = mutuallyExclusiveTrueProps('after', 'before');
 
 export type Props = LayoutProps & {
   /** Display the aside after the content. */
   after?: boolean;
-  /** Display the aside after the content. */
-  before?: boolean;
   /** The aside content. */
   aside: NonNullable<React.ReactNode>;
+  /** Display the aside after the content. */
+  before?: boolean;
 };
 
-/**
- * A fluid two-column layout with a before or after sidebar, and optional top and side navigation. */
+/** A two-column layout. */
 export default class TwoColumnLayout extends React.Component<Props> {
   static propTypes = {
     after: asidePropType,
+    aside: elementType(Aside).isRequired,
     before: asidePropType,
   };
 

--- a/packages/layouts/test/components/Aside.test.tsx
+++ b/packages/layouts/test/components/Aside.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Aside from '../../src/components/Aside';
+
+describe('<Aside />', () => {
+  it('renders with content', () => {
+    const wrapper = shallow(<Aside>Child</Aside>);
+
+    expect(wrapper.contains('Child')).toBe(true);
+  });
+
+  it('renders with props enabled', () => {
+    const wrapper = shallow(
+      <Aside noBorder noPadding before>
+        Child
+      </Aside>,
+    );
+
+    expect(wrapper.contains('Child')).toBe(true);
+  });
+});

--- a/packages/layouts/test/components/Aside.test.tsx
+++ b/packages/layouts/test/components/Aside.test.tsx
@@ -11,7 +11,7 @@ describe('<Aside />', () => {
 
   it('renders with props enabled', () => {
     const wrapper = shallow(
-      <Aside noBorder noPadding before>
+      <Aside noPadding before>
         Child
       </Aside>,
     );

--- a/packages/layouts/test/components/Layout.test.tsx
+++ b/packages/layouts/test/components/Layout.test.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import SideBar from '../../src/components/SideBar';
 import Layout from '../../src/components/Layout';
+import Aside from '../../src/components/Aside';
 
 describe('<Layout />', () => {
-  it('errors if invalid `sideBar` is passed', () => {
-    expect(() => {
-      shallow(<Layout sideBar="Sidebar">Child</Layout>).dive();
-    }).toThrowErrorMatchingSnapshot();
-  });
-
   it('renders with main content', () => {
     const wrapper = shallow(<Layout>Child</Layout>).dive();
 
@@ -18,44 +12,34 @@ describe('<Layout />', () => {
     expect(wrapper.find('main').text()).toBe('Child');
   });
 
-  it('renders a sidebar', () => {
-    const sidebar = <SideBar accessibilityLabel="Test">Item</SideBar>;
-    const wrapper = shallow(<Layout sideBar={sidebar}>Child</Layout>).dive();
-
-    expect(wrapper.find('aside')).toHaveLength(1);
-    expect(wrapper.find('aside').contains(sidebar)).toBe(true);
-  });
-
   it('renders a before aside', () => {
     const aside = <div>Before</div>;
-    const wrapper = shallow(<Layout before={aside}>Child</Layout>).dive();
+    const wrapper = shallow(<Layout before={<Aside>{aside}</Aside>}>Child</Layout>).dive();
 
-    expect(wrapper.find('aside')).toHaveLength(1);
-    expect(wrapper.find('aside').contains(aside)).toBe(true);
+    expect(wrapper.find(Aside)).toHaveLength(1);
+    expect(wrapper.find(Aside).contains(aside)).toBe(true);
   });
 
   it('renders an after aside', () => {
     const aside = <div>After</div>;
-    const wrapper = shallow(<Layout after={aside}>Child</Layout>).dive();
+    const wrapper = shallow(<Layout after={<Aside>{aside}</Aside>}>Child</Layout>).dive();
 
-    expect(wrapper.find('aside')).toHaveLength(1);
-    expect(wrapper.find('aside').contains(aside)).toBe(true);
+    expect(wrapper.find(Aside)).toHaveLength(1);
+    expect(wrapper.find(Aside).contains(aside)).toBe(true);
   });
 
-  it('renders all 3 aside types', () => {
-    const sidebar = <SideBar accessibilityLabel="Test">Item</SideBar>;
+  it('renders both asides', () => {
     const before = <div>Before</div>;
     const after = <div>After</div>;
     const wrapper = shallow(
-      <Layout sideBar={sidebar} before={before} after={after}>
+      <Layout before={<Aside>{before}</Aside>} after={<Aside>{after}</Aside>}>
         Child
       </Layout>,
     ).dive();
-    const all = wrapper.find('aside');
+    const all = wrapper.find(Aside);
 
-    expect(all).toHaveLength(3);
-    expect(all.at(0).contains(sidebar)).toBe(true);
-    expect(all.at(1).contains(before)).toBe(true);
-    expect(all.at(2).contains(after)).toBe(true);
+    expect(all).toHaveLength(2);
+    expect(all.at(0).contains(before)).toBe(true);
+    expect(all.at(1).contains(after)).toBe(true);
   });
 });

--- a/packages/layouts/test/components/Layout.test.tsx
+++ b/packages/layouts/test/components/Layout.test.tsx
@@ -12,6 +12,16 @@ describe('<Layout />', () => {
     expect(wrapper.find('main').text()).toBe('Child');
   });
 
+  it('renders with props passed', () => {
+    const wrapper = shallow(
+      <Layout noBackground noPadding>
+        Child
+      </Layout>,
+    ).dive();
+
+    expect(wrapper.find('main')).toHaveLength(1);
+  });
+
   it('renders a before aside', () => {
     const aside = <div>Before</div>;
     const wrapper = shallow(<Layout before={<Aside>{aside}</Aside>}>Child</Layout>).dive();

--- a/packages/layouts/test/components/LayoutShell.test.tsx
+++ b/packages/layouts/test/components/LayoutShell.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SideBar from '../../src/components/SideBar';
+import LayoutShell from '../../src/components/LayoutShell';
+
+describe('<LayoutShell />', () => {
+  it('errors if invalid `sideBar` is passed', () => {
+    expect(() => {
+      shallow(<LayoutShell sideBar="Sidebar">Child</LayoutShell>);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it('renders with content', () => {
+    const wrapper = shallow(<LayoutShell>Child</LayoutShell>);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .text(),
+    ).toBe('Child');
+  });
+
+  it('renders a sidebar', () => {
+    const sidebar = <SideBar accessibilityLabel="Test">Item</SideBar>;
+    const wrapper = shallow(<LayoutShell sideBar={sidebar}>Child</LayoutShell>);
+
+    expect(wrapper.find('aside')).toHaveLength(1);
+    expect(wrapper.find('aside').contains(sidebar)).toBe(true);
+  });
+});

--- a/packages/layouts/test/components/LayoutShell.test.tsx
+++ b/packages/layouts/test/components/LayoutShell.test.tsx
@@ -7,7 +7,7 @@ describe('<LayoutShell />', () => {
   it('errors if invalid `sideBar` is passed', () => {
     expect(() => {
       shallow(<LayoutShell sideBar="Sidebar">Child</LayoutShell>);
-    }).toThrowErrorMatchingSnapshot();
+    }).toThrowError();
   });
 
   it('renders with content', () => {

--- a/packages/layouts/test/components/OneColumnLayout.test.tsx
+++ b/packages/layouts/test/components/OneColumnLayout.test.tsx
@@ -5,17 +5,12 @@ import OneColumnLayout from '../../src/components/OneColumnLayout';
 
 describe('<OneColumnLayout />', () => {
   it('renders and passes props to `Layout`', () => {
-    const wrapper = shallow(
-      <OneColumnLayout fluid asideWidth={100}>
-        Child
-      </OneColumnLayout>,
-    );
+    const wrapper = shallow(<OneColumnLayout fluid>Child</OneColumnLayout>);
 
     expect(wrapper.find(Layout).props()).toEqual(
       expect.objectContaining({
         children: 'Child',
         fluid: true,
-        asideWidth: 100,
       }),
     );
   });

--- a/packages/layouts/test/components/SplitLayout.test.tsx
+++ b/packages/layouts/test/components/SplitLayout.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Layout from '../../src/components/Layout';
+import Aside from '../../src/components/Aside';
 import SplitLayout from '../../src/components/SplitLayout';
 
 describe('<SplitLayout />', () => {
@@ -19,11 +20,12 @@ describe('<SplitLayout />', () => {
   // });
 
   it('renders and passes props to `Layout`', () => {
-    const wrapper = shallow(<SplitLayout asideWidth={100} before="Left" after="Right" />).dive();
+    const wrapper = shallow(
+      <SplitLayout before={<Aside>Left</Aside>} after={<Aside>Right</Aside>} />,
+    ).dive();
 
     expect(wrapper.find(Layout).props()).toEqual(
       expect.objectContaining({
-        asideWidth: 100,
         noBackground: true,
         noPadding: true,
       }),
@@ -31,19 +33,21 @@ describe('<SplitLayout />', () => {
   });
 
   it('renders before and after content', () => {
-    const wrapper = shallow(<SplitLayout before="Left" after="Right" />).dive();
+    const wrapper = shallow(
+      <SplitLayout before={<Aside>Left</Aside>} after={<Aside>Right</Aside>} />,
+    ).dive();
 
     expect(
       wrapper
-        .find('div')
-        .at(1)
+        .find(Aside)
+        .at(0)
         .prop('children'),
     ).toBe('Left');
 
     expect(
       wrapper
-        .find('div')
-        .at(2)
+        .find(Aside)
+        .at(1)
         .prop('children'),
     ).toBe('Right');
   });

--- a/packages/layouts/test/components/ThreeColumnLayout.test.tsx
+++ b/packages/layouts/test/components/ThreeColumnLayout.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Layout from '../../src/components/Layout';
+import Aside from '../../src/components/Aside';
 import ThreeColumnLayout from '../../src/components/ThreeColumnLayout';
 
 describe('<ThreeColumnLayout />', () => {
@@ -20,7 +21,7 @@ describe('<ThreeColumnLayout />', () => {
 
   it('renders and passes props to `Layout`', () => {
     const wrapper = shallow(
-      <ThreeColumnLayout fluid asideWidth={100} before="Left" after="Right">
+      <ThreeColumnLayout fluid before={<Aside>Left</Aside>} after={<Aside>Right</Aside>}>
         Child
       </ThreeColumnLayout>,
     );
@@ -28,10 +29,9 @@ describe('<ThreeColumnLayout />', () => {
     expect(wrapper.find(Layout).props()).toEqual(
       expect.objectContaining({
         children: 'Child',
-        before: 'Left',
-        after: 'Right',
+        before: <Aside>Left</Aside>,
+        after: <Aside>Right</Aside>,
         fluid: true,
-        asideWidth: 100,
       }),
     );
   });

--- a/packages/layouts/test/components/TwoColumnLayout.test.tsx
+++ b/packages/layouts/test/components/TwoColumnLayout.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Layout from '../../src/components/Layout';
+import Aside from '../../src/components/Aside';
 import TwoColumnLayout from '../../src/components/TwoColumnLayout';
 
 describe('<TwoColumnLayout />', () => {
@@ -15,7 +16,7 @@ describe('<TwoColumnLayout />', () => {
   it('errors if `before` and `after` are used at the same time', () => {
     expect(() => {
       shallow(
-        <TwoColumnLayout before after aside="Sidebar">
+        <TwoColumnLayout before after aside={<Aside>Sidebar</Aside>}>
           Child
         </TwoColumnLayout>,
       );
@@ -24,7 +25,7 @@ describe('<TwoColumnLayout />', () => {
 
   it('renders before and passes props to `Layout`', () => {
     const wrapper = shallow(
-      <TwoColumnLayout fluid before aside="Sidebar">
+      <TwoColumnLayout fluid before aside={<Aside>Sidebar</Aside>}>
         Child
       </TwoColumnLayout>,
     );
@@ -32,7 +33,7 @@ describe('<TwoColumnLayout />', () => {
     expect(wrapper.find(Layout).props()).toEqual(
       expect.objectContaining({
         children: 'Child',
-        before: 'Sidebar',
+        before: <Aside>Sidebar</Aside>,
         after: null,
         fluid: true,
       }),
@@ -41,7 +42,7 @@ describe('<TwoColumnLayout />', () => {
 
   it('renders after and passes props to `Layout`', () => {
     const wrapper = shallow(
-      <TwoColumnLayout fluid after aside="Sidebar">
+      <TwoColumnLayout fluid after aside={<Aside>Sidebar</Aside>}>
         Child
       </TwoColumnLayout>,
     );
@@ -49,7 +50,7 @@ describe('<TwoColumnLayout />', () => {
     expect(wrapper.find(Layout).props()).toEqual(
       expect.objectContaining({
         children: 'Child',
-        after: 'Sidebar',
+        after: <Aside>Sidebar</Aside>,
         before: null,
         fluid: true,
       }),

--- a/packages/layouts/test/components/__snapshots__/Layout.test.tsx.snap
+++ b/packages/layouts/test/components/__snapshots__/Layout.test.tsx.snap
@@ -1,6 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<Layout /> errors if invalid \`sideBar\` is passed 1`] = `
-"Warning: Failed prop type: Invalid prop \`sideBar\` of type \`string\` supplied to \`Layout\`, expected a single ReactElement.
-    in Layout"
-`;

--- a/packages/layouts/test/components/__snapshots__/LayoutShell.test.tsx.snap
+++ b/packages/layouts/test/components/__snapshots__/LayoutShell.test.tsx.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LayoutShell /> errors if invalid \`sideBar\` is passed 1`] = `
+"Warning: Failed prop type: Invalid prop \`sideBar\` of type \`string\` supplied to \`LayoutShell\`, expected a single ReactElement.
+    in LayoutShell"
+`;

--- a/packages/layouts/test/components/__snapshots__/LayoutShell.test.tsx.snap
+++ b/packages/layouts/test/components/__snapshots__/LayoutShell.test.tsx.snap
@@ -1,6 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<LayoutShell /> errors if invalid \`sideBar\` is passed 1`] = `
-"Warning: Failed prop type: Invalid prop \`sideBar\` of type \`string\` supplied to \`LayoutShell\`, expected a single ReactElement.
-    in LayoutShell"
-`;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

The current layout architecture is very basic and not at all useful for large applications. It was designed in such a way that the `*Layout` component must always be rendered at the root of the application, since it includes the side/top bars. This is quite problematic once apps become to complex, rely on crazy router logic, and need to adjust their layout based on many factors, but persist the sidebar.

This rework accomplishes the following:

- The side/top bar navigation logic has moved to a new component, `LayoutShell`, which should be rendered near the root. Now these bars will always persist across pages, regardless of how the content/router changes. 

- Asides should now be wrapped in a new `Aside` component, which handles the width, padding, and styling of the side columns. This opens up many future possibilities, for example, collapsible asides, scrollable content, variable width columns, and much more.

### Migration Guide

- Aside columns must be wrapped with `Aside`. The `asideWidth` prop has moved from all layout components to this new component.

```ts
// Before
<Layout asideWidth={300} before={<Column />} after={<Column />} />

// After
<Layout 
  before={<Aside width={300}><Column /></Aside>} 
  after={<Aside width={300}><Column /></Aside>} 
/>
```

- The `sideBar` prop has moved from all layout components to the new `LayoutShell` component.

```ts
// Before
<Layout sideBar={<SideBar />} />

// After
<LayoutShell sideBar={<SideBar />} />
  <Layout />
</LayoutShell>
```

## Motivation and Context

We want more control of how layouts are structured.

## Testing

Storybook.

## Screenshots

<img width="768" alt="Screen Shot 2019-06-14 at 1 26 48 PM" src="https://user-images.githubusercontent.com/143744/59537887-d32d6f00-8eac-11e9-9b79-73c1d1dee2a6.png">
<img width="1421" alt="Screen Shot 2019-06-14 at 1 26 58 PM" src="https://user-images.githubusercontent.com/143744/59537888-d32d6f00-8eac-11e9-9c71-cae83d25c4de.png">
<img width="699" alt="Screen Shot 2019-06-14 at 1 27 11 PM" src="https://user-images.githubusercontent.com/143744/59537889-d32d6f00-8eac-11e9-9a40-e9dd7e3aaa3c.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
