### PR TITLE
update(Modal): Update padding, widths, scrollable content, and layout.

### DIFF
--- a/packages/core/src/components/Modal.story.tsx
+++ b/packages/core/src/components/Modal.story.tsx
@@ -13,7 +13,7 @@ class ModalDemo extends React.Component<
     showFluid?: boolean;
     showFooter?: boolean;
     showLarge?: boolean;
-    showMedium?: boolean;
+    showSmall?: boolean;
     showScrollable?: boolean;
     showSubtitle?: boolean;
     showTitle?: boolean;
@@ -33,7 +33,7 @@ class ModalDemo extends React.Component<
       showFluid,
       showFooter,
       showLarge,
-      showMedium,
+      showSmall,
       showScrollable,
       showSubtitle,
       showTitle,
@@ -68,15 +68,15 @@ class ModalDemo extends React.Component<
               }
             }
             large={showLarge}
-            medium={showMedium}
             scrollable={showScrollable}
+            small={showSmall}
             subtitle={showSubtitle ? 'Modal Sub-Title' : undefined}
             title={showTitle ? 'Modal Title' : undefined}
             onClose={this.handleClose}
           >
             <Text>
               <LoremIpsum />
-              {(showLarge || showMedium) && showScrollable && (
+              {(showLarge || !showSmall) && showScrollable && (
                 <>
                   <LoremIpsum /> <LoremIpsum />
                 </>
@@ -93,16 +93,16 @@ storiesOf('Core/Modal', module)
   .addParameters({
     inspectComponents: [Modal],
   })
-  .add('A minimum modal (400px)', () => <ModalDemo />)
-  .add('A medium modal (600px)', () => <ModalDemo showMedium />)
-  .add('A large modal (800px)', () => <ModalDemo showLarge />)
-  .add('A fluid modal', () => <ModalDemo showFluid showTitle />)
+  .add('Default modal (600px)', () => <ModalDemo />)
+  .add('Small modal (400px)', () => <ModalDemo showSmall />)
+  .add('Large modal (800px)', () => <ModalDemo showLarge />)
+  .add('Fluid modal', () => <ModalDemo showFluid showTitle />)
   .add('With title', () => <ModalDemo showTitle />)
   .add('With subtitle', () => <ModalDemo showSubtitle showTitle />)
   .add('With title and footer', () => <ModalDemo showFooter showTitle />)
-  .add('Minimum scrollable content', () => <ModalDemo showFooter showTitle showScrollable />)
-  .add('Medium scrollable content', () => (
-    <ModalDemo showMedium showFooter showTitle showScrollable />
+  .add('Scrollable content', () => <ModalDemo showFooter showTitle showScrollable />)
+  .add('Small scrollable content', () => (
+    <ModalDemo showSmall showFooter showTitle showScrollable />
   ))
   .add('Large scrollable content', () => (
     <ModalDemo showLarge showFooter showTitle showScrollable />

--- a/packages/core/src/components/Modal.story.tsx
+++ b/packages/core/src/components/Modal.story.tsx
@@ -4,13 +4,20 @@ import LoremIpsum from ':storybook/components/LoremIpsum';
 import moon from ':storybook/images/moon.png';
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
-import Spacing from './Spacing';
-import Tooltip from './Tooltip';
 import Text from './Text';
 import Modal from './Modal';
 
 class ModalDemo extends React.Component<
-  { large?: boolean; noTitle?: boolean; image?: 'center' | 'cover' },
+  {
+    image?: 'center' | 'cover';
+    showFluid?: boolean;
+    showFooter?: boolean;
+    showLarge?: boolean;
+    showMedium?: boolean;
+    showScrollable?: boolean;
+    showSubtitle?: boolean;
+    showTitle?: boolean;
+  },
   { visible: boolean }
 > {
   state = { visible: false };
@@ -21,7 +28,16 @@ class ModalDemo extends React.Component<
 
   render() {
     const { visible } = this.state;
-    const { image, large, noTitle } = this.props;
+    const {
+      image,
+      showFluid,
+      showFooter,
+      showLarge,
+      showMedium,
+      showScrollable,
+      showSubtitle,
+      showTitle,
+    } = this.props;
 
     return (
       <div>
@@ -30,42 +46,42 @@ class ModalDemo extends React.Component<
         <br />
         <br />
 
-        {(image || large) && <Text>(May need to resize your browser to view the example)</Text>}
+        {image && <Text>(May need to resize your browser to view the example)</Text>}
 
         {visible && (
           <Modal
+            fluid={showFluid}
+            footer={
+              showFooter && (
+                <ButtonGroup>
+                  <Button onClick={this.handleToggle}>OK</Button>
+                  <Button inverted onClick={this.handleToggle}>
+                    Cancel
+                  </Button>
+                </ButtonGroup>
+              )
+            }
             image={
               image && {
                 type: image,
                 url: moon,
               }
             }
-            large={large}
-            footer={
-              <ButtonGroup>
-                <Button onClick={this.handleToggle}>OK</Button>
-                <Button inverted onClick={this.handleToggle}>
-                  Cancel
-                </Button>
-              </ButtonGroup>
-            }
+            large={showLarge}
+            medium={showMedium}
+            scrollable={showScrollable}
+            subtitle={showSubtitle ? 'Modal Sub-Title' : undefined}
+            title={showTitle ? 'Modal Title' : undefined}
             onClose={this.handleClose}
-            title={noTitle ? undefined : 'Modal Title'}
           >
-            <div>
-              <Text>
-                <LoremIpsum />
-              </Text>
-
-              <Spacing top={2}>
-                <Tooltip
-                  content="Tooltips are an anti-pattern! Please think carefully about accessibility before using them. Do not use tooltips for content that cannot be discovered by other means."
-                  remainOnMouseDown
-                >
-                  <Button>Hover Me</Button>
-                </Tooltip>
-              </Spacing>
-            </div>
+            <Text>
+              <LoremIpsum />
+              {(showLarge || showMedium) && showScrollable && (
+                <>
+                  <LoremIpsum /> <LoremIpsum />
+                </>
+              )}
+            </Text>
           </Modal>
         )}
       </div>
@@ -77,8 +93,19 @@ storiesOf('Core/Modal', module)
   .addParameters({
     inspectComponents: [Modal],
   })
-  .add('A standard modal.', () => <ModalDemo />)
-  .add('A large modal.', () => <ModalDemo large />)
-  .add('With no title.', () => <ModalDemo noTitle />)
-  .add('With a centered image.', () => <ModalDemo image="center" />)
-  .add('With a right cover image.', () => <ModalDemo image="cover" />);
+  .add('A minimum modal (400px)', () => <ModalDemo />)
+  .add('A medium modal (600px)', () => <ModalDemo showMedium showTitle />)
+  .add('A large modal (800px)', () => <ModalDemo showLarge showTitle />)
+  .add('A fluid modal', () => <ModalDemo showFluid showTitle />)
+  .add('With title', () => <ModalDemo showTitle />)
+  .add('With title and footer', () => <ModalDemo showFooter showTitle />)
+  .add('With subtitle', () => <ModalDemo showSubtitle showTitle />)
+  .add('Minimum scrollable content', () => <ModalDemo showFooter showTitle showScrollable />)
+  .add('Medium scrollable content', () => (
+    <ModalDemo showMedium showFooter showTitle showScrollable />
+  ))
+  .add('Large scrollable content', () => (
+    <ModalDemo showLarge showFooter showTitle showScrollable />
+  ))
+  .add('With a right, centered image.', () => <ModalDemo showFooter showTitle image="center" />)
+  .add('With a right, covered image.', () => <ModalDemo showFooter showTitle image="cover" />);

--- a/packages/core/src/components/Modal.story.tsx
+++ b/packages/core/src/components/Modal.story.tsx
@@ -94,12 +94,12 @@ storiesOf('Core/Modal', module)
     inspectComponents: [Modal],
   })
   .add('A minimum modal (400px)', () => <ModalDemo />)
-  .add('A medium modal (600px)', () => <ModalDemo showMedium showTitle />)
-  .add('A large modal (800px)', () => <ModalDemo showLarge showTitle />)
+  .add('A medium modal (600px)', () => <ModalDemo showMedium />)
+  .add('A large modal (800px)', () => <ModalDemo showLarge />)
   .add('A fluid modal', () => <ModalDemo showFluid showTitle />)
   .add('With title', () => <ModalDemo showTitle />)
-  .add('With title and footer', () => <ModalDemo showFooter showTitle />)
   .add('With subtitle', () => <ModalDemo showSubtitle showTitle />)
+  .add('With title and footer', () => <ModalDemo showFooter showTitle />)
   .add('Minimum scrollable content', () => <ModalDemo showFooter showTitle showScrollable />)
   .add('Medium scrollable content', () => (
     <ModalDemo showMedium showFooter showTitle showScrollable />

--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -60,7 +60,7 @@ export default withStyles(({ color, unit }) => ({
     display: 'flex',
     justifyContent: 'center',
     minHeight: '100%',
-    padding: unit * 8,
+    padding: unit * 2,
     width: '100%',
   },
 }))(Modal);

--- a/packages/core/src/components/Modal/private/ImageLayout.tsx
+++ b/packages/core/src/components/Modal/private/ImageLayout.tsx
@@ -52,7 +52,7 @@ class ModalImageLayout extends React.Component<Props & WithStylesProps> {
   }
 }
 
-export default withStyles(({ breakpoints, ui, unit }) => ({
+export default withStyles(({ responsive, ui, unit }) => ({
   splitContent: {
     display: 'flex',
   },
@@ -70,7 +70,7 @@ export default withStyles(({ breakpoints, ui, unit }) => ({
     position: 'relative',
 
     '@media': {
-      [`(max-width: ${breakpoints.xsmall}px)`]: {
+      [responsive.xsmall]: {
         display: 'none',
       },
     },

--- a/packages/core/src/components/Modal/private/ImageLayout.tsx
+++ b/packages/core/src/components/Modal/private/ImageLayout.tsx
@@ -30,13 +30,14 @@ class ModalImageLayout extends React.Component<Props & WithStylesProps> {
         <div className={cx(styles.splitContentPane, styles.splitContentImagePane)}>
           {type === 'center' && (
             <img
-              className={cx(styles.image, styles.imageMaxHeight, styles.imageCentered)}
+              className={cx(styles.image)}
               src={url}
               srcSet={srcSet && srcSet.join(',')}
               sizes={sizes && sizes.join(',')}
               alt=""
             />
           )}
+
           {type === 'cover' && (
             <img
               className={cx(styles.image, styles.imageCover)}
@@ -51,7 +52,7 @@ class ModalImageLayout extends React.Component<Props & WithStylesProps> {
   }
 }
 
-export default withStyles(({ responsive }) => ({
+export default withStyles(({ breakpoints, ui, unit }) => ({
   splitContent: {
     display: 'flex',
   },
@@ -61,6 +62,7 @@ export default withStyles(({ responsive }) => ({
   },
 
   splitContentImagePane: {
+    borderLeft: ui.border,
     alignItems: 'center',
     display: 'flex',
     justifyContent: 'center',
@@ -68,7 +70,7 @@ export default withStyles(({ responsive }) => ({
     position: 'relative',
 
     '@media': {
-      [responsive.small]: {
+      [`(max-width: ${breakpoints.xsmall}px)`]: {
         display: 'none',
       },
     },
@@ -76,32 +78,16 @@ export default withStyles(({ responsive }) => ({
 
   image: {
     display: 'block',
+    objectFit: 'contain',
     maxWidth: '100%',
-
-    '@media': {
-      [responsive.small]: {
-        maxHeight: MAX_HEIGHT_IMAGE_SMALL,
-      },
-    },
-  },
-
-  imageMaxHeight: {
-    maxHeight: MAX_HEIGHT_IMAGE,
-  },
-
-  imageCentered: {
-    marginLeft: 'auto',
-    marginRight: 'auto',
+    maxHeight: '100%',
+    margin: unit * 3,
   },
 
   imageCover: {
+    objectFit: 'cover',
     height: '100%',
-    minWidth: '100%',
-    width: 'auto',
-    maxWidth: 'none',
-    position: 'absolute',
-    left: '50%',
-    top: '50%',
-    transform: 'translateX(-50%) translateY(-50%)',
+    width: '100%',
+    margin: 0,
   },
 }))(ModalImageLayout);

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -76,7 +76,7 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
       footer,
       image,
       large,
-      medium,
+      small,
       fluid,
       scrollable,
       styles,
@@ -84,13 +84,13 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
       title,
     } = this.props;
 
-    const showLargeContent = large || medium || !!image;
+    const showLargeContent = large || !small || !!image;
 
     const innerContent = (
       <ModalInnerContent
         footer={footer}
         large={showLargeContent}
-        medium={medium && !showLargeContent}
+        small={small}
         scrollable={scrollable}
         subtitle={subtitle}
         title={title}
@@ -107,7 +107,7 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
         ref={this.dialogRef}
         className={cx(
           styles.content,
-          medium && styles.content_medium,
+          small && styles.content_small,
           (large || !!image) && styles.content_large,
           fluid && styles.content_fluid,
         )}
@@ -125,7 +125,7 @@ export default withStyles(({ color, responsive, ui }) => ({
     backgroundColor: color.accent.bg,
     borderRadius: ui.borderRadius,
     boxShadow: ui.boxShadowLarge,
-    maxWidth: MODAL_MAX_WIDTH_SMALL,
+    maxWidth: MODAL_MAX_WIDTH_MEDIUM,
     position: 'relative',
     width: '100%',
 
@@ -134,8 +134,8 @@ export default withStyles(({ color, responsive, ui }) => ({
     },
   },
 
-  content_medium: {
-    maxWidth: MODAL_MAX_WIDTH_MEDIUM,
+  content_small: {
+    maxWidth: MODAL_MAX_WIDTH_SMALL,
   },
 
   content_large: {

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -5,11 +5,15 @@ import focusFirstFocusableChild from '../../../utils/focus/focusFirstFocusableCh
 import ModalImageLayout, { ModalImageConfig } from './ImageLayout';
 import ModalInnerContent, { Props as ModalInnerContentProps } from './InnerContent';
 
-export const MODAL_MAX_WIDTH_SMALL = 568;
+export const MODAL_MAX_WIDTH_SMALL = 400;
+export const MODAL_MAX_WIDTH_MEDIUM = 600;
+export const MODAL_MAX_WIDTH_LARGE = 800;
 
 export type Props = ModalInnerContentProps & {
   /** Image configuration to be used as the right pane in a dual pane layout. If provided, will force the modal to a `large` layout. */
   image?: ModalImageConfig;
+  /** Fluid width, no max width. */
+  fluid?: boolean;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
@@ -66,15 +70,31 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
   };
 
   render() {
-    const { cx, children, footer, image, large, styles, title } = this.props;
-    const showLargeContent = large || !!image;
+    const {
+      cx,
+      children,
+      footer,
+      image,
+      large,
+      medium,
+      fluid,
+      scrollable,
+      styles,
+      subtitle,
+      title,
+    } = this.props;
+
+    const showLargeContent = large || medium || !!image;
 
     const innerContent = (
       <ModalInnerContent
         footer={footer}
         large={showLargeContent}
-        onClose={this.handleClose}
+        medium={medium && !showLargeContent}
+        scrollable={scrollable}
+        subtitle={subtitle}
         title={title}
+        onClose={this.handleClose}
       >
         {children}
       </ModalInnerContent>
@@ -85,7 +105,12 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
         aria-modal
         role="dialog"
         ref={this.dialogRef}
-        className={cx(styles.content, showLargeContent && styles.responsiveContent)}
+        className={cx(
+          styles.content,
+          medium && styles.content_medium,
+          (large || !!image) && styles.content_large,
+          fluid && styles.content_fluid,
+        )}
       >
         <FocusTrap>
           {image ? <ModalImageLayout {...image}>{innerContent}</ModalImageLayout> : innerContent}
@@ -98,23 +123,31 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
 export default withStyles(({ color, responsive, ui }) => ({
   content: {
     backgroundColor: color.accent.bg,
+    borderRadius: ui.borderRadius,
+    boxShadow: ui.boxShadowLarge,
     maxWidth: MODAL_MAX_WIDTH_SMALL,
     position: 'relative',
     width: '100%',
-    boxShadow: ui.boxShadowLarge,
-    borderRadius: ui.borderRadius,
 
     ':focus': {
       outline: 'none',
     },
   },
 
-  responsiveContent: {
+  content_medium: {
+    maxWidth: MODAL_MAX_WIDTH_MEDIUM,
+  },
+
+  content_large: {
+    maxWidth: MODAL_MAX_WIDTH_LARGE,
+  },
+
+  content_fluid: {
     maxWidth: '70%',
 
     '@media': {
       [responsive.small]: {
-        maxWidth: MODAL_MAX_WIDTH_SMALL,
+        maxWidth: '85%',
       },
     },
   },

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -117,8 +117,7 @@ export default withStyles(({ color, ui, unit }) => ({
     position: 'static',
     top: 0,
     right: 0,
-    marginTop: unit * 2,
-    marginRight: unit * 2,
+    margin: `${unit * 2}px ${unit * 2}px ${unit / 2}px ${unit / 2}px`,
   },
 
   body: {

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -6,6 +6,7 @@ import Title from '../../Title';
 import IconButton from '../../IconButton';
 import T from '../../Translate';
 import useTheme from '../../../hooks/useTheme';
+import toRGBA from '../../../utils/toRGBA';
 
 export type Props = {
   /** Dialog content. */
@@ -14,10 +15,10 @@ export type Props = {
   footer?: React.ReactNode;
   /** Show the large version of the Dialog. */
   large?: boolean;
-  /** Show the medium version of the Dialog. */
-  medium?: boolean;
   /** Modal content height becomes scrollable. */
   scrollable?: boolean;
+  /** Show the small version of the Dialog. */
+  small?: boolean;
   /** Dialog header subtitle. */
   subtitle?: React.ReactNode;
   /** Dialog header title. */
@@ -32,7 +33,7 @@ function ModalInnerContent({
   cx,
   footer,
   large,
-  medium,
+  small,
   onClose,
   scrollable,
   styles,
@@ -68,7 +69,7 @@ function ModalInnerContent({
           !withHeader && styles.body_paddingTop,
           !withFooter && styles.body_paddingBottom,
           scrollable && styles.body_scrollable,
-          scrollable && (medium || large) && styles.body_scrollableLarge,
+          scrollable && (!small || large) && styles.body_scrollableLarge,
         )}
       >
         {children}
@@ -102,7 +103,10 @@ export default withStyles(({ color, ui, unit }) => ({
       left: 0,
       right: 0,
       height: unit / 2,
-      background: 'linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, 0))',
+      background: `linear-gradient(${toRGBA(color.core.neutral[6], 15)}, ${toRGBA(
+        color.core.neutral[6],
+        0,
+      )})`,
     },
   },
 

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import IconClose from '@airbnb/lunar-icons/lib/interface/IconClose';
+import withStyles, { WithStylesProps } from '../../../composers/withStyles';
+import Text from '../../Text';
 import Title from '../../Title';
-import Spacing from '../../Spacing';
 import IconButton from '../../IconButton';
 import T from '../../Translate';
 import useTheme from '../../../hooks/useTheme';
@@ -11,8 +12,14 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Footer content. */
   footer?: React.ReactNode;
-  /** True to show the large version of the Dialog. */
+  /** Show the large version of the Dialog. */
   large?: boolean;
+  /** Show the medium version of the Dialog. */
+  medium?: boolean;
+  /** Modal content height becomes scrollable. */
+  scrollable?: boolean;
+  /** Dialog header subtitle. */
+  subtitle?: React.ReactNode;
   /** Dialog header title. */
   title?: React.ReactNode;
   /** Callback for when the Dialog should be closed.  */
@@ -20,31 +27,132 @@ export type Props = {
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
-export default function ModalInnerContent({ children, footer, large, onClose, title }: Props) {
+function ModalInnerContent({
+  children,
+  cx,
+  footer,
+  large,
+  medium,
+  onClose,
+  scrollable,
+  styles,
+  subtitle,
+  title,
+}: Props & WithStylesProps) {
   const theme = useTheme();
+  const withHeader = Boolean(title || subtitle);
+  const withFooter = Boolean(footer);
 
   return (
-    <Spacing bottom={6} horizontal={4} top={4}>
-      <Spacing bottom={title ? 3 : 0} tag="header">
-        <Spacing bottom={4}>
-          <IconButton onClick={onClose}>
-            <IconClose
-              accessibilityLabel={T.phrase('Close', {}, 'Close a modal popup')}
-              size={3 * theme.unit}
-            />
-          </IconButton>
-        </Spacing>
+    <div
+      className={cx(
+        styles.wrapper,
+        !withHeader && styles.wrapper_paddingTop,
+        !withFooter && styles.wrapper_paddingBottom,
+      )}
+    >
+      {withHeader && (
+        <header className={cx(styles.header, scrollable && styles.header_scrollable)}>
+          {title && <Title level={3}>{title}</Title>}
+          {subtitle && <Text muted>{subtitle}</Text>}
+        </header>
+      )}
 
-        {title && <Title level={large ? 1 : 3}>{title}</Title>}
-      </Spacing>
+      <div className={cx(styles.close)}>
+        <IconButton onClick={onClose}>
+          <IconClose
+            accessibilityLabel={T.phrase('Close', {}, 'Close a modal popup')}
+            color={theme.color.muted}
+            size={theme.unit * 3}
+          />
+        </IconButton>
+      </div>
 
-      {children}
+      <div
+        className={cx(
+          styles.body,
+          scrollable && styles.body_scrollable,
+          scrollable && (medium || large) && styles.body_scrollableLarge,
+        )}
+      >
+        {children}
+      </div>
 
       {footer && (
-        <Spacing tag="footer" top={4}>
+        <footer className={cx(styles.footer, scrollable && styles.footer_scrollable)}>
           {footer}
-        </Spacing>
+        </footer>
       )}
-    </Spacing>
+    </div>
   );
 }
+
+export default withStyles(({ color, ui, unit }) => ({
+  wrapper: {
+    position: 'relative',
+  },
+
+  wrapper_paddingBottom: {
+    paddingBottom: unit * 3,
+  },
+
+  wrapper_paddingTop: {
+    paddingTop: unit * 3,
+  },
+
+  header: {
+    padding: unit * 3,
+  },
+
+  header_scrollable: {
+    position: 'relative',
+
+    ':after': {
+      content: '" "',
+      position: 'absolute',
+      top: '100%',
+      left: 0,
+      right: 0,
+      height: unit / 2,
+      background: 'linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, 0))',
+    },
+  },
+
+  close: {
+    position: 'absolute',
+    top: unit * 2,
+    right: unit * 2,
+  },
+
+  body: {
+    padding: `0 ${unit * 3}px`,
+  },
+
+  body_scrollable: {
+    paddingBottom: unit * 3,
+    maxHeight: 160,
+    overflow: 'auto',
+
+    ':before': {
+      content: '" "',
+      position: 'sticky',
+      display: 'block',
+      width: `calc(100% + ${unit * 6}px)`,
+      marginLeft: -unit * 3,
+      height: unit / 2,
+      background: color.accent.bg,
+    },
+  },
+
+  body_scrollableLarge: {
+    maxHeight: 300,
+  },
+
+  footer: {
+    padding: unit * 3,
+  },
+
+  footer_scrollable: {
+    borderTop: ui.border,
+  },
+}))(ModalInnerContent);

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -44,13 +44,7 @@ function ModalInnerContent({
   const withFooter = Boolean(footer);
 
   return (
-    <div
-      className={cx(
-        styles.wrapper,
-        !withHeader && styles.wrapper_paddingTop,
-        !withFooter && styles.wrapper_paddingBottom,
-      )}
-    >
+    <div className={cx(styles.wrapper)}>
       {withHeader && (
         <header className={cx(styles.header, scrollable && styles.header_scrollable)}>
           {title && <Title level={3}>{title}</Title>}
@@ -58,7 +52,7 @@ function ModalInnerContent({
         </header>
       )}
 
-      <div className={cx(styles.close)}>
+      <div className={cx(styles.close, !withHeader && styles.close_float)}>
         <IconButton onClick={onClose}>
           <IconClose
             accessibilityLabel={T.phrase('Close', {}, 'Close a modal popup')}
@@ -71,6 +65,8 @@ function ModalInnerContent({
       <div
         className={cx(
           styles.body,
+          !withHeader && styles.body_paddingTop,
+          !withFooter && styles.body_paddingBottom,
           scrollable && styles.body_scrollable,
           scrollable && (medium || large) && styles.body_scrollableLarge,
         )}
@@ -90,14 +86,6 @@ function ModalInnerContent({
 export default withStyles(({ color, ui, unit }) => ({
   wrapper: {
     position: 'relative',
-  },
-
-  wrapper_paddingBottom: {
-    paddingBottom: unit * 3,
-  },
-
-  wrapper_paddingTop: {
-    paddingTop: unit * 3,
   },
 
   header: {
@@ -124,8 +112,25 @@ export default withStyles(({ color, ui, unit }) => ({
     right: unit * 2,
   },
 
+  close_float: {
+    float: 'right',
+    position: 'static',
+    top: 0,
+    right: 0,
+    marginTop: unit * 2,
+    marginRight: unit * 2,
+  },
+
   body: {
     padding: `0 ${unit * 3}px`,
+  },
+
+  body_paddingBottom: {
+    paddingBottom: unit * 3,
+  },
+
+  body_paddingTop: {
+    paddingTop: unit * 3,
   },
 
   body_scrollable: {

--- a/packages/core/src/themes/size.ts
+++ b/packages/core/src/themes/size.ts
@@ -1,6 +1,7 @@
 import { Theme } from '../types';
 
 export const breakpoints = {
+  xsmall: 767,
   small: 980,
   medium: 1280,
   large: 1690,

--- a/packages/core/src/themes/size.ts
+++ b/packages/core/src/themes/size.ts
@@ -8,6 +8,7 @@ export const breakpoints = {
 };
 
 export const responsive: Theme['responsive'] = {
+  xsmall: `(max-width: ${breakpoints.xsmall}px)`,
   small: `(max-width: ${breakpoints.medium - 1}px)`,
   medium: `(min-width: ${breakpoints.medium}px)`,
   large: `(min-width: ${breakpoints.large}px)`,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,6 +152,7 @@ export type Theme = {
     large: string;
     medium: string;
     small: string;
+    xsmall: string;
   };
   transition: {
     box: StyleBlock;

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -151,7 +151,13 @@ describe('<Modal />', () => {
 
   it('same class for image as large size', () => {
     const wrapper = shallowWithStyles(
-      <ModalInner image="foo.jpg" onClose={jest.fn()}>
+      <ModalInner
+        image={{
+          type: 'center',
+          url: 'some_image',
+        }}
+        onClose={jest.fn()}
+      >
         Foo
       </ModalInner>,
     );

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -5,7 +5,7 @@ import Modal, { Props } from '../../src/components/Modal';
 import ModalImageLayout from '../../src/components/Modal/private/ImageLayout';
 import ModalInner from '../../src/components/Modal/private/Inner';
 import ModalInnerContent from '../../src/components/Modal/private/InnerContent';
-import Spacing from '../../src/components/Spacing';
+import Text from '../../src/components/Text';
 import Title from '../../src/components/Title';
 import { ESCAPE } from '../../src/keys';
 import focusFirstFocusableChild from '../../src/utils/focus/focusFirstFocusableChild';
@@ -217,10 +217,41 @@ describe('<Modal />', () => {
     expect(titleWrapper.prop('children')).toBe('Title wave');
   });
 
-  it('adjusts header spacing if no title is provided', () => {
+  it('renders a subtitle', () => {
+    const { wrapper } = setup(
+      {
+        title: 'Title wave',
+        subtitle: 'Subtitle',
+      },
+      false /* isShallow */,
+    );
+
+    expect(wrapper.find('header')).toHaveLength(1);
+
+    expect(
+      wrapper
+        .find('header')
+        .find(Text)
+        .prop('children'),
+    ).toBe('Subtitle');
+  });
+
+  it('no header if no title is provided', () => {
     const { wrapper } = setup(
       {
         title: null,
+      },
+      false /* isShallow */,
+    );
+
+    expect(wrapper.find('header')).toHaveLength(0);
+  });
+
+  it('no header if no title or subtitle are provided', () => {
+    const { wrapper } = setup(
+      {
+        title: null,
+        subtitle: null,
       },
       false /* isShallow */,
     );

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -128,29 +128,49 @@ describe('<Modal />', () => {
   });
 
   it('different class for small size', () => {
-    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
-    const small = shallowWithStyles(<ModalInner small>Foo</ModalInner>);
+    const wrapper = shallowWithStyles(<ModalInner onClose={jest.fn()}>Foo</ModalInner>);
+    const small = shallowWithStyles(
+      <ModalInner small onClose={jest.fn()}>
+        Foo
+      </ModalInner>,
+    );
 
     expect(wrapper.prop('className')).not.toBe(small.prop('className'));
   });
 
   it('different class for large size', () => {
-    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
-    const large = shallowWithStyles(<ModalInner large>Foo</ModalInner>);
+    const wrapper = shallowWithStyles(<ModalInner onClose={jest.fn()}>Foo</ModalInner>);
+    const large = shallowWithStyles(
+      <ModalInner large onClose={jest.fn()}>
+        Foo
+      </ModalInner>,
+    );
 
     expect(wrapper.prop('className')).not.toBe(large.prop('className'));
   });
 
   it('same class for image as large size', () => {
-    const wrapper = shallowWithStyles(<ModalInner image="foo.jpg">Foo</ModalInner>);
-    const large = shallowWithStyles(<ModalInner large>Foo</ModalInner>);
+    const wrapper = shallowWithStyles(
+      <ModalInner image="foo.jpg" onClose={jest.fn()}>
+        Foo
+      </ModalInner>,
+    );
+    const large = shallowWithStyles(
+      <ModalInner large onClose={jest.fn()}>
+        Foo
+      </ModalInner>,
+    );
 
     expect(wrapper.prop('className')).toBe(large.prop('className'));
   });
 
   it('different class for fluid size', () => {
-    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
-    const fluid = shallowWithStyles(<ModalInner fluid>Foo</ModalInner>);
+    const wrapper = shallowWithStyles(<ModalInner onClose={jest.fn()}>Foo</ModalInner>);
+    const fluid = shallowWithStyles(
+      <ModalInner fluid onClose={jest.fn()}>
+        Foo
+      </ModalInner>,
+    );
 
     expect(wrapper.prop('className')).not.toBe(fluid.prop('className'));
   });

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -127,6 +127,34 @@ describe('<Modal />', () => {
     });
   });
 
+  it('different class for small size', () => {
+    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
+    const small = shallowWithStyles(<ModalInner small>Foo</ModalInner>);
+
+    expect(wrapper.prop('className')).not.toBe(small.prop('className'));
+  });
+
+  it('different class for large size', () => {
+    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
+    const large = shallowWithStyles(<ModalInner large>Foo</ModalInner>);
+
+    expect(wrapper.prop('className')).not.toBe(large.prop('className'));
+  });
+
+  it('same class for image as large size', () => {
+    const wrapper = shallowWithStyles(<ModalInner image="foo.jpg">Foo</ModalInner>);
+    const large = shallowWithStyles(<ModalInner large>Foo</ModalInner>);
+
+    expect(wrapper.prop('className')).toBe(large.prop('className'));
+  });
+
+  it('different class for fluid size', () => {
+    const wrapper = shallowWithStyles(<ModalInner>Foo</ModalInner>);
+    const fluid = shallowWithStyles(<ModalInner fluid>Foo</ModalInner>);
+
+    expect(wrapper.prop('className')).not.toBe(fluid.prop('className'));
+  });
+
   it('focuses the first element on open', () => {
     jest.useFakeTimers();
     setup({}, false /* isShallow */);

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -210,11 +210,7 @@ describe('<Modal />', () => {
       false /* isShallow */,
     );
 
-    const headerWrapper = wrapper
-      .find(Spacing)
-      .find({ tag: 'header' })
-      .first();
-    expect(headerWrapper.prop('bottom')).toEqual(3);
+    expect(wrapper.find('header')).toHaveLength(1);
 
     const titleWrapper = wrapper.find(Title);
     expect(titleWrapper.prop('level')).toEqual(3);
@@ -229,11 +225,7 @@ describe('<Modal />', () => {
       false /* isShallow */,
     );
 
-    const headerWrapper = wrapper
-      .find(Spacing)
-      .find({ tag: 'header' })
-      .first();
-    expect(headerWrapper.prop('bottom')).toEqual(0);
+    expect(wrapper.find('header')).toHaveLength(0);
   });
 
   it('renders a footer, if provided', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Per design specs and prototypes, here are some modal updates:
- close button moved to the right
- padding overhaul
- three widths (more than just default and large):
  - base 400px
  - medium 600px
  - large 800px
- new `fluid` prop to have a % based max width
- new `scrollable` prop to have modal body content have a fixed height with scrollable content
- new `subtitle` prop
- various responsive tweaks

## Motivation and Context

design request (see solar issue)

## Testing

# ~ WIP updating tests ~ #

## Screenshots

<img width="1392" alt="Storybook 2019-06-27 13-45-22" src="https://user-images.githubusercontent.com/306275/60300018-ec89de80-98e2-11e9-889a-3776fed9f1b1.png">
<img width="1392" alt="Storybook 2019-06-27 13-45-31" src="https://user-images.githubusercontent.com/306275/60300019-ed227500-98e2-11e9-806d-a0b68d073ca6.png">
<img width="1392" alt="Storybook 2019-06-27 13-54-45" src="https://user-images.githubusercontent.com/306275/60300260-7639ac00-98e3-11e9-82d6-0bc6cc15a527.png">
<img width="1392" alt="Storybook 2019-06-27 13-45-57" src="https://user-images.githubusercontent.com/306275/60300022-ed227500-98e2-11e9-9b8a-9dd1a94e7b65.png">
<img width="1392" alt="Storybook 2019-06-27 13-46-09" src="https://user-images.githubusercontent.com/306275/60300023-ed227500-98e2-11e9-90f6-881ff23521d5.png">
<img width="1392" alt="Storybook 2019-06-27 13-46-27" src="https://user-images.githubusercontent.com/306275/60300024-ed227500-98e2-11e9-8a71-c3ce31980e6c.png">
<img width="1392" alt="Storybook 2019-06-27 13-46-39" src="https://user-images.githubusercontent.com/306275/60300025-ed227500-98e2-11e9-8dff-3852c56e9a56.png">
<img width="1392" alt="Storybook 2019-06-27 13-46-57" src="https://user-images.githubusercontent.com/306275/60300026-ed227500-98e2-11e9-8a4a-16e0233c2fe4.png">
<img width="1392" alt="Storybook 2019-06-27 13-47-07" src="https://user-images.githubusercontent.com/306275/60300027-edbb0b80-98e2-11e9-818e-ed6e8054170e.png">
<img width="1392" alt="Storybook 2019-06-27 13-47-17" src="https://user-images.githubusercontent.com/306275/60300028-edbb0b80-98e2-11e9-9435-bbd9faa436dd.png">

dark mode example
<img width="1011" alt="Screen Shot 2019-06-28 at 4 05 41 PM" src="https://user-images.githubusercontent.com/306275/60375554-a144fe00-99be-11e9-96e4-3009c49ef9c6.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
