### PR TITLE
update(DataTable): add prop for callback on row selection

### DIFF
--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -16,7 +16,7 @@ import Button from './Button';
 import Input from './Input';
 import Row from './Row';
 import Spacing from './Spacing';
-import { SelectedRows, VirtualRow, IndexedParentRow } from './DataTable/types';
+import { ExpandedRow, SelectedRows, IndexedParentRow, VirtualRow } from './DataTable/types';
 
 const renderers = {
   name: EditableTextRenderer,
@@ -92,6 +92,10 @@ const defaultEditCallback = (
   event: React.SyntheticEvent<EventTarget>,
 ) => {
   action('this callback has access to row, key, newVal and event');
+};
+
+const selectCallback = (rowData: ExpandedRow, selectedRows: SelectedRows) => () => {
+  action('this callback has access to the newly selected row and all selected row');
 };
 
 export interface SearchDemoProps {
@@ -244,12 +248,15 @@ storiesOf('Core/DataTable', module)
       tableHeaderHeight="large"
     />
   ))
-  .add('An table that logs custom edit callbacks.', () => (
+  .add('An table that logs custom edit callbacks and select callback.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
       data={getData()}
       defaultEditCallback={defaultEditCallback}
       editCallbacks={editCallbacks}
+      selectCallback={selectCallback}
+      selectable
+      expandable
     />
   ))
   .add('A complex table with all features enabled.', () => (

--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -223,7 +223,7 @@ storiesOf('Core/DataTable', module)
       renderers={renderers}
     />
   ))
-  .add('An table with zebra coloring, a colspan, infered keys and renderers.', () => (
+  .add('A table with zebra coloring, a colspan, infered keys and renderers.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
       data={getData()}
@@ -234,7 +234,7 @@ storiesOf('Core/DataTable', module)
       renderers={renderers}
     />
   ))
-  .add('An table with different row, column header and table header heights.', () => (
+  .add('A table with different row, column header and table header heights.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
       data={getData()}
@@ -248,7 +248,7 @@ storiesOf('Core/DataTable', module)
       tableHeaderHeight="large"
     />
   ))
-  .add('An table that logs custom edit callbacks and select callback.', () => (
+  .add('A table that logs custom edit callbacks and select callback.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
       data={getData()}

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -57,6 +57,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     renderers: {},
     rowHeight: 'regular',
     selectable: false,
+    selectCallback: (rowData: ExpandedRow, selectedRows: SelectedRows) => () => {},
     selectOnRowClick: false,
     showAllRows: false,
     showColumnDividers: false,
@@ -231,7 +232,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   };
 
   private handleChildSelection = (row: ExpandedRow) => {
-    const { data } = this.props;
+    const { data, selectCallback } = this.props;
     const {
       selectedRows,
       sortBy,
@@ -278,13 +279,12 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       };
     }
 
-    this.setState({
-      selectedRows,
-    });
+    this.setState({ selectedRows }, selectCallback!(row, selectedRows));
   };
 
   private handleParentSelection(row: ExpandedRow) {
-    const { selectedRows }: { selectedRows: SelectedRows } = this.state;
+    const { selectedRows } = this.state;
+    const { selectCallback } = this.props;
     const { originalIndex } = row.metadata;
 
     // If parent is already selected
@@ -302,7 +302,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       };
     }
 
-    this.setState({ selectedRows });
+    this.setState({ selectedRows }, selectCallback!(row, selectedRows));
   }
 
   private handleSelection = (rowData: ExpandedRow) => () => {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -77,6 +77,8 @@ export interface DataTableProps {
   rowHeight?: RowHeightOptions;
   /** If enabled, a special column is rendered to allows rows to be selected. */
   selectable?: boolean;
+  /** Function that gets called on row selection. */
+  selectCallback?: (rowData: ExpandedRow, selectedRows: SelectedRows) => () => void;
   /** If enabled, clicking the row triggers the same function as click the selection checkbox. */
   selectOnRowClick?: boolean;
   /**
@@ -95,7 +97,7 @@ export interface DataTableProps {
   sortByOverride?: string;
   /** sortDirection value if override is enabled. */
   sortDirectionOverride?: SortDirectionType;
-  /** sortCallback in override is enabled. */
+  /** sortCallback if override is enabled. */
   sortCallback?: (sortBy: string, sortDirection: SortDirectionType) => void;
   /** Label for the table header. */
   tableHeaderLabel?: string;

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -286,7 +286,7 @@ describe('<DataTable /> rows can be selected', () => {
 
     selectRow(table, ROW);
 
-    expect(selectCallback.mock.calls.length).toBe(1);
+    expect(selectCallback.mock.calls).toHaveLength(1);
   });
 
   it('should be expandable', () => {

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -10,12 +10,7 @@ import Text from '../../src/components/Text';
 import Translate from '../../src/components/Translate';
 import Button from '../../src/components/Button';
 import Checkbox from '../../src/components/CheckBox';
-import {
-  EditCallback,
-  SelectCallback,
-  ParentRow,
-  VirtualRow,
-} from '../../src/components/DataTable/types';
+import { EditCallback, ParentRow, VirtualRow } from '../../src/components/DataTable/types';
 import { STATUS_OPTIONS } from '../../src/components/DataTable/constants';
 
 type EditableTextRendererProps = {

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -10,7 +10,12 @@ import Text from '../../src/components/Text';
 import Translate from '../../src/components/Translate';
 import Button from '../../src/components/Button';
 import Checkbox from '../../src/components/CheckBox';
-import { EditCallback, ParentRow, VirtualRow } from '../../src/components/DataTable/types';
+import {
+  EditCallback,
+  SelectCallback,
+  ParentRow,
+  VirtualRow,
+} from '../../src/components/DataTable/types';
 import { STATUS_OPTIONS } from '../../src/components/DataTable/constants';
 
 type EditableTextRendererProps = {
@@ -191,6 +196,8 @@ const headerButtonClick = jest.fn();
 
 const editCallback = jest.fn();
 
+const selectCallback = jest.fn();
+
 const editCallbacks = {
   name: editCallback,
 };
@@ -277,6 +284,14 @@ describe('<DataTable /> rows can be selected', () => {
     table.update();
 
     expect(getCheckbox(table, ROW).props().checked).toBe(true);
+  });
+
+  it('should trigger callbacks on selection', () => {
+    const table = mountWithStyles(<DataTable {...simpleProps} selectCallback={selectCallback} />);
+
+    selectRow(table, ROW);
+
+    expect(selectCallback.mock.calls.length).toBe(1);
   });
 
   it('should be expandable', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Currently, the only want to interact with selectedRows from outside DataTable is to configure custom header buttons. This satisfied the existing use case for Bighead of selecting rows and then performing an action on them, but there have been requests for having access to selections as a callback.

This PR adds a new prop for users to pass in a function, and then adds it as a `setState` callback when we update `selectedRows`

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
