### PR TITLE
update(AccordionItem): Change title to node instead of string

### DIFF
--- a/packages/core/src/components/Accordion.story.tsx
+++ b/packages/core/src/components/Accordion.story.tsx
@@ -37,4 +37,21 @@ storiesOf('Core/Accordion', module)
         </Text>
       </Item>
     </Accordion>
+  ))
+  .add('Custom title component.', () => (
+    <Accordion bordered>
+      <Item
+        title={
+          <header>
+            <div>Main Title</div>
+            <small>Subtitle</small>
+          </header>
+        }
+        id="one"
+      >
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+    </Accordion>
   ));

--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -14,7 +14,7 @@ export type Props = {
   /** Index amongst a collection of accordion items. */
   index?: number;
   /** Title of the accordion item. */
-  title?: string;
+  title?: React.ReactNode;
   /** Callback fired when the accordion item is clicked. */
   onClick?: (index: number) => void;
 };

--- a/packages/core/test/components/Accordion/Item.test.tsx
+++ b/packages/core/test/components/Accordion/Item.test.tsx
@@ -19,6 +19,26 @@ describe('<AccordionItem />', () => {
     expect(wrapper.find('section')).toHaveLength(1);
   });
 
+  it('renders the title as a string', () => {
+    const wrapper = shallowWithStyles(
+      <AccordionItem id=".0" index={0} title="unique string" onClick={() => {}} />,
+    );
+
+    expect(wrapper.find('button').html()).toMatch('unique string');
+  });
+
+  it('renders the title as a component', () => {
+    function CustomTitleComponent() {
+      return null;
+    }
+
+    const wrapper = shallowWithStyles(
+      <AccordionItem id=".0" index={0} title={<CustomTitleComponent />} onClick={() => {}} />,
+    );
+
+    expect(wrapper.find(CustomTitleComponent)).toHaveLength(1);
+  });
+
   it('renders children', () => {
     const child = <div>Foo</div>;
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

AccordionItem expects a `title` of string, but this just changes the prop type to more broadly accept a ReactNode.

## Motivation and Context

I had a use case in which I wanted to use AccordionItem, but specifically needed to have a more complex title.

## Testing

```npm run jest```

and visual check of Storybook story.

## Screenshots

Storybook now, with a story and updated `title` prop in the table (showing ReactNode instead of string)

![image](https://user-images.githubusercontent.com/673941/60991820-1fc76700-a300-11e9-804d-3e3575a8d2be.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
