### PR TITLE
fix(DataTable): Correct sorting in ascending/descending order

### DIFF
--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -160,6 +160,14 @@ storiesOf('Core/DataTable', module)
     inspectComponents: [DataTable],
   })
   .add('A standard table.', () => <DataTable data={getData()} keys={['name', 'jobTitle']} />)
+  .add('A standard table with initial sorting.', () => (
+    <DataTable
+      data={getData()}
+      keys={['name', 'jobTitle']}
+      sortByOverride="name"
+      sortDirectionOverride="ASC"
+    />
+  ))
   .add('A table with selectable and exandable rows.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"

--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -96,8 +96,8 @@ export default function ColumnLabels({
               </span>
               {label && sortable && (
                 <SortCarets
-                  enableUp={sort === SortDirection.DESC}
-                  enableDown={sort === SortDirection.ASC}
+                  enableUp={sort === SortDirection.ASC}
+                  enableDown={sort === SortDirection.DESC}
                 />
               )}
             </div>

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -1,7 +1,7 @@
 import { SortDirection, SortDirectionType } from 'react-virtualized';
 import { GenericRow } from '../types';
 
-function sortAsc(a: any, b: any) {
+function sortDesc(a: any, b: any) {
   if (typeof b === 'undefined' || a < b) {
     return 1;
   }
@@ -9,7 +9,7 @@ function sortAsc(a: any, b: any) {
   return -1;
 }
 
-function sortDesc(a: any, b: any) {
+function sortAsc(a: any, b: any) {
   if (typeof b === 'undefined' || a < b) {
     return -1;
   }

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -408,6 +408,18 @@ describe('<DataTable /> renders and sorts data', () => {
 
     expect(text).toBe('Dev Ops Danny');
   });
+
+  it('should sort data in Descending order through props', () => {
+    const table = mount(
+      <DataTable {...simpleProps} sortByOverride="name" sortDirectionOverride="DESC" />,
+    );
+
+    const text = getCell(table, 1, NAME_COL)
+      .find(Text)
+      .text();
+
+    expect(text).toBe('Product Percy');
+  });
 });
 
 describe('<DataTable /> renders column labels', () => {

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -370,12 +370,12 @@ describe('<DataTable /> renders and sorts data', () => {
     expect(text).toBe(data[0].data.name);
   });
 
-  it('should sort data in Descending Order', () => {
+  it('should sort data in Descending order', () => {
     const table = mount(<DataTable {...simpleProps} />);
 
     const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').first();
     nameHeader.simulate('click');
-
+    nameHeader.simulate('click');
     const text = getCell(table, 1, NAME_COL)
       .find(Text)
       .text();
@@ -383,13 +383,24 @@ describe('<DataTable /> renders and sorts data', () => {
     expect(text).toBe('Product Percy');
   });
 
-  it('should sort data in Ascending Order', () => {
+  it('should sort data in Ascending order', () => {
     const table = mount(<DataTable {...simpleProps} />);
 
     const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').at(NAME_COL - 1);
     nameHeader.simulate('click');
-    nameHeader.simulate('click');
     table.update();
+
+    const text = getCell(table, 1, NAME_COL)
+      .find(Text)
+      .text();
+
+    expect(text).toBe('Dev Ops Danny');
+  });
+
+  it('should sort data in Ascending order through props', () => {
+    const table = mount(
+      <DataTable {...simpleProps} sortByOverride="name" sortDirectionOverride="ASC" />,
+    );
 
     const text = getCell(table, 1, NAME_COL)
       .find(Text)


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Previously I had flipped sortAsc and sortDesc to do the exact opposite. This didn't ordinarily come up unless developers used the overrideSortDirection prop and wasn't caught until now.

This change corrects sorting order, and adds a test and story for overrideSortDirection.

@milesj I made this change [here](https://github.com/airbnb/lunar/pull/97)) but built it on top of an existing branch and included commits, this is the PR with a clean commit history.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
