### PR TITLE
build: Add story examples to Storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,5 @@
 import './addons/props/register';
+import './addons/story/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-a11y/register';
 import '@storybook/addon-backgrounds/register';

--- a/.storybook/addons/props/index.js
+++ b/.storybook/addons/props/index.js
@@ -1,27 +1,6 @@
 import addons, { makeDecorator } from '@storybook/addons';
 import kebabCase from 'lodash/kebabCase';
-
-function stripHOCs(fullName) {
-  if (typeof fullName !== 'string') {
-    return fullName;
-  }
-
-  let innerName = fullName;
-
-  while (/\([^()]*\)/g.test(innerName)) {
-    let HOC = innerName;
-    let previousHOC;
-
-    do {
-      previousHOC = HOC;
-      HOC = previousHOC.replace(/\([^()]*\)/g, '');
-    } while (previousHOC !== HOC);
-
-    innerName = innerName.replace(RegExp(`^${HOC}\\(|\\)$`, 'g'), '');
-  }
-
-  return innerName;
-}
+import stripHOCs from '../../helpers/stripHOCs';
 
 export const withProps = makeDecorator({
   name: 'withProps',

--- a/.storybook/addons/story/Panel.js
+++ b/.storybook/addons/story/Panel.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+import { SyntaxHighlighter } from '@storybook/components';
+
+const Wrapper = styled.div({
+  padding: 16,
+  fontSize: 14,
+});
+
+export default class Panel extends React.Component {
+  static defaultProps = {
+    active: false,
+  };
+
+  state = {
+    storySource: '',
+  };
+
+  componentDidMount() {
+    this.props.channel.on('SET_STORY_DATA', this.handleSetData);
+  }
+
+  componentWillUnmount() {
+    this.props.channel.removeListener('SET_STORY_DATA', this.handleSetData);
+  }
+
+  handleSetData = ({ storySource }) => {
+    this.setState({ storySource });
+  };
+
+  render() {
+    const { active } = this.props;
+    const { storySource } = this.state;
+
+    if (!active) {
+      return null;
+    }
+
+    return (
+      <Wrapper>
+        <SyntaxHighlighter bordered copyable format={false} language="jsx">
+          {storySource}
+        </SyntaxHighlighter>
+      </Wrapper>
+    );
+  }
+}

--- a/.storybook/addons/story/index.js
+++ b/.storybook/addons/story/index.js
@@ -1,0 +1,23 @@
+import addons, { makeDecorator } from '@storybook/addons';
+import reactElementToJsxString from 'react-element-to-jsx-string';
+import stripHOCs from '../../helpers/stripHOCs';
+
+export const withStory = makeDecorator({
+  name: 'withStory',
+  parameterName: 'story',
+  wrapper: (getStory, context) => {
+    addons.getChannel().emit('SET_STORY_DATA', {
+      storySource: reactElementToJsxString(getStory(context), {
+        displayName: element =>
+          typeof element.type === 'string'
+            ? element.type
+            : stripHOCs(element.type.displayName || element.type.name),
+        functionValue: () => '(func)',
+        showDefaultProps: false,
+        sortProps: false,
+      }).replace(/\t/g, '  '),
+    });
+
+    return getStory(context);
+  },
+});

--- a/.storybook/addons/story/index.js
+++ b/.storybook/addons/story/index.js
@@ -6,18 +6,21 @@ export const withStory = makeDecorator({
   name: 'withStory',
   parameterName: 'story',
   wrapper: (getStory, context) => {
+    const story = getStory(context);
+    const storySource = reactElementToJsxString(story, {
+      displayName: element =>
+        typeof element.type === 'string'
+          ? element.type
+          : stripHOCs(element.type.displayName || element.type.name),
+      functionValue: () => '(func)',
+      showDefaultProps: false,
+      sortProps: false,
+    }).replace(/\t/g, '  ');
+
     addons.getChannel().emit('SET_STORY_DATA', {
-      storySource: reactElementToJsxString(getStory(context), {
-        displayName: element =>
-          typeof element.type === 'string'
-            ? element.type
-            : stripHOCs(element.type.displayName || element.type.name),
-        functionValue: () => '(func)',
-        showDefaultProps: false,
-        sortProps: false,
-      }).replace(/\t/g, '  '),
+      storySource,
     });
 
-    return getStory(context);
+    return story;
   },
 });

--- a/.storybook/addons/story/register.js
+++ b/.storybook/addons/story/register.js
@@ -2,9 +2,9 @@ import React from 'react';
 import addons, { types } from '@storybook/addons';
 import Panel from './Panel';
 
-addons.register('storybook/props', api => {
-  addons.add('storybook/props/panel', {
-    title: 'Info',
+addons.register('storybook/story', api => {
+  addons.add('storybook/story/panel', {
+    title: 'Story',
     type: types.PANEL,
     render: ({ active, key }) => (
       <Panel key={key} api={api} active={active} channel={addons.getChannel()} />

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,3 +1,4 @@
+import 'airbnb-js-shims';
 import React from 'react';
 import { stripHexcode } from 'emojibase';
 import { addDecorator, addParameters, configure } from '@storybook/react';
@@ -5,6 +6,7 @@ import { withContexts } from '@storybook/addon-contexts/react';
 import { withA11y } from '@storybook/addon-a11y';
 import Lunar from '@airbnb/lunar';
 import { withProps } from './addons/props';
+import { withStory } from './addons/story';
 import contexts from './contexts';
 
 Lunar.initialize({
@@ -19,6 +21,7 @@ Lunar.initialize({
 
 addDecorator(withA11y);
 addDecorator(withProps);
+addDecorator(withStory);
 addDecorator(withContexts(contexts));
 addDecorator(story => (
   <div style={{ padding: 20, fontSize: 15, fontFamily: Lunar.settings.fontFamily }}>{story()}</div>

--- a/.storybook/helpers/stripHOCs.js
+++ b/.storybook/helpers/stripHOCs.js
@@ -1,0 +1,21 @@
+export default function stripHOCs(fullName) {
+  if (typeof fullName !== 'string') {
+    return fullName;
+  }
+
+  let innerName = fullName;
+
+  while (/\([^()]*\)/g.test(innerName)) {
+    let HOC = innerName;
+    let previousHOC;
+
+    do {
+      previousHOC = HOC;
+      HOC = previousHOC.replace(/\([^()]*\)/g, '');
+    } while (previousHOC !== HOC);
+
+    innerName = innerName.replace(RegExp(`^${HOC}\\(|\\)$`, 'g'), '');
+  }
+
+  return innerName;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10241,6 +10241,11 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug=="
+    },
     "get-pkg-repo": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
@@ -11744,8 +11749,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -11772,6 +11776,11 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-root": {
       "version": "2.0.0",
@@ -15690,6 +15699,15 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-element-to-jsx-string": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.0.2.tgz",
+      "integrity": "sha512-eYcPUg3FJisgAb8q3sSdce8F/xMZD/iFEjMZYnkE3b7gPi5OamGr2Hst/1pE72mzn7//dfYPXb+UqPK2xdSGsg==",
+      "requires": {
+        "is-plain-object": "2.0.4",
+        "stringify-object": "3.2.2"
+      }
+    },
     "react-error-overlay": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
@@ -17333,6 +17351,16 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "^2.0.1",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9111,9 +9111,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.2.tgz",
-      "integrity": "sha512-L5rSdcOWQssiO7D1CWPwL9CT1ZG90PGhYQEfKOL3OC95ChQDA0S6AuP7Zi9dhaOaUihUXZ2oUlW2xeisF0nAaQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.3.tgz",
+      "integrity": "sha512-scDJbDhN+6S4ELXzzN96Fqm5y1CMRn+Io3C4Go+n/gUKP+LW26Wma6IxLSsX2eAMBUOFmyHKDBrUSuoHsycQ5A==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "@storybook/addon-viewport": "^5.1.9",
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",
-    "markdown-to-jsx": "^6.10.2"
+    "markdown-to-jsx": "^6.10.2",
+    "react-element-to-jsx-string": "^14.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-unicorn": "^9.1.1",
-    "fast-glob": "^3.0.2",
+    "fast-glob": "^3.0.3",
     "full-icu": "^1.3.0",
     "gh-pages": "^2.0.1",
     "jest": "^24.8.0",


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This has been a highly requested feature, so now we display the JSX examples for the stories! It works well for the most part but does not support the following:

- Components that use function children or React context.
- Stories that reference "demo" components.

## Motivation and Context

Make consumption easier.

## Testing

Storybook, obviously.

## Screenshots

<img width="469" alt="Screen Shot 2019-06-27 at 11 50 18 AM" src="https://user-images.githubusercontent.com/143744/60293470-29020e00-98d4-11e9-94b7-d119b5dc31a0.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
