### PR TITLE
style(Button,Input,Autocomplete,Menu): Normalize and standardize spacing

### DIFF
--- a/packages/core/src/components/Autocomplete.story.tsx
+++ b/packages/core/src/components/Autocomplete.story.tsx
@@ -87,7 +87,7 @@ storiesOf('Core/Autocomplete', module)
       isItemSelectable={(item, selected) => !selected}
     />
   ))
-  .add('With custom states in a compact form.', () => (
+  .add('With custom states in a smallt form.', () => (
     <>
       <Autocomplete
         accessibilityLabel="Label"
@@ -98,7 +98,7 @@ storiesOf('Core/Autocomplete', module)
         onLoadItems={value => Promise.reject(new Error('Failed to load.'))}
         renderError={error => <div>{error.message}</div>}
         loadItemsOnMount
-        compact
+        small
       />
 
       <Autocomplete
@@ -110,7 +110,7 @@ storiesOf('Core/Autocomplete', module)
         onLoadItems={value => new Promise(() => {})}
         renderLoading={() => <div>Loading...</div>}
         loadItemsOnMount
-        compact
+        small
       />
 
       <Autocomplete
@@ -122,7 +122,7 @@ storiesOf('Core/Autocomplete', module)
         onLoadItems={value => Promise.resolve([])}
         renderNoResults={() => <div>Nothing to see here!</div>}
         loadItemsOnMount
-        compact
+        small
       />
     </>
   ));

--- a/packages/core/src/components/Autocomplete.story.tsx
+++ b/packages/core/src/components/Autocomplete.story.tsx
@@ -87,7 +87,7 @@ storiesOf('Core/Autocomplete', module)
       isItemSelectable={(item, selected) => !selected}
     />
   ))
-  .add('With custom states in a smallt form.', () => (
+  .add('With custom states in a small form.', () => (
     <>
       <Autocomplete
         accessibilityLabel="Label"

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -17,7 +17,7 @@ export const CACHE_DURATION = toMilliseconds('5 minutes');
 
 function getItemValue(item: any): string {
   return String(item.value || item.id);
-},
+}
 
 function renderItem(item: any): NonNullable<React.ReactNode> {
   return <Text>{item.name || item.title || item.value}</Text>;

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -17,7 +17,7 @@ export const CACHE_DURATION = toMilliseconds('5 minutes');
 
 function getItemValue(item: any): string {
   return String(item.value || item.id);
-}
+},
 
 function renderItem(item: any): NonNullable<React.ReactNode> {
   return <Text>{item.name || item.title || item.value}</Text>;
@@ -457,6 +457,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
             key: 'lunar.common.search',
           },
         ),
+      small,
       type: 'text',
     };
   }

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -8,6 +8,7 @@ import ErrorMessage from '../ErrorMessage';
 import FormField, { Props as FormFieldProps, partitionFieldProps } from '../FormField';
 import Loader from '../Loader';
 import Menu, { Item as MenuItem, Row as MenuRow } from '../Menu';
+import Spacing from '../Spacing';
 import T from '../Translate';
 import Text from '../Text';
 import renderElementOrFunction, { RenderableProp } from '../../utils/renderElementOrFunction';
