### PR TITLE
fix(Proofreader): Reduce calls in componentDidUpdate.

### DIFF
--- a/packages/core/src/components/TextArea/Proofreader/Mark.tsx
+++ b/packages/core/src/components/TextArea/Proofreader/Mark.tsx
@@ -7,15 +7,17 @@ export type Props = {
   onSelect: (top: number, left: number) => void;
 };
 
-class Mark extends React.Component<Props & WithStylesProps> {
+class Mark extends React.PureComponent<Props & WithStylesProps> {
   ref = React.createRef<HTMLSpanElement>();
 
   componentDidMount() {
     this.handleSelect();
   }
 
-  componentDidUpdate() {
-    this.handleSelect();
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.selected !== prevProps.selected) {
+      this.handleSelect();
+    }
   }
 
   private handleSelect = () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

setting state in CDU causing proofreader to crash. only handle select when selected state has changed.

## Motivation and Context

fix it

## Testing

local storybook

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
