### PR TITLE
style(Button): Adjust minimum widths.

### DIFF
--- a/packages/core/src/components/Button/index.tsx
+++ b/packages/core/src/components/Button/index.tsx
@@ -6,8 +6,6 @@ import Loader from '../Loader';
 
 const sizingProp = mutuallyExclusiveTrueProps('small', 'large');
 
-const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
-
 export type Props = ButtonOrLinkProps & {
   /** Render as a block with full width. */
   block?: boolean;
@@ -152,17 +150,17 @@ export default withStyles(
 
     button_small: {
       ...pattern.smallButton,
-      minWidth: GOLDEN_RATIO * 4 * unit,
+      minWidth: 6 * unit,
     },
 
     button_regular: {
       ...pattern.regularButton,
-      minWidth: GOLDEN_RATIO * 6 * unit,
+      minWidth: 8 * unit,
     },
 
     button_large: {
       ...pattern.largeButton,
-      minWidth: GOLDEN_RATIO * 8 * unit,
+      minWidth: 9 * unit,
     },
   }),
   {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
This reduces min-width on each of the button sizes and removes the golden ratio calculation.

Values were previously:
52, 78, 104
<img width="279" alt="Screen Shot 2019-07-11 at 11 40 04 AM" src="https://user-images.githubusercontent.com/8676510/61076257-a51a4c80-a3d0-11e9-944c-961171ab8f96.png">

Values are now:
48, 64, 72
<img width="238" alt="Screen Shot 2019-07-11 at 11 39 55 AM" src="https://user-images.githubusercontent.com/8676510/61076262-a77ca680-a3d0-11e9-800e-b2afc72bc50a.png">


<!--- Describe your change in detail. -->

## Motivation and Context
See discussion between @adamirl and @kenchendesign in #dls-for-internaltools

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots


<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
