### PR TITLE
build: Fix Storybook undefined length error

### DIFF
--- a/.storybook/addons/props/Panel.js
+++ b/.storybook/addons/props/Panel.js
@@ -57,6 +57,7 @@ export default class Panel extends React.Component {
           )}
         />
       ),
+      items: [],
     }));
 
     if (tabs.length === 1) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 [![Build Status](https://travis-ci.com/airbnb/lunar.svg?branch=master)](https://travis-ci.com/airbnb/lunar)
 
-React toolkit and design language for Airbnb open source and internal projects. It is _not_ for the
-general public.
+React toolkit and design language for Airbnb open source and internal projects.
+
+Lunar is built for Airbnb projects and _not_ the general public.
 
 </div>


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

A few stories are failing with "TypeError: Cannot read property 'length' of undefined". Looks like `Tabs` has an `items` property that doesn't check for existence, so this adds an empty array.

## Motivation and Context

Fix storybook.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
