### PR TITLE
fix(StatusLabel): Add transparent border for height consistency.

### DIFF
--- a/packages/core/src/components/StatusLabel.story.tsx
+++ b/packages/core/src/components/StatusLabel.story.tsx
@@ -90,4 +90,12 @@ storiesOf('Core/StatusLabel', module)
         Info Inverted
       </StatusLabel>
     </>
+  ))
+  .add('Same height with or without border applied', () => (
+    <>
+      <StatusLabel>Default</StatusLabel>
+      <StatusLabel inverted bordered>
+        Default
+      </StatusLabel>
+    </>
   ));

--- a/packages/core/src/components/StatusLabel/index.tsx
+++ b/packages/core/src/components/StatusLabel/index.tsx
@@ -144,7 +144,7 @@ export default withStyles(({ color, font, ui, unit }) => ({
   },
 
   label_bordered: {
-    border: ui.border,
+    borderColor: color.accent.border,
   },
 
   label_compact: {

--- a/packages/core/src/components/StatusLabel/index.tsx
+++ b/packages/core/src/components/StatusLabel/index.tsx
@@ -135,6 +135,8 @@ export default withStyles(({ color, font, ui, unit }) => ({
     backgroundColor: color.core.neutral[1],
     color: color.accent.text,
     fontWeight: font.weights.semibold,
+    border: ui.border,
+    borderColor: 'transparent',
   },
 
   label_uppercased: {

--- a/packages/core/test/components/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/StatusLabel.test.tsx.snap
@@ -1,321 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<StatusLabel /> statuses renders bordered 1`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_notice_h3lmxn"
->
-  <span>
-    notice
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 2`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_info_5ni0mj"
->
-  <span>
-    info
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 3`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_success_9ngehh"
->
-  <span>
-    success
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 4`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_warning_kas06q"
->
-  <span>
-    warning
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 5`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_danger_p8x1nu"
->
-  <span>
-    danger
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 6`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_muted_s1bxkr"
->
-  <span>
-    muted
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 7`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_luxury_1ue0q2o"
->
-  <span>
-    luxury
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 8`] = `
-<span
-  className="label_1bayjlq-o_O-label_bordered_1urjdog-o_O-label_plus_ncs1rt"
->
-  <span>
-    plus
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 1`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_notice_a0aok"
->
-  <span>
-    notice
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 2`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_info_13z9huf"
->
-  <span>
-    info
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 3`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_success_1dekfjx"
->
-  <span>
-    success
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 4`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_warning_sew9to"
->
-  <span>
-    warning
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 5`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_danger_15o6i4l"
->
-  <span>
-    danger
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 6`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_muted_q8d046"
->
-  <span>
-    muted
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 7`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_luxury_1tvijvk"
->
-  <span>
-    luxury
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 8`] = `
-<span
-  className="label_1bayjlq-o_O-label_inverted_1jg2760-o_O-label_inverted_plus_1l928rd"
->
-  <span>
-    plus
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 1`] = `
-<span
-  className="label_1bayjlq-o_O-label_notice_h3lmxn"
->
-  <span>
-    notice
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 2`] = `
-<span
-  className="label_1bayjlq-o_O-label_info_5ni0mj"
->
-  <span>
-    info
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 3`] = `
-<span
-  className="label_1bayjlq-o_O-label_success_9ngehh"
->
-  <span>
-    success
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 4`] = `
-<span
-  className="label_1bayjlq-o_O-label_warning_kas06q"
->
-  <span>
-    warning
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 5`] = `
-<span
-  className="label_1bayjlq-o_O-label_danger_p8x1nu"
->
-  <span>
-    danger
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 6`] = `
-<span
-  className="label_1bayjlq-o_O-label_muted_s1bxkr"
->
-  <span>
-    muted
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 7`] = `
-<span
-  className="label_1bayjlq-o_O-label_luxury_1ue0q2o"
->
-  <span>
-    luxury
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders label 8`] = `
-<span
-  className="label_1bayjlq-o_O-label_plus_ncs1rt"
->
-  <span>
-    plus
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 1`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_notice_h3lmxn"
->
-  <span>
-    notice
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 2`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_info_5ni0mj"
->
-  <span>
-    info
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 3`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_success_9ngehh"
->
-  <span>
-    success
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 4`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_warning_kas06q"
->
-  <span>
-    warning
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 5`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_danger_p8x1nu"
->
-  <span>
-    danger
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 6`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_muted_s1bxkr"
->
-  <span>
-    muted
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 7`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_luxury_1ue0q2o"
->
-  <span>
-    luxury
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 8`] = `
-<span
-  className="label_1bayjlq-o_O-label_uppercased_4efw5a-o_O-label_plus_ncs1rt"
->
-  <span>
-    plus
-  </span>
-</span>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;

--- a/packages/core/test/components/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/StatusLabel.test.tsx.snap
@@ -1,193 +1,321 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<StatusLabel /> statuses renders bordered 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_notice_h3lmxn"
+>
+  <span>
+    notice
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 2`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_info_5ni0mj"
+>
+  <span>
+    info
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 3`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_success_9ngehh"
+>
+  <span>
+    success
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 4`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_warning_kas06q"
+>
+  <span>
+    warning
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 5`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_danger_p8x1nu"
+>
+  <span>
+    danger
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 6`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_muted_s1bxkr"
+>
+  <span>
+    muted
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 7`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_luxury_1ue0q2o"
+>
+  <span>
+    luxury
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders bordered 8`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_bordered_1f3aaih-o_O-label_plus_ncs1rt"
+>
+  <span>
+    plus
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_notice_a0aok"
+>
+  <span>
+    notice
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 2`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_info_13z9huf"
+>
+  <span>
+    info
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 3`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_success_1dekfjx"
+>
+  <span>
+    success
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 4`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_warning_sew9to"
+>
+  <span>
+    warning
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 5`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_danger_15o6i4l"
+>
+  <span>
+    danger
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 6`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_muted_q8d046"
+>
+  <span>
+    muted
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 7`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_luxury_1tvijvk"
+>
+  <span>
+    luxury
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders inverted state 8`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_inverted_1jg2760-o_O-label_inverted_plus_1l928rd"
+>
+  <span>
+    plus
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_notice_h3lmxn"
+>
+  <span>
+    notice
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 2`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_info_5ni0mj"
+>
+  <span>
+    info
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 3`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_success_9ngehh"
+>
+  <span>
+    success
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 4`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_warning_kas06q"
+>
+  <span>
+    warning
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 5`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_danger_p8x1nu"
+>
+  <span>
+    danger
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 6`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_muted_s1bxkr"
+>
+  <span>
+    muted
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 7`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_luxury_1ue0q2o"
+>
+  <span>
+    luxury
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders label 8`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_plus_ncs1rt"
+>
+  <span>
+    plus
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_notice_h3lmxn"
+>
+  <span>
+    notice
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 2`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_info_5ni0mj"
+>
+  <span>
+    info
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 3`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_success_9ngehh"
+>
+  <span>
+    success
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 4`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_warning_kas06q"
+>
+  <span>
+    warning
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 5`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_danger_p8x1nu"
+>
+  <span>
+    danger
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 6`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_muted_s1bxkr"
+>
+  <span>
+    muted
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 7`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_luxury_1ue0q2o"
+>
+  <span>
+    luxury
+  </span>
+</span>
 `;
 
 exports[`<StatusLabel /> statuses renders uppercased state 8`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<span
+  className="label_xffcmo-o_O-label_uppercased_4efw5a-o_O-label_plus_ncs1rt"
+>
+  <span>
+    plus
+  </span>
+</span>
 `;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

before (different heights for default vs bordered):
<img width="227" alt="Screen Shot 2019-06-21 at 4 07 19 PM" src="https://user-images.githubusercontent.com/306275/59955457-148ac500-943f-11e9-8de8-8065a0cd3374.png">
<img width="256" alt="Screen Shot 2019-06-21 at 4 07 33 PM" src="https://user-images.githubusercontent.com/306275/59955456-13f22e80-943f-11e9-8680-8d62876be5c6.png">


after:
<img width="537" alt="Storybook 2019-06-21 16-08-16" src="https://user-images.githubusercontent.com/306275/59955458-1a80a600-943f-11e9-8e6e-4d5b7598a8b9.png">


## Motivation and Context

consistency

## Testing

storybook

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
