### PR TITLE
update(Modal): Add z-index to close button.

### DIFF
--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -6,6 +6,7 @@ import Title from '../../Title';
 import IconButton from '../../IconButton';
 import T from '../../Translate';
 import useTheme from '../../../hooks/useTheme';
+import { Z_INDEX_MODAL } from '../../../constants';
 import toRGBA from '../../../utils/toRGBA';
 
 export type Props = {
@@ -118,11 +119,12 @@ export default withStyles(({ color, ui, unit }) => ({
     position: 'absolute',
     top: unit * 2,
     right: unit * 2,
+    zIndex: Z_INDEX_MODAL,
   },
 
   close_float: {
     float: 'right',
-    position: 'static',
+    position: 'relative',
     top: 0,
     right: 0,
     margin: `${unit * 2}px ${unit * 2}px ${unit / 2}px ${unit / 2}px`,


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Ensure the close button is on top of modal content.

## Motivation and Context

 Noticed this was necessary in an internal modal image viewer.

## Testing

- locally with storybook
- chrome dev tools

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
