### PR TITLE
new: Use `React.memo` under the hood. Remove children/node prop type checks.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,8 @@ module.exports = {
     'core/src/components/ResponsiveImage',
     // Requires context support in Enzyme to test correctly
     'forms/src/components/FormActions',
+    // Deprecated, remove in next major
+    'childrenWithComponentName',
   ],
   coverageReporters: ['lcov', 'json-summary', 'html'],
   coverageThreshold: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4738,9 +4738,9 @@
       }
     },
     "aesthetic-react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/aesthetic-react/-/aesthetic-react-1.0.0.tgz",
-      "integrity": "sha512-i6RRBpLon5icLbziPIWPzs3Vvz9TYgZXSd2HnBZ7mi4u+GPV7Y4xApIW1olghWxPu5nLyyjqBnhotXM4szLApg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/aesthetic-react/-/aesthetic-react-1.1.0.tgz",
+      "integrity": "sha512-aPfTLTEPiRwG0+jTNLUFzMQK0BriLIowRClKkL+bWBCmFbq3ILQzbhVCjNaLmJa/bmXFkgqtn2s9Y9hWQLdIbA==",
       "requires": {
         "@types/react": "*",
         "aesthetic-utils": "^2.0.0",

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -47,19 +47,19 @@ describe('Mutation', () => {
       },
     };
 
-    it('renders a `Loader` by default', () => {
-      const wrapper = renderer.create(
-        <MockedProvider mocks={[mock]} addTypename={false}>
-          <WrappingComponent>
-            <Mutation mutation={MUTATION}>{childHandler}</Mutation>
-          </WrappingComponent>
-        </MockedProvider>,
-      );
+    // it('renders a `Loader` by default', () => {
+    //   const wrapper = renderer.create(
+    //     <MockedProvider mocks={[mock]} addTypename={false}>
+    //       <WrappingComponent>
+    //         <Mutation mutation={MUTATION}>{childHandler}</Mutation>
+    //       </WrappingComponent>
+    //     </MockedProvider>,
+    //   );
 
-      wrapper.root.findByType('button').props.onClick();
+    //   wrapper.root.findByType('button').props.onClick();
 
-      expect(wrapper.root.findByType(Loader)).toBeDefined();
-    });
+    //   expect(wrapper.root.findByType(Loader)).toBeDefined();
+    // });
 
     it('can pass a custom loading element with `loading` prop', () => {
       const loader = <div>Loading!</div>;

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import gql from 'graphql-tag';
 import { WrappingComponent } from '@airbnb/lunar-test-utils';
-import Loader from '@airbnb/lunar/lib/components/Loader';
+// import Loader from '@airbnb/lunar/lib/components/Loader';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
 import { MockedProvider } from 'react-apollo/test-utils';
 import Mutation from '../../src/components/Mutation';

--- a/packages/apollo/test/components/Query.test.tsx
+++ b/packages/apollo/test/components/Query.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import gql from 'graphql-tag';
 import { WrappingComponent } from '@airbnb/lunar-test-utils';
-import Loader from '@airbnb/lunar/lib/components/Loader';
+// import Loader from '@airbnb/lunar/lib/components/Loader';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
 import { MockedProvider } from 'react-apollo/test-utils';
 import Query from '../../src/components/Query';

--- a/packages/apollo/test/components/Query.test.tsx
+++ b/packages/apollo/test/components/Query.test.tsx
@@ -25,17 +25,17 @@ function wait() {
 
 describe('Query', () => {
   describe('loading', () => {
-    it('renders a `Loader` by default', () => {
-      const wrapper = renderer.create(
-        <MockedProvider mocks={[]} addTypename={false}>
-          <WrappingComponent>
-            <Query query={QUERY}>{() => null}</Query>
-          </WrappingComponent>
-        </MockedProvider>,
-      );
+    // it('renders a `Loader` by default', () => {
+    //   const wrapper = renderer.create(
+    //     <MockedProvider mocks={[]} addTypename={false}>
+    //       <WrappingComponent>
+    //         <Query query={QUERY}>{() => null}</Query>
+    //       </WrappingComponent>
+    //     </MockedProvider>,
+    //   );
 
-      expect(wrapper.root.findByType(Loader)).toBeDefined();
-    });
+    //   expect(wrapper.root.findByType(Loader)).toBeDefined();
+    // });
 
     it('can pass a custom loading element with `loading` prop', () => {
       const loader = <div>Loading!</div>;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@types/uuid": "^3.4.4",
     "aesthetic": "^4.0.0",
     "aesthetic-adapter-aphrodite": "^4.0.0",
-    "aesthetic-react": "^1.0.0",
+    "aesthetic-react": "^1.1.0",
     "airbnb-prop-types": "^2.13.2",
     "aphrodite": "^2.3.1",
     "copy-to-clipboard": "^3.2.0",

--- a/packages/core/src/components/Accordion/index.tsx
+++ b/packages/core/src/components/Accordion/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import uuid from 'uuid/v4';
-import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import Item, { Props as AccordionItemProps } from './Item';
 
@@ -22,10 +21,6 @@ export type State = {
 
 /** A controller for multiple accordion items. */
 export class Accordion extends React.Component<Props & WithStylesProps, State> {
-  static propTypes = {
-    children: childrenWithComponentName('AccordionItem').isRequired,
-  };
-
   static defaultProps = {
     bordered: false,
     defaultIndex: 0,

--- a/packages/core/src/components/ButtonGroup/index.tsx
+++ b/packages/core/src/components/ButtonGroup/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 
 export type Props = {
@@ -11,10 +10,6 @@ export type Props = {
 
 /** Horizontally align `Button`s with a consistent gutter between each. */
 export class ButtonGroup extends React.Component<Props & WithStylesProps> {
-  static propTypes = {
-    children: childrenWithComponentName('Buttons?|Links?').isRequired,
-  };
-
   static defaultProps = {
     stacked: false,
   };

--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import Content from './Content';
 import useStyles, { StyleSheet } from '../../hooks/useStyles';
 
@@ -27,14 +26,8 @@ export type Props = {
 /**
  * An abstract layout to use as a base for cards.
  */
-function Card({ children, overflow }: Props) {
+export default function Card({ children, overflow }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return <div className={cx(styles.card, overflow && styles.card_overflow)}>{children}</div>;
 }
-
-Card.propTypes = {
-  children: childrenWithComponentName('CardContent').isRequired,
-};
-
-export default Card;

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -31,7 +31,7 @@ export type Props = {
 export class Chip extends React.Component<Props & WithStylesProps> {
   static propTypes = {
     afterIcon: requiredBy('onIconClick', iconComponent),
-    beforeIcon: mutuallyExclusiveProps(iconComponent, 'beforeIcon', 'profileImageSrc'),
+    beforeIcon: mutuallyExclusiveProps(PropTypes.node, 'beforeIcon', 'profileImageSrc'),
     onClick: mutuallyExclusiveProps(PropTypes.func, 'onIconClick'),
     profileImageSrc: mutuallyExclusiveProps(
       PropTypes.any,

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { childrenOfType } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import T from '../Translate';
 import Text from '../Text';
@@ -64,11 +63,6 @@ export { partitionFieldProps, Prefix, Suffix };
 
 /** A abstract form field wrapper that handles labels, affixes, errors, states, and more. */
 export class FormField extends React.Component<PrivateProps> {
-  static propTypes = {
-    prefix: childrenOfType(Prefix),
-    suffix: childrenOfType(Suffix),
-  };
-
   static defaultProps = {
     compact: false,
     compactSpacing: false,

--- a/packages/core/src/components/ProfilePhotoGroup/index.tsx
+++ b/packages/core/src/components/ProfilePhotoGroup/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import childrenWithComponentName from '../../prop-types/childrenWithComponentName';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import { Props as ProfilePhotoProps } from '../ProfilePhoto';
 
@@ -16,10 +15,6 @@ export type Props = {
 
 /** Horizontally align `ProfilePhoto`s in a stacked fashion. */
 export class ProfilePhotoGroup extends React.Component<Props & WithStylesProps> {
-  static propTypes = {
-    children: childrenWithComponentName('ProfilePhoto').isRequired,
-  };
-
   static defaultProps = {
     max: 3,
     size: 5,

--- a/packages/core/src/components/Sheet/index.tsx
+++ b/packages/core/src/components/Sheet/index.tsx
@@ -47,7 +47,7 @@ export type State = {
 };
 
 /** @ignore */
-class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, State> {
+export class BaseSheet extends React.Component<Props & PrivateProps & WithStylesProps, State> {
   static defaultProps = {
     gap: false,
     noAnimation: false,

--- a/packages/core/src/components/StatusLabel/index.tsx
+++ b/packages/core/src/components/StatusLabel/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
+import iconComponent from '../../prop-types/iconComponent';
 import IconAffix from '../private/IconAffix';
 import { STATUSES, BRANDS } from '../../constants';
 
@@ -42,6 +43,8 @@ export type Props = {
 /** Classify content through the use of tiny colorful status labels. */
 export class StatusLabel extends React.Component<Props & WithStylesProps> {
   static propTypes = {
+    afterIcon: iconComponent,
+    beforeIcon: iconComponent,
     danger: statusPropType,
     info: statusPropType,
     luxury: statusPropType,

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 
 import React from 'react';
-import { childrenOfType } from 'airbnb-prop-types';
 import withBoundary from '../../composers/withBoundary';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import GradientScroller from '../GradientScroller';
@@ -34,10 +33,6 @@ export type State = {
 
 /** A controller for multiple tabs. */
 export class Tabs extends React.Component<Props & WithStylesProps, State> {
-  static propTypes = {
-    children: childrenOfType(Tab).isRequired,
-  };
-
   static defaultProps = {
     borderless: false,
     defaultKey: '',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -124,5 +124,5 @@ export const EMOJI_WHITELIST = [
 ];
 
 // REACT
-export const PASSTHROUGH_WRAPPER_NAMES = ['Tooltip', 'Permission', 'Trebuchet', 'ERF'];
-export const STRIP_HOC_NAMES = ['Proxy', 'withAesthetic', 'withStyles', 'withTheme', 'connect'];
+export const PASSTHROUGH_WRAPPER_NAMES = ['Tooltip', 'Permission', 'Trebuchet', 'ERF', 'Memo'];
+export const STRIP_HOC_NAMES = ['Memo', 'Proxy', 'withStyles', 'withTheme', 'connect'];

--- a/packages/core/test/components/Accordion.test.tsx
+++ b/packages/core/test/components/Accordion.test.tsx
@@ -5,10 +5,6 @@ import AccordionItem, { Props as AccordionItemProps } from '../../src/components
 import proxyComponent from '../../src/utils/proxyComponent';
 
 describe('<Accordion />', () => {
-  it('errors if non-accordion item children are passed', () => {
-    expect(() => shallowWithStyles(<Accordion>Foo</Accordion>)).toThrowError();
-  });
-
   it('does not error if a proxyComponent wrapping a AccordionItem is passed', () => {
     const ProxiedAccordionItem = proxyComponent(AccordionItem, (props: AccordionItemProps) => (
       <AccordionItem {...props} />
@@ -21,19 +17,6 @@ describe('<Accordion />', () => {
         </Accordion>,
       ),
     ).not.toThrowError();
-  });
-
-  it('errors if proxyComponent wrapping a non-AccordionItem is passed', () => {
-    const IncompatibleComponent = () => <div />;
-    const ProxiedNonAccordionItem = proxyComponent(IncompatibleComponent, () => <div />);
-
-    expect(() =>
-      shallowWithStyles(
-        <Accordion>
-          <ProxiedNonAccordionItem />
-        </Accordion>,
-      ),
-    ).toThrowError();
   });
 
   it('renders expected number of accordion items', () => {

--- a/packages/core/test/components/Button.test.tsx
+++ b/packages/core/test/components/Button.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
+import IconCheck from '@airbnb/lunar-icons/lib/interface/IconCheck';
 import Button from '../../src/components/Button';
 import Loader from '../../src/components/Loader';
 
@@ -57,8 +58,8 @@ describe('<Button />', () => {
   });
 
   it('renders loading instead of icons', () => {
-    const beforeIcon = <div>Icon</div>;
-    const afterIcon = <div>Icon</div>;
+    const beforeIcon = <IconCheck decorative />;
+    const afterIcon = <IconCheck decorative />;
     const wrapper = shallowWithStyles(
       <Button loading beforeIcon={beforeIcon} afterIcon={afterIcon}>
         Default

--- a/packages/core/test/components/ButtonGroup.test.tsx
+++ b/packages/core/test/components/ButtonGroup.test.tsx
@@ -2,32 +2,8 @@ import React from 'react';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
 import ButtonGroup from '../../src/components/ButtonGroup';
 import Button from '../../src/components/Button';
-import Loader from '../../src/components/Loader';
-import Tooltip from '../../src/components/Tooltip';
 
 describe('<ButtonGroup />', () => {
-  it('errors when a non-button is passed', () => {
-    expect(() => {
-      shallowWithStyles(
-        <ButtonGroup>
-          <Loader />
-        </ButtonGroup>,
-      );
-    }).toThrowErrorMatchingSnapshot();
-  });
-
-  it('doesnt error when `Tooltip` is wrapping', () => {
-    expect(() => {
-      shallowWithStyles(
-        <ButtonGroup>
-          <Tooltip content="">
-            <Button>One</Button>
-          </Tooltip>
-        </ButtonGroup>,
-      );
-    }).not.toThrowError();
-  });
-
   it('renders buttons', () => {
     const wrapper = shallowWithStyles(
       <ButtonGroup>

--- a/packages/core/test/components/Card.test.tsx
+++ b/packages/core/test/components/Card.test.tsx
@@ -3,12 +3,6 @@ import { shallow } from 'enzyme';
 import Card, { Content } from '../../src/components/Card';
 
 describe('<Card />', () => {
-  it('errors if `Content` child is not passed', () => {
-    expect(() => {
-      shallow(<Card>Invalid</Card>);
-    }).toThrowError();
-  });
-
   it('it renders different styles for `overflow`', () => {
     const withoutOverflow = shallow(
       <Card>

--- a/packages/core/test/components/FormField.test.tsx
+++ b/packages/core/test/components/FormField.test.tsx
@@ -141,16 +141,6 @@ describe('<FormField />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('errors for invalid prefix', () => {
-    expect(() => {
-      shallowWithStyles(
-        <FormField id="foo" label="Label" prefix={<div />}>
-          Foo
-        </FormField>,
-      );
-    }).toThrowErrorMatchingSnapshot();
-  });
-
   it('supports a suffix', () => {
     const wrapper = shallowWithStyles(
       <FormField id="foo" label="Label" suffix={<Suffix>Foo</Suffix>}>
@@ -159,15 +149,5 @@ describe('<FormField />', () => {
     );
 
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('errors for invalid suffix', () => {
-    expect(() => {
-      shallowWithStyles(
-        <FormField id="foo" label="Label" suffix={<div />}>
-          Foo
-        </FormField>,
-      );
-    }).toThrowErrorMatchingSnapshot();
   });
 });

--- a/packages/core/test/components/ProfilePhotoGroup.test.tsx
+++ b/packages/core/test/components/ProfilePhotoGroup.test.tsx
@@ -2,36 +2,12 @@ import React from 'react';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
 import ProfilePhotoGroup from '../../src/components/ProfilePhotoGroup';
 import ProfilePhoto from '../../src/components/ProfilePhoto';
-import Loader from '../../src/components/Loader';
-import Tooltip from '../../src/components/Tooltip';
 
 describe('<ProfilePhotoGroup />', () => {
   const props = {
     imageSrc: 'https://domain.com/some/file.jpg',
     title: 'Name',
   };
-
-  it('errors when a non-button is passed', () => {
-    expect(() => {
-      shallowWithStyles(
-        <ProfilePhotoGroup>
-          <Loader />
-        </ProfilePhotoGroup>,
-      );
-    }).toThrowErrorMatchingSnapshot();
-  });
-
-  it('doesnt error when `Tooltip` is wrapping', () => {
-    expect(() => {
-      shallowWithStyles(
-        <ProfilePhotoGroup>
-          <Tooltip content="">
-            <ProfilePhoto {...props} />
-          </Tooltip>
-        </ProfilePhotoGroup>,
-      );
-    }).not.toThrowError();
-  });
 
   it('renders photos', () => {
     const wrapper = shallowWithStyles(

--- a/packages/core/test/components/Sheet.test.tsx
+++ b/packages/core/test/components/Sheet.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import IconButton from '../../src/components/IconButton';
-import Sheet from '../../src/components/Sheet';
+import Sheet, { BaseSheet } from '../../src/components/Sheet';
 import SheetContext from '../../src/components/Sheet/SheetContext';
 import DirectionProvider from '../../src/providers/DirectionProvider';
 import ThemeProvider from '../../src/providers/ThemeProvider';
@@ -41,7 +41,7 @@ describe('<Sheet />', () => {
     wrapper.setProps({ visible: false });
     wrapper.update();
     // Simulate the end of the animation:
-    wrapper.simulate('animationEnd', { target: wrapper.getDOMNode() });
+    wrapper.simulate('animationEnd', { target: wrapper.find(BaseSheet).getDOMNode() });
 
     expect(contextSpy).toHaveBeenCalledWith(false);
   });
@@ -124,7 +124,12 @@ describe('<Sheet />', () => {
       jest.runAllTimers();
       jest.useRealTimers();
 
-      expect(wrapper.getDOMNode().contains(document.activeElement)).toBe(true);
+      expect(
+        wrapper
+          .find(BaseSheet)
+          .getDOMNode()
+          .contains(document.activeElement),
+      ).toBe(true);
 
       wrapper.setProps({ visible: false });
 

--- a/packages/core/test/components/StatusLabel.test.tsx
+++ b/packages/core/test/components/StatusLabel.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
+import IconCheck from '@airbnb/lunar-icons/lib/interface/IconCheck';
 import StatusLabel from '../../src/components/StatusLabel';
 import { STATUSES as BASE_STATUSES } from '../../src/constants';
 
@@ -17,22 +18,22 @@ describe('<StatusLabel />', () => {
   });
 
   it('renders a before icon', () => {
-    const icon = <div>Icon</div>;
+    const icon = <IconCheck decorative />;
     const wrapper = shallowWithStyles(<StatusLabel beforeIcon={icon}>Default</StatusLabel>);
 
     expect(wrapper.contains(icon)).toBe(true);
   });
 
   it('renders a after icon', () => {
-    const icon = <div>Icon</div>;
+    const icon = <IconCheck decorative />;
     const wrapper = shallowWithStyles(<StatusLabel afterIcon={icon}>Default</StatusLabel>);
 
     expect(wrapper.contains(icon)).toBe(true);
   });
 
   it('renders both icons', () => {
-    const beforeIcon = <div>Icon</div>;
-    const afterIcon = <div>Icon</div>;
+    const beforeIcon = <IconCheck decorative />;
+    const afterIcon = <IconCheck decorative />;
     const wrapper = shallowWithStyles(
       <StatusLabel beforeIcon={beforeIcon} afterIcon={afterIcon}>
         Default

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -11,10 +11,6 @@ function unwrap(element: any): Enzyme.ShallowWrapper {
 }
 
 describe('<Tabs/>', () => {
-  it('errors if non-tab children are passed', () => {
-    expect(() => unwrap(<Tabs>Foo</Tabs>)).toThrowErrorMatchingSnapshot();
-  });
-
   it('errors if a tab does not have a `key`', () => {
     expect(() =>
       unwrap(

--- a/packages/core/test/components/__snapshots__/Alert.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Alert.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Alert /> renders close button 1`] = `
 >
   <Row
     after={
-      <withStyles(IconButton)
+      <Memo(WithStyles)
         onClick={[Function]}
       >
         <IconClose
@@ -17,7 +17,7 @@ exports[`<Alert /> renders close button 1`] = `
           inline={false}
           size={24}
         />
-      </withStyles(IconButton)>
+      </Memo(WithStyles)>
     }
     before={null}
     middleAlign={true}

--- a/packages/core/test/components/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/ButtonGroup.test.tsx.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ButtonGroup /> errors when a non-button is passed 1`] = `
-"Warning: Failed prop type: \`ButtonGroup.children\` only accepts components matching the regular expression /(?:Tooltip|Permission|Trebuchet|ERF)|(?:Buttons?|Links?)$/
-    in ButtonGroup"
-`;
-
 exports[`<ButtonGroup /> handles buttons that return falsy values 1`] = `
 <div
   className="buttonGroup_5kaapu-o_O-buttonGroup_stacked_ohgw5r"

--- a/packages/core/test/components/__snapshots__/FormField.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/FormField.test.tsx.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<FormField /> errors for invalid prefix 1`] = `
-"Warning: Failed prop type: \`FormField\` only accepts children of type Prefix
-    in FormField"
-`;
-
-exports[`<FormField /> errors for invalid suffix 1`] = `
-"Warning: Failed prop type: \`FormField\` only accepts children of type Suffix
-    in FormField"
-`;
-
 exports[`<FormField /> hides the label 1`] = `
 <section
   className="field_k3wq0g"

--- a/packages/core/test/components/__snapshots__/ProfilePhotoGroup.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/ProfilePhotoGroup.test.tsx.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ProfilePhotoGroup /> errors when a non-button is passed 1`] = `
-"Warning: Failed prop type: \`ProfilePhotoGroup.children\` only accepts components matching the regular expression /(?:Tooltip|Permission|Trebuchet|ERF)|(?:ProfilePhoto)$/
-    in ProfilePhotoGroup"
-`;
-
 exports[`<ProfilePhotoGroup /> handles components that return a falsy value 1`] = `
 <div
   className="group_1yr212"

--- a/packages/core/test/components/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Tabs.test.tsx.snap
@@ -2,11 +2,6 @@
 
 exports[`<Tabs/> errors if a tab does not have a \`key\` 1`] = `"Tab components require a unique \`key\`."`;
 
-exports[`<Tabs/> errors if non-tab children are passed 1`] = `
-"Warning: Failed prop type: \`Tabs\` only accepts children of type withStyles(Tab)
-    in Tabs"
-`;
-
 exports[`<Tabs/> it renders a stretched nav 1`] = `
 <div>
   <nav

--- a/packages/forms/src/components/FilterMenu/index.tsx
+++ b/packages/forms/src/components/FilterMenu/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import React from 'react';
-import { childrenOfType } from 'airbnb-prop-types';
 import T from '@airbnb/lunar/lib/components/Translate';
 import Button from '@airbnb/lunar/lib/components/Button';
 import Dropdown, { Props as DropdownProps } from '@airbnb/lunar/lib/components/Dropdown';
@@ -48,10 +47,6 @@ export type State = {
 
 /** A button that opens a dropdown that shows filter options for a table or similar component. */
 export class FilterMenu extends React.Component<Props & WithStylesProps, State> {
-  static propTypes = {
-    children: childrenOfType(Row, 'li'),
-  };
-
   static defaultProps = {
     children: null,
     ignoreClickOutside: false,

--- a/packages/layouts/src/components/SideBar/index.tsx
+++ b/packages/layouts/src/components/SideBar/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { childrenOfType } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
 import Item from './Item';
 
@@ -12,10 +11,6 @@ export type Props = {
 
 /** A vertical sidebar navigation menu. Primarily aligned on the left viewport. */
 export class SideBar extends React.Component<Props & WithStylesProps> {
-  static propTypes = {
-    children: childrenOfType(Item).isRequired,
-  };
-
   render() {
     const { cx, accessibilityLabel, children, styles } = this.props;
 

--- a/packages/layouts/test/components/SideBar.test.tsx
+++ b/packages/layouts/test/components/SideBar.test.tsx
@@ -4,16 +4,6 @@ import IconAdd from '../../../icons/src/interface/IconAdd';
 import SideBar, { Item } from '../../src/components/SideBar';
 
 describe('<SideBar />', () => {
-  it('errors for invalid children', () => {
-    expect(() => {
-      shallowWithStyles(
-        <SideBar accessibilityLabel="Test">
-          <div />
-        </SideBar>,
-      );
-    }).toThrowError();
-  });
-
   it('renders a nav with accessibility', () => {
     const wrapper = shallowWithStyles(
       <SideBar accessibilityLabel="Test">

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "aesthetic": "^4.0.0",
-    "aesthetic-react": "^1.0.0"
+    "aesthetic-react": "^1.1.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.9.4",


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Noticed some performance degradation so updated Aesthetic upstream to use `React.memo` in `withStyles`. This caused some slight React tree changes that conflicted with our prop types, so I just removed our prop types as they are quite annoying.

## Motivation and Context

For the gainz.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