@@ -568,11 +569,11 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   renderError = (error: Error) => (
-    <MenuRow>
+    <MenuItem>
       {renderElementOrFunction(this.props.renderError, error) || (
         <ErrorMessage error={error} inline />
       )}
-    </MenuRow>
+    </MenuItem>
   );
 
   renderItem = (
@@ -616,7 +617,11 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   renderLoading = () => (
-    <MenuRow>{renderElementOrFunction(this.props.renderLoading) || <Loader inline />}</MenuRow>
+    <MenuRow>
+      <Spacing horizontal={1}>
+        {renderElementOrFunction(this.props.renderLoading) || <Loader inline />}
+      </Spacing>
+    </MenuRow>
   );
 
   renderMenu = () => {
@@ -653,7 +658,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   renderNoResults = () => (
-    <MenuRow>
+    <MenuItem>
       {renderElementOrFunction(this.props.renderNoResults) || (
         <Text>
           {this.props.noResultsText || (
@@ -665,7 +670,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
           )}
         </Text>
       )}
-    </MenuRow>
+    </MenuItem>
   );
 
   render() {

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -569,11 +569,13 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   renderError = (error: Error) => (
-    <MenuItem>
-      {renderElementOrFunction(this.props.renderError, error) || (
-        <ErrorMessage error={error} inline />
-      )}
-    </MenuItem>
+    <MenuRow>
+      <Spacing horizontal={1}>
+        {renderElementOrFunction(this.props.renderError, error) || (
+          <ErrorMessage error={error} inline />
+        )}
+      </Spacing>
+    </MenuRow>
   );
 
   renderItem = (
@@ -659,17 +661,19 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
 
   renderNoResults = () => (
     <MenuItem>
-      {renderElementOrFunction(this.props.renderNoResults) || (
-        <Text>
-          {this.props.noResultsText || (
-            <T
-              k="lunar.common.noResults"
-              phrase="No results found."
-              context="No results found for autocomplete search"
-            />
-          )}
-        </Text>
-      )}
+      <Spacing horizontal={1}>
+        {renderElementOrFunction(this.props.renderNoResults) || (
+          <Text>
+            {this.props.noResultsText || (
+              <T
+                k="lunar.common.noResults"
+                phrase="No results found."
+                context="No results found for autocomplete search"
+              />
+            )}
+          </Text>
+        )}
+      </Spacing>
     </MenuItem>
   );
 

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -570,7 +570,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
 
   renderError = (error: Error) => (
     <MenuRow>
-      <Spacing horizontal={1}>
+      <Spacing horizontal={0.5}>
         {renderElementOrFunction(this.props.renderError, error) || (
           <ErrorMessage error={error} inline />
         )}

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -424,7 +424,17 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   }
 
   getInputProps(props: Props<T>) {
-    const { compact, disabled, invalid, name, optional, placeholder, onBlur, onFocus } = props;
+    const {
+      compact,
+      disabled,
+      invalid,
+      name,
+      optional,
+      placeholder,
+      onBlur,
+      onFocus,
+      small,
+    } = props;
     const { id } = this.state;
 
     // Should match the props passed within `Input`
@@ -680,6 +690,12 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   render() {
     const { id, open, value } = this.state;
     const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
+
+    if (__DEV__) {
+      if (inputProps.compact) {
+        console.log('Autocomplete: `compact` prop is deprecated, please use `small` instead.');
+      }
+    }
 
     return (
       <FormField {...fieldProps} id={id}>

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -671,7 +671,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
   };
 
   renderNoResults = () => (
-    <MenuItem>
+    <MenuRow>
       <Spacing horizontal={1}>
         {renderElementOrFunction(this.props.renderNoResults) || (
           <Text>
@@ -685,7 +685,7 @@ export default class Autocomplete<T extends Item> extends React.Component<Props<
           </Text>
         )}
       </Spacing>
-    </MenuItem>
+    </MenuRow>
   );
 
   render() {

--- a/packages/core/src/components/Button/index.tsx
+++ b/packages/core/src/components/Button/index.tsx
@@ -17,9 +17,9 @@ export type Props = ButtonOrLinkProps & {
   invalid?: boolean;
   /** Invert text colors. */
   inverted?: boolean;
-  /** Increase font size to large. */
+  /** Increase font size and padding to large. */
   large?: boolean;
-  /** Decrease font size to small. */
+  /** Decrease font size and padding to small. */
   small?: boolean;
 };
 

--- a/packages/core/src/components/Button/index.tsx
+++ b/packages/core/src/components/Button/index.tsx
@@ -91,7 +91,7 @@ export default withStyles(
       position: 'relative',
       color: color.base,
       backgroundColor: color.core.primary[3],
-      border: `2px solid ${color.core.primary[3]}`,
+      border: `${ui.borderWidthThick}px solid ${color.core.primary[3]}`,
       borderRadius: ui.borderRadius,
       textAlign: 'center',
 

--- a/packages/core/src/components/Input.story.tsx
+++ b/packages/core/src/components/Input.story.tsx
@@ -15,7 +15,7 @@ storiesOf('Core/Input', module)
       onChange={action('onChange')}
     />
   ))
-  .add('With a compact smaller view.', () => (
+  .add('With a compact smaller view or expanded larger view .', () => (
     <>
       <Input
         name="input-compact"
@@ -29,6 +29,13 @@ storiesOf('Core/Input', module)
         label="Regular"
         placeholder="Placeholder"
         onChange={action('onChange')}
+      />
+      <Input
+        name="input-large"
+        label="Large"
+        placeholder="Placeholder"
+        onChange={action('onChange')}
+        large
       />
     </>
   ))

--- a/packages/core/src/components/Input.story.tsx
+++ b/packages/core/src/components/Input.story.tsx
@@ -15,14 +15,14 @@ storiesOf('Core/Input', module)
       onChange={action('onChange')}
     />
   ))
-  .add('With a compact smaller view or expanded larger view .', () => (
+  .add('With different sizing: small, default or large.', () => (
     <>
       <Input
-        name="input-compact"
-        label="Compact"
+        name="input-small"
+        label="Small"
         placeholder="Placeholder"
         onChange={action('onChange')}
-        compact
+        small
       />
       <Input
         name="input-regular"

--- a/packages/core/src/components/Menu/index.tsx
+++ b/packages/core/src/components/Menu/index.tsx
@@ -59,11 +59,11 @@ export class Menu extends React.Component<Props & WithStylesProps> {
 
 export { Item, Separator, Row };
 
-export default withStyles(({ color, ui, pattern }) => ({
+export default withStyles(({ color, ui, pattern, unit }) => ({
   menu: {
     ...pattern.box,
     margin: 0,
-    padding: 0,
+    padding: `${unit}px 0`,
     backgroundColor: color.accent.bg,
     listStyle: 'none',
 

--- a/packages/core/src/components/Menu/index.tsx
+++ b/packages/core/src/components/Menu/index.tsx
@@ -63,7 +63,7 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
   menu: {
     ...pattern.box,
     margin: 0,
-    padding: `${unit}px 0`,
+    padding: 0,
     backgroundColor: color.accent.bg,
     listStyle: 'none',
 
@@ -74,11 +74,13 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
 
       // These are jank. Better way?
       '> li:first-child > *': {
+        borderTop: `${unit}px solid white`,
         borderTopLeftRadius: ui.borderRadius,
         borderTopRightRadius: ui.borderRadius,
       },
 
       '> li:last-child > *': {
+        borderBottom: `${unit}px solid white`,
         borderBottomLeftRadius: ui.borderRadius,
         borderBottomRightRadius: ui.borderRadius,
       },

--- a/packages/core/src/components/Menu/index.tsx
+++ b/packages/core/src/components/Menu/index.tsx
@@ -74,13 +74,13 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
 
       // These are jank. Better way?
       '> li:first-child > *': {
-        borderTop: `${unit}px solid white`,
+        borderTop: `${unit}px solid transparent`,
         borderTopLeftRadius: ui.borderRadius,
         borderTopRightRadius: ui.borderRadius,
       },
 
       '> li:last-child > *': {
-        borderBottom: `${unit}px solid white`,
+        borderBottom: `${unit}px solid transparent`,
         borderBottomLeftRadius: ui.borderRadius,
         borderBottomRightRadius: ui.borderRadius,
       },

--- a/packages/core/src/components/Menu/index.tsx
+++ b/packages/core/src/components/Menu/index.tsx
@@ -63,7 +63,7 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
   menu: {
     ...pattern.box,
     margin: 0,
-    padding: 0,
+    padding: `${unit}px 0`,
     backgroundColor: color.accent.bg,
     listStyle: 'none',
 
@@ -74,13 +74,11 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
 
       // These are jank. Better way?
       '> li:first-child > *': {
-        borderTop: `${unit}px solid ${color.accent.bg}`,
         borderTopLeftRadius: ui.borderRadius,
         borderTopRightRadius: ui.borderRadius,
       },
 
       '> li:last-child > *': {
-        borderBottom: `${unit}px solid ${color.accent.bg}`,
         borderBottomLeftRadius: ui.borderRadius,
         borderBottomRightRadius: ui.borderRadius,
       },

--- a/packages/core/src/components/Menu/index.tsx
+++ b/packages/core/src/components/Menu/index.tsx
@@ -74,13 +74,13 @@ export default withStyles(({ color, ui, pattern, unit }) => ({
 
       // These are jank. Better way?
       '> li:first-child > *': {
-        borderTop: `${unit}px solid transparent`,
+        borderTop: `${unit}px solid ${color.accent.bg}`,
         borderTopLeftRadius: ui.borderRadius,
         borderTopRightRadius: ui.borderRadius,
       },
 
       '> li:last-child > *': {
-        borderBottom: `${unit}px solid transparent`,
+        borderBottom: `${unit}px solid ${color.accent.bg}`,
         borderBottomLeftRadius: ui.borderRadius,
         borderBottomRightRadius: ui.borderRadius,
       },

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -43,6 +43,8 @@ export type Props<T = any> = {
   optional?: boolean;
   /** Reference to access the underlying input DOM element. */
   propagateRef?: React.Ref<T>;
+  /** Decrease font size and padding to small. */
+  small?: boolean;
   /** Current value. */
   value?: string;
 };
@@ -77,6 +79,7 @@ class FormInput extends React.Component<PrivateProps> {
   static propTypes = {
     compact: sizingProp,
     large: sizingProp,
+    small: sizingProp,
   };
 
   static defaultProps = {
@@ -91,6 +94,7 @@ class FormInput extends React.Component<PrivateProps> {
     large: false,
     noTranslate: false,
     optional: false,
+    small: false,
     value: '',
   };
 
@@ -110,6 +114,7 @@ class FormInput extends React.Component<PrivateProps> {
       noTranslate,
       optional,
       propagateRef,
+      small,
       styles,
       tagName: Tag,
       ...restProps
@@ -119,7 +124,7 @@ class FormInput extends React.Component<PrivateProps> {
       ...restProps,
       className: cx(
         styles.input,
-        compact && styles.input_compact,
+        (compact || small) && styles.input_compact,
         disabled && styles.input_disabled,
         hasPrefix && styles.input_hasPrefix,
         hasSuffix && styles.input_hasSuffix,
@@ -134,6 +139,12 @@ class FormInput extends React.Component<PrivateProps> {
       id,
       required: !optional,
     };
+
+    if (__DEV__) {
+      if (compact) {
+        console.log('Input: `compact` prop is deprecated, please use `small` instead.');
+      }
+    }
 
     // Only populate when invalid, otherwise it will break some CSS selectors
     if (invalid) {

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import { Omit } from 'utility-types';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import buildInputStyles from '../../themes/buildInputStyles';
+
+const sizingProp = mutuallyExclusiveTrueProps('compact', 'large');
 
 export type IgnoreAttributes =
   | 'children'
@@ -26,12 +29,14 @@ export type IgnoreAttributes =
   | 'security';
 
 export type Props<T = any> = {
-  /** Decrease font size and padding. */
+  /** Decrease font size and padding to small. */
   compact?: boolean;
   /** Mark the field as important. */
   important?: boolean;
   /** Mark the field as invalid. */
   invalid?: boolean;
+  /** Increase font size and padding to large. */
+  large?: boolean;
   /** Add "notranslate" className to prevent Google Chrome translation. */
   noTranslate?: boolean;
   /** Mark the field as optional. */
@@ -78,6 +83,7 @@ class FormInput extends React.Component<PrivateProps> {
     hidden: false,
     important: false,
     invalid: false,
+    large: false,
     noTranslate: false,
     optional: false,
     value: '',
@@ -95,6 +101,7 @@ class FormInput extends React.Component<PrivateProps> {
       id,
       important,
       invalid,
+      large,
       noTranslate,
       optional,
       propagateRef,
@@ -107,15 +114,16 @@ class FormInput extends React.Component<PrivateProps> {
       ...restProps,
       className: cx(
         styles.input,
-        important && styles.input_important,
         compact && styles.input_compact,
-        invalid && styles.input_invalid,
         disabled && styles.input_disabled,
-        hidden && styles.input_hidden,
-        isSelect && styles.select,
-        isSelect && compact && styles.select_compact,
         hasPrefix && styles.input_hasPrefix,
         hasSuffix && styles.input_hasSuffix,
+        hidden && styles.input_hidden,
+        important && styles.input_important,
+        invalid && styles.input_invalid,
+        isSelect && styles.select,
+        isSelect && compact && styles.select_compact,
+        large && styles.input_large,
       ),
       disabled,
       id,

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -4,7 +4,7 @@ import { Omit } from 'utility-types';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import buildInputStyles from '../../themes/buildInputStyles';
 
-const sizingProp = mutuallyExclusiveTrueProps('compact', 'large');
+const sizingProp = mutuallyExclusiveTrueProps('small', 'compact', 'large');
 
 export type IgnoreAttributes =
   | 'children'
@@ -29,7 +29,7 @@ export type IgnoreAttributes =
   | 'security';
 
 export type Props<T = any> = {
-  /** Decrease font size and padding to small. */
+  /** @deprecated decrease font size and padding to small. */
   compact?: boolean;
   /** Mark the field as important. */
   important?: boolean;

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -74,6 +74,11 @@ export type PrivateProps = Props &
   };
 
 class FormInput extends React.Component<PrivateProps> {
+  static propTypes = {
+    compact: sizingProp,
+    large: sizingProp,
+  };
+
   static defaultProps = {
     children: null,
     compact: false,

--- a/packages/core/src/themes/buildInputStyles.ts
+++ b/packages/core/src/themes/buildInputStyles.ts
@@ -152,6 +152,10 @@ export default function buildInputStyles({
       borderBottomRightRadius: 0,
     },
 
+    input_large: {
+      ...pattern.largeButton,
+    },
+
     select: {
       appearance: 'none',
       paddingRight: unit * 4.5,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -23,7 +23,7 @@ export default function buildTheme(
 ): Theme {
   const {
     base,
-    borderRadius = 3,
+    borderRadius = 4,
     boxShadow = [2, 3],
     brand,
     color,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -118,7 +118,7 @@ export default function buildTheme(
       },
       largeButton: {
         ...font.textLarge,
-        padding: `${unit * 1.5}px ${unit * 2.5}px`,
+        padding: `${unit * 1.5}px ${unit * 2}px`,
       },
     },
     breakpoints,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -115,7 +115,7 @@ export default function buildTheme(
       },
       smallButton: {
         ...font.textSmall,
-        padding: `${unit * 1 - borderWidthThick}px ${unit * 1.5 - borderWidthThick}px`,
+        padding: `${unit - borderWidthThick}px ${unit * 1.5 - borderWidthThick}px`,
       },
       regularButton: {
         ...font.textRegular,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -14,6 +14,9 @@ export type Options = {
   transitionTime?: string;
 };
 
+const borderWidth = 1;
+const borderWidthThick = 2;
+
 export default function buildTheme(
   options: Options,
   accents: Partial<Theme['color']['accent']> = {},
@@ -42,10 +45,12 @@ export default function buildTheme(
   };
 
   const ui = {
-    border: `1px solid ${accent.border}`,
-    borderThick: `2px solid ${accent.border}`,
+    border: `${borderWidth}px solid ${accent.border}`,
+    borderThick: `$${borderWidthThick}px solid ${accent.border}`,
     borderRadius,
     borderRadiusThick: borderRadius * 2,
+    borderWidth,
+    borderWidthThick,
     boxShadow: `0 ${boxShadow[0]}px ${boxShadow[1]}px ${toRGBA(color.neutral[6], 10)}`,
     boxShadowMedium: `0 ${boxShadow[0] * 3}px ${boxShadow[1] * 2}px ${toRGBA(
       color.neutral[6],
@@ -110,15 +115,15 @@ export default function buildTheme(
       },
       smallButton: {
         ...font.textSmall,
-        padding: `${unit * 1}px ${unit * 1.5}px`,
+        padding: `${unit * 1 - borderWidthThick}px ${unit * 1.5 - borderWidthThick}px`,
       },
       regularButton: {
         ...font.textRegular,
-        padding: `${unit * 1.25}px ${unit * 1.5}px`,
+        padding: `${unit * 1.25 - borderWidthThick}px ${unit * 1.5 - borderWidthThick}px`,
       },
       largeButton: {
         ...font.textLarge,
-        padding: `${unit * 1.5}px ${unit * 2}px`,
+        padding: `${unit * 1.5 - borderWidthThick}px ${unit * 2 - borderWidthThick}px`,
       },
     },
     breakpoints,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -46,7 +46,7 @@ export default function buildTheme(
 
   const ui = {
     border: `${borderWidth}px solid ${accent.border}`,
-    borderThick: `$${borderWidthThick}px solid ${accent.border}`,
+    borderThick: `${borderWidthThick}px solid ${accent.border}`,
     borderRadius,
     borderRadiusThick: borderRadius * 2,
     borderWidth,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -110,7 +110,7 @@ export default function buildTheme(
       },
       smallButton: {
         ...font.textSmall,
-        padding: `${unit * 0.75}px ${unit * 1.25}px`,
+        padding: `${unit * 1}px ${unit * 1.5}px`,
       },
       regularButton: {
         ...font.textRegular,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,6 +176,8 @@ export type Theme = {
     borderThick: string;
     borderRadius: number;
     borderRadiusThick: number;
+    borderWidth: number;
+    borderWidthThick: number;
     boxShadow: string;
     boxShadowMedium: string;
     boxShadowLarge: string;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Changes:
- Decrease `large` spacing from `20px` to `16px`
- Add `large` option to `Input`
- Increase `small` spacing from `6/10` to `8/12`
- Change `MenuRow` in `Autocomplete` to `MenuItem` for No Results and Error states
- Add Spacing to `Autocomplete` Loading state
- Add top/bottom padding to `Menu`
- Subtract border width from spacing calculations
- **[new as of 7/11]** Increase theme borderRadius to 4

A few controversial points:
- The `Input` size props are now `compact` and `large`, ideally this would be `small` and large. I could add the `small` prop with redundant functionality and add a developers note that `compact` will be deprecated and/or we could make this a breaking change in the future.

- First/Last Menu Items now have asymmetrical focus outline. This is to make the extra padding clickable as part of the items.
![Screen Shot 2019-07-09 at 11 46 48 AM](https://user-images.githubusercontent.com/8676510/60921896-665d8880-a250-11e9-90c0-6995ed780acf.png)

- When `Button` is borderless, spacing doesn't grow to compensate

<!--- Describe your change in detail. -->

## Motivation and Context
@kenchendesign has noticed some inconsistencies and misalignments in Lunar spacing these changes aim to correct. There's a full description of these issues in another PR I'll try to find and append.
<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
![Screen Shot 2019-07-09 at 1 51 54 PM](https://user-images.githubusercontent.com/8676510/60922056-c05e4e00-a250-11e9-96f4-122fdc28d3e0.png)
![Screen Shot 2019-07-09 at 1 51 49 PM](https://user-images.githubusercontent.com/8676510/60922057-c05e4e00-a250-11e9-9702-8d609067e59c.png)
![Screen Shot 2019-07-09 at 1 51 38 PM](https://user-images.githubusercontent.com/8676510/60922058-c05e4e00-a250-11e9-8b61-2805f3e7adc7.png)
![Screen Shot 2019-07-09 at 1 51 18 PM](https://user-images.githubusercontent.com/8676510/60922059-c0f6e480-a250-11e9-841a-e980cb4dd764.png)
![Screen Shot 2019-07-09 at 1 51 08 PM](https://user-images.githubusercontent.com/8676510/60922060-c0f6e480-a250-11e9-85f5-125dcda7d26c.png)
![Screen Shot 2019-07-09 at 1 50 58 PM](https://user-images.githubusercontent.com/8676510/60922061-c0f6e480-a250-11e9-96ef-1b32fc2a471a.png)

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
