### PR TITLE
update(DataTable): Add `selectedRowsFirst` prop.

### DIFF
--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -177,13 +177,14 @@ storiesOf('Core/DataTable', module)
       sortDirectionOverride="ASC"
     />
   ))
-  .add('A table with selectable and exandable rows.', () => (
+  .add('A table with selectable and exandable rows that displays selected rows first.', () => (
     <DataTable
       tableHeaderLabel="My Great Table"
       data={getData()}
       keys={['name', 'jobTitle']}
       expandable
       selectable
+      selectedRowsFirst
     />
   ))
   .add('A table with filtered data.', () => (

--- a/packages/core/src/components/DataTable/helpers/expandData.ts
+++ b/packages/core/src/components/DataTable/helpers/expandData.ts
@@ -1,11 +1,13 @@
 import { SortDirectionType } from 'react-virtualized';
-import sortList from './sortData';
-import { IndexedParentRow, IndexedChildRow, ExpandedRow } from '../types';
+import sortData from './sortData';
+import { SelectedRows, IndexedParentRow, IndexedChildRow, ExpandedRow } from '../types';
 
 /*  Iterate over the sortedDataList in state to flatten out children stashed in metadata */
 export default function expandData(
   sortedData: IndexedParentRow[],
   expandedRows: Set<number>,
+  selectedRows: SelectedRows,
+  selectedRowsFirst: boolean,
   sortBy: string,
   keys: string[],
   sortDirection?: SortDirectionType,
@@ -20,7 +22,14 @@ export default function expandData(
       },
     });
     if (row.metadata.originalIndex !== undefined && expandedRows.has(row.metadata.originalIndex)) {
-      const children = sortList(row.metadata.children, keys, sortBy, sortDirection);
+      const children = sortData(
+        row.metadata.children,
+        keys,
+        selectedRows,
+        selectedRowsFirst,
+        sortBy,
+        sortDirection,
+      );
       children.forEach((child: IndexedChildRow) => {
         expandedData.push({
           ...child,

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -1,5 +1,5 @@
 import { SortDirection, SortDirectionType } from 'react-virtualized';
-import { GenericRow } from '../types';
+import { IndexedParentRow, SelectedRows } from '../types';
 
 function sortDesc(a: any, b: any) {
   if (typeof b === 'undefined' || a < b) {
@@ -17,18 +17,50 @@ function sortAsc(a: any, b: any) {
   return 1;
 }
 
-export default function sortData<T extends GenericRow>(
-  list: T[],
+export default function sortData(
+  list: IndexedParentRow[],
+  keys: string[],
+  selectedRows: SelectedRows,
+  selectedRowsFirst: boolean,
+  sortBy?: string,
+  sortDirection?: SortDirectionType,
+): IndexedParentRow[] {
+  if (selectedRowsFirst) {
+    const selectedList = list.filter((row: IndexedParentRow) =>
+      selectedRows.hasOwnProperty(row.metadata.originalIndex),
+    );
+    const sortedSelectedList = sortList(selectedList, keys, sortBy, sortDirection);
+
+    const unselectedList = list.filter(
+      (row: IndexedParentRow) => !selectedRows.hasOwnProperty(row.metadata.originalIndex),
+    );
+
+    const sortedUnselectedList = sortList(unselectedList, keys, sortBy, sortDirection);
+
+    return sortedSelectedList.concat(sortedUnselectedList);
+  }
+
+  return sortList(list, keys, sortBy, sortDirection);
+}
+
+function sortList(
+  list: IndexedParentRow[],
   keys: string[],
   sortBy?: string,
   sortDirection?: SortDirectionType,
-): T[] {
+): IndexedParentRow[] {
   if (sortBy && keys.includes(sortBy)) {
     if (sortDirection === SortDirection.ASC) {
-      return list.slice().sort((a: T, b: T) => sortAsc(a.data[sortBy], b.data[sortBy]));
+      return list
+        .slice()
+        .sort((a: IndexedParentRow, b: IndexedParentRow) =>
+          sortAsc(a.data[sortBy], b.data[sortBy]),
+        );
     }
 
-    return list.slice().sort((a: T, b: T) => sortDesc(a.data[sortBy], b.data[sortBy]));
+    return list
+      .slice()
+      .sort((a: IndexedParentRow, b: IndexedParentRow) => sortDesc(a.data[sortBy], b.data[sortBy]));
   }
 
   return list;

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -43,8 +43,8 @@ export default function sortData<T extends GenericRow>(
   sortDirection?: SortDirectionType,
 ): T[] {
   if (selectedRowsFirst) {
-    let selectedList: T[] = [];
-    let unselectedList: T[] = [];
+    const selectedList: T[] = [];
+    const unselectedList: T[] = [];
 
     list.forEach((row: T) => {
       if (Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex)) {

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -1,5 +1,5 @@
 import { SortDirection, SortDirectionType } from 'react-virtualized';
-import { IndexedParentRow, SelectedRows } from '../types';
+import { GenericRow, IndexedParentRow, SelectedRows } from '../types';
 
 function sortDesc(a: any, b: any) {
   if (typeof b === 'undefined' || a < b) {
@@ -17,22 +17,22 @@ function sortAsc(a: any, b: any) {
   return 1;
 }
 
-export default function sortData(
-  list: IndexedParentRow[],
+export default function sortData<T extends GenericRow>(
+  list: T[],
   keys: string[],
   selectedRows: SelectedRows,
   selectedRowsFirst: boolean,
   sortBy?: string,
   sortDirection?: SortDirectionType,
-): IndexedParentRow[] {
+): T[] {
   if (selectedRowsFirst) {
-    const selectedList = list.filter((row: IndexedParentRow) =>
+    const selectedList = list.filter((row: T) =>
       selectedRows.hasOwnProperty(row.metadata.originalIndex),
     );
     const sortedSelectedList = sortList(selectedList, keys, sortBy, sortDirection);
 
     const unselectedList = list.filter(
-      (row: IndexedParentRow) => !selectedRows.hasOwnProperty(row.metadata.originalIndex),
+      (row: T) => !selectedRows.hasOwnProperty(row.metadata.originalIndex),
     );
 
     const sortedUnselectedList = sortList(unselectedList, keys, sortBy, sortDirection);
@@ -43,24 +43,18 @@ export default function sortData(
   return sortList(list, keys, sortBy, sortDirection);
 }
 
-function sortList(
-  list: IndexedParentRow[],
+function sortList<T extends GenericRow>(
+  list: T[],
   keys: string[],
   sortBy?: string,
   sortDirection?: SortDirectionType,
-): IndexedParentRow[] {
+): T[] {
   if (sortBy && keys.includes(sortBy)) {
     if (sortDirection === SortDirection.ASC) {
-      return list
-        .slice()
-        .sort((a: IndexedParentRow, b: IndexedParentRow) =>
-          sortAsc(a.data[sortBy], b.data[sortBy]),
-        );
+      return list.slice().sort((a: T, b: T) => sortAsc(a.data[sortBy], b.data[sortBy]));
     }
 
-    return list
-      .slice()
-      .sort((a: IndexedParentRow, b: IndexedParentRow) => sortDesc(a.data[sortBy], b.data[sortBy]));
+    return list.slice().sort((a: T, b: T) => sortDesc(a.data[sortBy], b.data[sortBy]));
   }
 
   return list;

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -43,15 +43,18 @@ export default function sortData<T extends GenericRow>(
   sortDirection?: SortDirectionType,
 ): T[] {
   if (selectedRowsFirst) {
-    const selectedList = list.filter((row: T) =>
-      Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex),
-    );
+    let selectedList: T[] = [];
+    let unselectedList: T[] = [];
+
+    list.forEach((row: T) => {
+      if (Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex)) {
+        selectedList.push(row);
+      } else {
+        unselectedList.push(row);
+      }
+    });
+
     const sortedSelectedList = sortList(selectedList, keys, sortBy, sortDirection);
-
-    const unselectedList = list.filter(
-      (row: T) => !Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex),
-    );
-
     const sortedUnselectedList = sortList(unselectedList, keys, sortBy, sortDirection);
 
     return sortedSelectedList.concat(sortedUnselectedList);

--- a/packages/core/src/components/DataTable/helpers/sortData.ts
+++ b/packages/core/src/components/DataTable/helpers/sortData.ts
@@ -1,5 +1,5 @@
 import { SortDirection, SortDirectionType } from 'react-virtualized';
-import { GenericRow, IndexedParentRow, SelectedRows } from '../types';
+import { GenericRow, SelectedRows } from '../types';
 
 function sortDesc(a: any, b: any) {
   if (typeof b === 'undefined' || a < b) {
@@ -17,32 +17,6 @@ function sortAsc(a: any, b: any) {
   return 1;
 }
 
-export default function sortData<T extends GenericRow>(
-  list: T[],
-  keys: string[],
-  selectedRows: SelectedRows,
-  selectedRowsFirst: boolean,
-  sortBy?: string,
-  sortDirection?: SortDirectionType,
-): T[] {
-  if (selectedRowsFirst) {
-    const selectedList = list.filter((row: T) =>
-      selectedRows.hasOwnProperty(row.metadata.originalIndex),
-    );
-    const sortedSelectedList = sortList(selectedList, keys, sortBy, sortDirection);
-
-    const unselectedList = list.filter(
-      (row: T) => !selectedRows.hasOwnProperty(row.metadata.originalIndex),
-    );
-
-    const sortedUnselectedList = sortList(unselectedList, keys, sortBy, sortDirection);
-
-    return sortedSelectedList.concat(sortedUnselectedList);
-  }
-
-  return sortList(list, keys, sortBy, sortDirection);
-}
-
 function sortList<T extends GenericRow>(
   list: T[],
   keys: string[],
@@ -58,4 +32,30 @@ function sortList<T extends GenericRow>(
   }
 
   return list;
+}
+
+export default function sortData<T extends GenericRow>(
+  list: T[],
+  keys: string[],
+  selectedRows: SelectedRows,
+  selectedRowsFirst: boolean,
+  sortBy?: string,
+  sortDirection?: SortDirectionType,
+): T[] {
+  if (selectedRowsFirst) {
+    const selectedList = list.filter((row: T) =>
+      Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex),
+    );
+    const sortedSelectedList = sortList(selectedList, keys, sortBy, sortDirection);
+
+    const unselectedList = list.filter(
+      (row: T) => !Object.prototype.hasOwnProperty.call(selectedRows, row.metadata.originalIndex),
+    );
+
+    const sortedUnselectedList = sortList(unselectedList, keys, sortBy, sortDirection);
+
+    return sortedSelectedList.concat(sortedUnselectedList);
+  }
+
+  return sortList(list, keys, sortBy, sortDirection);
 }

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -392,8 +392,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortDirection,
     );
 
-    console.log(expandedData);
-
     return (
       <div>
         {this.shouldRenderTableHeader() && (

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -392,6 +392,8 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortDirection,
     );
 
+    console.log(expandedData);
+
     return (
       <div>
         {this.shouldRenderTableHeader() && (

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -373,6 +373,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       rowHeight,
       selectable,
       styles,
+      selectedRowsFirst,
     } = this.props;
 
     const { expandedRows, sortBy, sortDirection, editMode, selectedRows } = this.state;
@@ -381,7 +382,15 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
     const filteredData = filterData!(sortedData);
 
-    const expandedData = expandData(filteredData, expandedRows, sortBy, this.keys, sortDirection);
+    const expandedData = expandData(
+      filteredData,
+      expandedRows,
+      selectedRows,
+      selectedRowsFirst!,
+      sortBy,
+      this.keys,
+      sortDirection,
+    );
 
     return (
       <div>

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -58,6 +58,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     rowHeight: 'regular',
     selectable: false,
     selectCallback: (rowData: ExpandedRow, selectedRows: SelectedRows) => () => {},
+    selectedRowsFirst: false,
     selectOnRowClick: false,
     showAllRows: false,
     showColumnDividers: false,
@@ -103,9 +104,22 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   });
 
   private getData = memoize(
-    (data: ParentRow[], sortBy: string, sortDirection: SortDirectionType): IndexedParentRow[] => {
+    (
+      data: ParentRow[],
+      sortBy: string,
+      sortDirection: SortDirectionType,
+      selectedRows: SelectedRows,
+    ): IndexedParentRow[] => {
+      const { selectedRowsFirst } = this.props;
       const indexedData = indexData(data);
-      const sortedData = sortData(indexedData, this.keys, sortBy, sortDirection);
+      const sortedData = sortData(
+        indexedData,
+        this.keys,
+        selectedRows,
+        selectedRowsFirst!,
+        sortBy,
+        sortDirection,
+      );
 
       return sortedData;
     },
@@ -243,7 +257,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortDirection: SortDirectionType;
     } = this.state;
 
-    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection);
+    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection, selectedRows);
 
     const { parentOriginalIndex, parentIndex, originalIndex } = row.metadata;
 
@@ -363,7 +377,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
     const { expandedRows, sortBy, sortDirection, editMode, selectedRows } = this.state;
 
-    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection);
+    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection, selectedRows);
 
     const filteredData = filterData!(sortedData);
 

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -115,6 +115,9 @@ export interface GenericRow {
   data: {
     [key: string]: any;
   };
+  metadata: {
+    [key: string]: any;
+  };
 }
 
 /** The row used by React Virtualized. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -79,6 +79,8 @@ export interface DataTableProps {
   selectable?: boolean;
   /** Function that gets called on row selection. */
   selectCallback?: (rowData: ExpandedRow, selectedRows: SelectedRows) => () => void;
+  /** Display selected rows above everything else, regardless of sort order. */
+  selectedRowsFirst?: boolean;
   /** If enabled, clicking the row triggers the same function as click the selection checkbox. */
   selectOnRowClick?: boolean;
   /**

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -401,6 +401,28 @@ describe('<DataTable /> renders and sorts data', () => {
     expect(text).toBe('Dev Ops Danny');
   });
 
+  it('should sort data in Ascending order with selectedRowsFirst', () => {
+    const table = mountWithStyles(<DataTable selectedRowsFirst {...simpleProps} />);
+
+    selectRow(table, ROW);
+
+    const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').at(NAME_COL - 1);
+    nameHeader.simulate('click');
+    table.update();
+
+    expect(
+      getCell(table, 1, NAME_COL)
+        .find(Text)
+        .text(),
+    ).toBe('Engineer Emma');
+
+    expect(
+      getCell(table, 2, NAME_COL)
+        .find(Text)
+        .text(),
+    ).toBe('Dev Ops Danny');
+  });
+
   it('should sort data in Ascending order through props', () => {
     const table = mountWithStyles(
       <DataTable {...simpleProps} sortByOverride="name" sortDirectionOverride="ASC" />,

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -424,6 +424,19 @@ describe('<DataTable /> renders and sorts data', () => {
 
     expect(text).toBe('Product Percy');
   });
+
+  it('should sort data in Descending order with selected rows first', () => {
+    const table = mountWithStyles(<DataTable selectedRowsFirst {...simpleProps} />);
+
+    const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').first();
+    nameHeader.simulate('click');
+    nameHeader.simulate('click');
+    const text = getCell(table, 1, NAME_COL)
+      .find(Text)
+      .text();
+
+    expect(text).toBe('Product Percy');
+  });
 });
 
 describe('<DataTable /> renders column labels', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Independent of sorting, this allows developers to pass in a prop so that selected rows are always displayed first. Does not apply to children, but does sort selected -> hasChildrenSelected -> unselected.

<!--- Describe your change in detail. -->

## Motivation and Context
Xuan Lu requested this change, it seems reasonable and could be useful in other applications as well. The user interaction is a little janky because you select a row, and then it immediately jumps to the top.

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
<img width="767" alt="Screen Shot 2019-07-18 at 5 49 29 PM" src="https://user-images.githubusercontent.com/8676510/61501487-695d2500-a984-11e9-97e0-e2e9d6598414.png">

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
