### PR TITLE
fix(ToggleButtonController): Fix compact to render small buttons.

### DIFF
--- a/packages/core/src/components/ToggleButtonController.story.tsx
+++ b/packages/core/src/components/ToggleButtonController.story.tsx
@@ -87,13 +87,13 @@ storiesOf('Core/ToggleButtonController', module)
     >
       {ControlledButton => (
         <ButtonGroup>
-          <ControlledButton compact value="red" key="red">
+          <ControlledButton value="red" key="red">
             Red
           </ControlledButton>
-          <ControlledButton compact value="blue" key="blue">
+          <ControlledButton value="blue" key="blue">
             Blue
           </ControlledButton>
-          <ControlledButton compact value="green" key="green">
+          <ControlledButton value="green" key="green">
             Green
           </ControlledButton>
         </ButtonGroup>

--- a/packages/core/src/components/ToggleButtonController.story.tsx
+++ b/packages/core/src/components/ToggleButtonController.story.tsx
@@ -33,11 +33,11 @@ storiesOf('Core/ToggleButtonController', module)
   ))
   .add('Handles invalid state.', () => (
     <ToggleButtonController
+      invalid
       value="red"
       name="button-group-controller"
       label="Favorite color?"
       onChange={action('onChange')}
-      invalid
     >
       {ControlledButton => (
         <ButtonGroup>
@@ -56,11 +56,57 @@ storiesOf('Core/ToggleButtonController', module)
   ))
   .add('Handles disabled state.', () => (
     <ToggleButtonController
+      disabled
       value="red"
       name="button-group-controller"
       label="Favorite color?"
       onChange={action('onChange')}
-      disabled
+    >
+      {ControlledButton => (
+        <ButtonGroup>
+          <ControlledButton value="red" key="red">
+            Red
+          </ControlledButton>
+          <ControlledButton value="blue" key="blue">
+            Blue
+          </ControlledButton>
+          <ControlledButton value="green" key="green">
+            Green
+          </ControlledButton>
+        </ButtonGroup>
+      )}
+    </ToggleButtonController>
+  ))
+  .add('With `compact`', () => (
+    <ToggleButtonController
+      compact
+      value="red"
+      name="button-group-controller"
+      label="Favorite color?"
+      onChange={action('onChange')}
+    >
+      {ControlledButton => (
+        <ButtonGroup>
+          <ControlledButton compact value="red" key="red">
+            Red
+          </ControlledButton>
+          <ControlledButton compact value="blue" key="blue">
+            Blue
+          </ControlledButton>
+          <ControlledButton compact value="green" key="green">
+            Green
+          </ControlledButton>
+        </ButtonGroup>
+      )}
+    </ToggleButtonController>
+  ))
+  .add('With `inline`', () => (
+    <ToggleButtonController
+      inline
+      value="red"
+      name="button-group-controller"
+      label="Favorite color?"
+      onChange={action('onChange')}
     >
       {ControlledButton => (
         <ButtonGroup>

--- a/packages/core/src/components/ToggleButtonController/index.tsx
+++ b/packages/core/src/components/ToggleButtonController/index.tsx
@@ -64,7 +64,7 @@ export default class ToggleButtonController extends React.Component<Props, State
   };
 
   renderButton = proxyComponent(BaseButton, ({ children, value, ...props }: PropsProvided) => {
-    const { compact } = this.props;
+    const { compact, disabled, invalid } = this.props;
     const { id, value: selectedValue } = this.state;
     const selected = value === selectedValue;
 
@@ -74,9 +74,9 @@ export default class ToggleButtonController extends React.Component<Props, State
         id={`${id}-${value}`}
         name={name}
         value={value}
-        disabled={this.props.disabled}
+        disabled={disabled}
         inverted={!selected}
-        invalid={this.props.invalid}
+        invalid={invalid}
         small={compact}
         onClick={this.handleClick}
       >

--- a/packages/core/src/components/ToggleButtonController/index.tsx
+++ b/packages/core/src/components/ToggleButtonController/index.tsx
@@ -64,6 +64,7 @@ export default class ToggleButtonController extends React.Component<Props, State
   };
 
   renderButton = proxyComponent(BaseButton, ({ children, value, ...props }: PropsProvided) => {
+    const { compact } = this.props;
     const { id, value: selectedValue } = this.state;
     const selected = value === selectedValue;
 
@@ -76,6 +77,7 @@ export default class ToggleButtonController extends React.Component<Props, State
         disabled={this.props.disabled}
         inverted={!selected}
         invalid={this.props.invalid}
+        small={compact}
         onClick={this.handleClick}
       >
         {children}

--- a/packages/core/test/components/ToggleButtonController.test.tsx
+++ b/packages/core/test/components/ToggleButtonController.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
-import BaseButton from '../../src/componentsButton';
+import BaseButton from '../../src/components/Button';
 import ToggleButtonController from '../../src/components/ToggleButtonController';
 
 describe('<ToggleButtonController />', () => {

--- a/packages/core/test/components/ToggleButtonController.test.tsx
+++ b/packages/core/test/components/ToggleButtonController.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
-import BaseButton from '../../src/components/Button';
 import ToggleButtonController from '../../src/components/ToggleButtonController';
 
 describe('<ToggleButtonController />', () => {
@@ -43,7 +42,7 @@ describe('<ToggleButtonController />', () => {
   it('passes proxy component and current value to function child', () => {
     shallow(
       <ToggleButtonController {...props}>
-        {(Comp: BaseButton, values: string) => {
+        {(Comp, values: string) => {
           expect(typeof Comp).toBe('function');
           expect(values).toEqual('foo');
 
@@ -57,7 +56,7 @@ describe('<ToggleButtonController />', () => {
     const onChange = jest.fn();
     const wrapper = shallowWithStyles(
       <ToggleButtonController {...props} onChange={onChange} value="1">
-        {(ProxyButton: BaseButton) => (
+        {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -76,7 +75,7 @@ describe('<ToggleButtonController />', () => {
     const onChange = jest.fn();
     const wrapper = shallow(
       <ToggleButtonController {...props} onChange={onChange}>
-        {(ProxyButton: BaseButton) => (
+        {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -99,7 +98,7 @@ describe('<ToggleButtonController />', () => {
   it('inverts inactive buttons', () => {
     const wrapper = shallow(
       <ToggleButtonController {...props} value="1">
-        {(ProxyButton: BaseButton) => (
+        {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -134,7 +133,7 @@ describe('<ToggleButtonController />', () => {
   it('`compact` renders `small` buttons', () => {
     const wrapper = shallow(
       <ToggleButtonController {...props} compact value="1">
-        {(ProxyButton: BaseButton) => (
+        {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>

--- a/packages/core/test/components/ToggleButtonController.test.tsx
+++ b/packages/core/test/components/ToggleButtonController.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
+import BaseButton from '../../src/componentsButton';
 import ToggleButtonController from '../../src/components/ToggleButtonController';
 
 describe('<ToggleButtonController />', () => {
@@ -42,7 +43,7 @@ describe('<ToggleButtonController />', () => {
   it('passes proxy component and current value to function child', () => {
     shallow(
       <ToggleButtonController {...props}>
-        {(Comp, values) => {
+        {(Comp: BaseButton, values: string) => {
           expect(typeof Comp).toBe('function');
           expect(values).toEqual('foo');
 
@@ -56,7 +57,7 @@ describe('<ToggleButtonController />', () => {
     const onChange = jest.fn();
     const wrapper = shallowWithStyles(
       <ToggleButtonController {...props} onChange={onChange} value="1">
-        {ProxyButton => (
+        {(ProxyButton: BaseButton) => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -75,7 +76,7 @@ describe('<ToggleButtonController />', () => {
     const onChange = jest.fn();
     const wrapper = shallow(
       <ToggleButtonController {...props} onChange={onChange}>
-        {ProxyButton => (
+        {(ProxyButton: BaseButton) => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -98,7 +99,7 @@ describe('<ToggleButtonController />', () => {
   it('inverts inactive buttons', () => {
     const wrapper = shallow(
       <ToggleButtonController {...props} value="1">
-        {ProxyButton => (
+        {(ProxyButton: BaseButton) => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
             <ProxyButton value="2">2</ProxyButton>
@@ -127,6 +128,41 @@ describe('<ToggleButtonController />', () => {
         .find({ value: '3' })
         .dive()
         .prop('inverted'),
+    ).toBeTruthy();
+  });
+
+  it('`compact` renders `small` buttons', () => {
+    const wrapper = shallow(
+      <ToggleButtonController {...props} compact value="1">
+        {(ProxyButton: BaseButton) => (
+          <div>
+            <ProxyButton value="1">1</ProxyButton>
+            <ProxyButton value="2">2</ProxyButton>
+            <ProxyButton value="3">3</ProxyButton>
+          </div>
+        )}
+      </ToggleButtonController>,
+    );
+
+    expect(
+      wrapper
+        .find({ value: '1' })
+        .dive()
+        .prop('small'),
+    ).toBeTruthy();
+
+    expect(
+      wrapper
+        .find({ value: '2' })
+        .dive()
+        .prop('small'),
+    ).toBeTruthy();
+
+    expect(
+      wrapper
+        .find({ value: '3' })
+        .dive()
+        .prop('small'),
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- adds a story showing `<ToggleButtonController compact>` 
- adds a story showing `<ToggleButtonController inline>`
- fixes `compact` to render buttons as `small`: `compact` is not a valid prop for the base button; maps `compact` to `small`

## Motivation and Context

danks and i were chatting! he asked for a story showing compact

## Testing

locally and test updates

## Screenshots

<img width="1278" alt="Storybook 2019-06-26 14-35-24" src="https://user-images.githubusercontent.com/306275/60216962-568d7f80-9820-11e9-98f4-6a637eadcbf1.png">
<img width="1278" alt="Storybook 2019-06-26 14-34-59" src="https://user-images.githubusercontent.com/306275/60216963-568d7f80-9820-11e9-8448-00188a369ad8.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
