### PR TITLE
new(mockWithStyles): Utility to mock out WithStyles in tests.

### DIFF
--- a/packages/test-utils/package-lock.json
+++ b/packages/test-utils/package-lock.json
@@ -1,0 +1,168 @@
+{
+  "name": "@airbnb/lunar-test-utils",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/cheerio": {
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.11.tgz",
+      "integrity": "sha512-x0X3kPbholdJZng9wDMhb2swvUi3UYRNAuWAmIPIWlfgAJZp//cql/qblE7181Mg7SjWVwq6ldCPCLn5AY/e7w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/enzyme": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.1.tgz",
+      "integrity": "sha512-Jd2hvn3w/0rBH8qD2n+JLMq2GjmZoKTZc5TTg8q9cDnJ9jkR7gzPV+ZdipKwGkWpMRXKDm9kuc9UiUqsW5s20w==",
+      "dev": true,
+      "requires": {
+        "@types/cheerio": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.15.tgz",
+      "integrity": "sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==",
+      "dev": true,
+      "requires": {
+        "@types/jest-diff": "*"
+      }
+    },
+    "@types/jest-diff": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
+      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.8.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.22.tgz",
+      "integrity": "sha512-C3O1yVqk4sUXqWyx0wlys76eQfhrQhiDhDlHBrjER76lR2S2Agiid/KpOU9oCqj1dISStscz7xXz1Cg8+sCQeA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "aesthetic-adapter-aphrodite": {
+      "version": "4.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/aesthetic-adapter-aphrodite/-/aesthetic-adapter-aphrodite-4.0.0-alpha.6.tgz",
+      "integrity": "sha512-2IfTWEgedYcv298L8tfn0NX6Y3l1H7TG2xeGm6wgtXSHT8qegGfCYmPHtAYdRXam4u8aHDRUqgI2ZaQP/ssVWw==",
+      "dev": true,
+      "requires": {
+        "aesthetic-utils": "^2.0.0-alpha.6"
+      }
+    },
+    "aesthetic-react": {
+      "version": "1.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/aesthetic-react/-/aesthetic-react-1.0.0-alpha.7.tgz",
+      "integrity": "sha512-y6fiUYlLkUtS/19Tn4VHhtLXL40A+UJQkScSC7jUrTULhvYrOFXBHrX9i3YPnP8GMTjNT0Izt+2qmH2/VHEyhg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "aesthetic-utils": "^2.0.0-alpha.6",
+        "direction": "^1.0.3",
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.7.2",
+        "utility-types": "^3.7.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "aesthetic-utils": {
+      "version": "2.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/aesthetic-utils/-/aesthetic-utils-2.0.0-alpha.6.tgz",
+      "integrity": "sha512-h2xfskTvAp6tQFQrOPXLTRI6ncNZeUHuUR+FuqvvY0uy1JVCbYSGN+ljcNY8ATjy3bwjIi7A3bg5yI9BYYK1rA==",
+      "dev": true,
+      "requires": {
+        "utility-types": "^3.7.0"
+      }
+    },
+    "csstype": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
+      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==",
+      "dev": true
+    },
+    "direction": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
+      "integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w==",
+      "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
+    },
+    "utility-types": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.7.0.tgz",
+      "integrity": "sha512-mqRJXN7dEArK/NZNJUubjr9kbFFVZcmF/JHDc9jt5O/aYXUVmopHYujDMhLmLil1Bxo2+khe6KAIVvDH9Yc4VA==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    }
+  }
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -22,6 +22,8 @@
   "devDependencies": {
     "@types/enzyme": "^3.9.4",
     "@types/jest": "^24.0.15",
-    "@types/react": "^16.8.22"
+    "@types/react": "^16.8.22",
+    "aesthetic-adapter-aphrodite": "^4.0.0-alpha.6",
+    "aesthetic-react": "^1.0.0-alpha.7"
   }
 }

--- a/packages/test-utils/src/index.tsx
+++ b/packages/test-utils/src/index.tsx
@@ -203,3 +203,5 @@ export function mockResizeObserver() {
     window.ResizeObserver = oldObserver;
   };
 }
+
+

--- a/packages/test-utils/src/mockWithStyles.tsx
+++ b/packages/test-utils/src/mockWithStyles.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { WithStylesWrappedProps } from 'aesthetic-react';
+import { NativeBlock, ParsedBlock } from 'aesthetic-adapter-aphrodite';
+
+export type WithStylesProps = WithStylesWrappedProps<{}, NativeBlock, ParsedBlock>;
+
+export default function mockWithStyles() {
+  jest.mock('@airbnb/lunar/lib/composers/withStyles', () => {
+    const core = jest.requireActual('@airbnb/lunar').default;
+
+    const theme = core.aesthetic.getTheme('light');
+
+    return function withStyles() {
+      function styleComponent<T>(WrappedComponent: React.ComponentType<T & WithStylesProps>) {
+        function Passthrough(props: T) {
+          return <WrappedComponent styles={{}} cx={() => ''} theme={theme} {...props} />;
+        }
+
+        Passthrough.extendStyles = () => Passthrough;
+        const wrappedName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+        Passthrough.displayName = `withStyles(${wrappedName})`;
+
+        return Passthrough;
+      }
+      styleComponent.extendStyles = () => {};
+
+      return styleComponent;
+    };
+  });
+}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

adding a utility to mock out withstyles

@milesj Any advice on a better way to mock is appreciated.  The way it is mocked now, it breaks tests that snapshot and rely on differences.  Since it does not output unique classnames.  I don't know if that is done much, we just had one test that did that locally.

Also unsure of what CI to run locally on test utils, so I'm sorry if CI fails here.

## Motivation and Context

With the new layers of complexity of testing components that are wrapped in withStyles, I thought it appropriate to mock it out in a  way that you only need to dive once to make it backwards compatible.  
## Testing

Using this code locally in torch.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
