### PR TITLE
update: Refine and use explicit value types. Allow null and undefined default values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
     "@testing-library/react": "^8.0.4",
-    "@types/enzyme": "^3.9.4",
+    "@types/enzyme": "^3.10.3",
     "@types/google.analytics": "0.0.40",
     "@types/jest": "^24.0.15",
     "@types/jscodeshift": "^0.6.1",

--- a/packages/core/src/components/DatePickerInput/Input/index.tsx
+++ b/packages/core/src/components/DatePickerInput/Input/index.tsx
@@ -43,7 +43,7 @@ export default class PrivatePickerInput extends DayPickerInput {
 
   handleOverlayFocus?(): void;
 
-  private loadRef = (ref: HTMLInputElement | null) => {
+  private loadInputRef = (ref: HTMLInputElement | null) => {
     // @ts-ignore Ignore typings
     const { propagateRef } = this.props.inputProps;
 
@@ -54,7 +54,7 @@ export default class PrivatePickerInput extends DayPickerInput {
     }
   };
 
-  private handlePickerRef = (ref: any) => {
+  private loadPickerRef = (ref: any) => {
     this.daypicker = ref;
   };
 
@@ -93,7 +93,7 @@ export default class PrivatePickerInput extends DayPickerInput {
         onBlur={this.handleOverlayBlur}
       >
         <DatePicker
-          ref={this.handlePickerRef}
+          ref={this.loadPickerRef}
           {...(dayPickerProps as any)}
           month={this.state.month}
           selectedDays={selectedDay}
@@ -123,7 +123,7 @@ export default class PrivatePickerInput extends DayPickerInput {
           onKeyDown={this.handleInputKeyDown}
           onKeyUp={this.handleInputKeyUp}
           onClick={this.handleInputClick}
-          propagateRef={this.loadRef}
+          propagateRef={this.loadInputRef}
         />
 
         {this.state.showOverlay && this.renderOverlay()}

--- a/packages/core/src/components/Multicomplete/private/Chip.tsx
+++ b/packages/core/src/components/Multicomplete/private/Chip.tsx
@@ -18,7 +18,7 @@ export default class MulticompleteChip extends React.Component<Props> {
     const { value } = this.props;
 
     return (
-      <Chip afterIcon={<IconCloseAlt size="2em" />} onIconClick={this.handleClick}>
+      <Chip afterIcon={<IconCloseAlt decorative size="2em" />} onIconClick={this.handleClick}>
         {value}
       </Chip>
     );

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -27,13 +27,11 @@
   "dependencies": {
     "@types/airbnb-prop-types": "^2.13.1",
     "@types/lodash": "^4.14.134",
-    "@types/prop-types": "^15.7.1",
     "@types/shallowequal": "^1.1.1",
     "@types/uuid": "^3.4.4",
     "airbnb-prop-types": "^2.13.2",
     "final-form": "^4.16.1",
     "lodash": "^4.17.11",
-    "prop-types": "^15.7.2",
     "shallowequal": "^1.1.0",
     "utility-types": "^3.7.0",
     "uuid": "^3.3.2"

--- a/packages/forms/src/components/Form/Autocomplete.tsx
+++ b/packages/forms/src/components/Form/Autocomplete.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import BaseAutocomplete, { Props, Item } from '@airbnb/lunar/lib/components/Autocomplete';
+import BaseAutocomplete, { Props } from '@airbnb/lunar/lib/components/Autocomplete';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `Autocomplete` automatically connected to the parent `Form`. */
-export function FormAutocomplete<T extends Item>(props: Props<T> & ConnectToFormProps) {
-  return <BaseAutocomplete<T> {...props} />;
+export function FormAutocomplete(props: Props<any> & ConnectToFormProps<string>) {
+  return <BaseAutocomplete {...props} />;
 }
 
-export default connectToForm()(FormAutocomplete);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormAutocomplete);

--- a/packages/forms/src/components/Form/CheckBox.tsx
+++ b/packages/forms/src/components/Form/CheckBox.tsx
@@ -4,11 +4,12 @@ import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm
 import { toBool } from '../../helpers';
 
 /** `CheckBox` automatically connected to the parent `Form`.  */
-export function FormCheckBox(props: Props & ConnectToFormProps) {
+export function FormCheckBox(props: Props & ConnectToFormProps<boolean>) {
   return <BaseCheckBox {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<boolean>({
+  initialValue: false,
   parse: toBool,
   valueProp: 'checked',
 })(FormCheckBox);

--- a/packages/forms/src/components/Form/CheckBoxController.tsx
+++ b/packages/forms/src/components/Form/CheckBoxController.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import BaseCheckBoxController, { Props } from '@airbnb/lunar/lib/components/CheckBoxController';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `CheckBoxController` automatically connected to the parent `Form`.  */
-export function FormCheckBoxController(props: Props & ConnectToFormProps) {
+export function FormCheckBoxController(props: Props & ConnectToFormProps<string[]>) {
   return <BaseCheckBoxController {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<string[]>({
+  initialValue: [],
   multiple: true,
+  parse: toString,
 })(FormCheckBoxController);

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import BaseDatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `DatePickerInput` automatically connected to the parent `Form`.  */
-export function FormDatePickerInput(props: Props & ConnectToFormProps) {
+export function FormDatePickerInput(props: Props & ConnectToFormProps<string>) {
   return <BaseDatePickerInput {...props} />;
 }
 
-export default connectToForm()(FormDatePickerInput);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormDatePickerInput);

--- a/packages/forms/src/components/Form/DateTimeSelect.tsx
+++ b/packages/forms/src/components/Form/DateTimeSelect.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import BaseDateTimeSelect, { Props } from '@airbnb/lunar/lib/components/DateTimeSelect';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `DateTimeSelect` automatically connected to the parent `Form`.  */
-export function FormDateTimeSelect(props: Props & ConnectToFormProps) {
+export function FormDateTimeSelect(props: Props & ConnectToFormProps<string>) {
   return <BaseDateTimeSelect {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<string>({
   initialValue: new Date().toISOString(),
+  parse: toString,
 })(FormDateTimeSelect);

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -3,10 +3,14 @@ import BaseFileInput, { Props } from '@airbnb/lunar/lib/components/FileInput';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
 
 /** `FileInput` automatically connected to the parent `Form`.  */
-export function FormFileInput(props: Props & ConnectToFormProps) {
+export function FormFileInput(props: Props & ConnectToFormProps<File[]>) {
   return <BaseFileInput {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<File[]>({
+  initialValue: [],
   ignoreValue: true,
+  // This isn't used since we ignore the value,
+  // but is required by the types.
+  parse: value => value as any,
 })(FormFileInput);

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -9,5 +9,4 @@ export function FormFileInput(props: Props & ConnectToFormProps) {
 
 export default connectToForm({
   ignoreValue: true,
-  parse: files => files,
 })(FormFileInput);

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -10,7 +10,4 @@ export function FormFileInput(props: Props & ConnectToFormProps<File[]>) {
 export default connectToForm<File[]>({
   initialValue: [],
   ignoreValue: true,
-  // This isn't used since we ignore the value,
-  // but is required by the types.
-  parse: value => value as any,
 })(FormFileInput);

--- a/packages/forms/src/components/Form/Input.tsx
+++ b/packages/forms/src/components/Form/Input.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import BaseInput, { Props } from '@airbnb/lunar/lib/components/Input';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `Input` automatically connected to the parent `Form`.  */
-export function FormInput(props: Props & ConnectToFormProps) {
+export function FormInput(props: Props & ConnectToFormProps<string>) {
   return <BaseInput {...props} />;
 }
 
-export default connectToForm()(FormInput);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormInput);

--- a/packages/forms/src/components/Form/Multicomplete.tsx
+++ b/packages/forms/src/components/Form/Multicomplete.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import BaseMulticomplete, { Props, Item } from '@airbnb/lunar/lib/components/Multicomplete';
+import BaseMulticomplete, { Props } from '@airbnb/lunar/lib/components/Multicomplete';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `Multicomplete` automatically connected to the parent `Form`.  */
-export function FormMulticomplete<T extends Item>(props: Props<T> & ConnectToFormProps) {
-  return <BaseMulticomplete<T> {...props} />;
+export function FormMulticomplete(props: Props<any> & ConnectToFormProps<string>) {
+  return <BaseMulticomplete {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<string[]>({
+  initialValue: [],
   multiple: true,
+  parse: toString,
 })(FormMulticomplete);

--- a/packages/forms/src/components/Form/Multicomplete.tsx
+++ b/packages/forms/src/components/Form/Multicomplete.tsx
@@ -4,7 +4,7 @@ import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm
 import { toString } from '../../helpers';
 
 /** `Multicomplete` automatically connected to the parent `Form`.  */
-export function FormMulticomplete(props: Props<any> & ConnectToFormProps<string>) {
+export function FormMulticomplete(props: Props<any> & ConnectToFormProps<string[]>) {
   return <BaseMulticomplete {...props} />;
 }
 

--- a/packages/forms/src/components/Form/RadioButtonController.tsx
+++ b/packages/forms/src/components/Form/RadioButtonController.tsx
@@ -3,10 +3,14 @@ import BaseRadioButtonController, {
   Props,
 } from '@airbnb/lunar/lib/components/RadioButtonController';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `RadioButtonController` automatically connected to the parent `Form`.  */
-export function FormRadioButtonController(props: Props & ConnectToFormProps) {
+export function FormRadioButtonController(props: Props & ConnectToFormProps<string>) {
   return <BaseRadioButtonController {...props} />;
 }
 
-export default connectToForm()(FormRadioButtonController);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormRadioButtonController);

--- a/packages/forms/src/components/Form/Select.tsx
+++ b/packages/forms/src/components/Form/Select.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import BaseSelect, { Props } from '@airbnb/lunar/lib/components/Select';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `Select` automatically connected to the parent `Form`.  */
-export function FormSelect(props: Props & ConnectToFormProps) {
+export function FormSelect(props: Props & ConnectToFormProps<string>) {
   return <BaseSelect {...props} />;
 }
 
-export default connectToForm()(FormSelect);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormSelect);

--- a/packages/forms/src/components/Form/Switch.tsx
+++ b/packages/forms/src/components/Form/Switch.tsx
@@ -4,11 +4,12 @@ import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm
 import { toBool } from '../../helpers';
 
 /** `Switch` automatically connected to the parent `Form`.  */
-export function FormSwitch(props: Props & ConnectToFormProps) {
+export function FormSwitch(props: Props & ConnectToFormProps<boolean>) {
   return <BaseSwitch {...props} />;
 }
 
-export default connectToForm({
+export default connectToForm<boolean>({
+  initialValue: false,
   parse: toBool,
   valueProp: 'checked',
 })(FormSwitch);

--- a/packages/forms/src/components/Form/TextArea.tsx
+++ b/packages/forms/src/components/Form/TextArea.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import BaseTextArea, { Props } from '@airbnb/lunar/lib/components/TextArea';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `TextArea` automatically connected to the parent `Form`.  */
-export function FormTextArea(props: Props & ConnectToFormProps) {
+export function FormTextArea(props: Props & ConnectToFormProps<string>) {
   return <BaseTextArea {...props} />;
 }
 
-export default connectToForm()(FormTextArea);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormTextArea);

--- a/packages/forms/src/components/Form/ToggleButtonController.tsx
+++ b/packages/forms/src/components/Form/ToggleButtonController.tsx
@@ -3,10 +3,14 @@ import BaseToggleButtonController, {
   Props,
 } from '@airbnb/lunar/lib/components/ToggleButtonController';
 import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import { toString } from '../../helpers';
 
 /** `ToggleButtonController` automatically connected to the parent `Form`.  */
-export function FormToggleButtonController(props: Props & ConnectToFormProps) {
+export function FormToggleButtonController(props: Props & ConnectToFormProps<string>) {
   return <BaseToggleButtonController {...props} />;
 }
 
-export default connectToForm()(FormToggleButtonController);
+export default connectToForm<string>({
+  initialValue: '',
+  parse: toString,
+})(FormToggleButtonController);

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -19,7 +19,7 @@ import T from '@airbnb/lunar/lib/components/Translate';
 import { getErrorMessage } from '@airbnb/lunar/lib/components/ErrorMessage';
 import FormErrorMessage from '@airbnb/lunar/lib/components/FormErrorMessage';
 import FormContext from '../FormContext';
-import { Context, Errors, Parse, Field, FieldInput, FieldOutput } from '../../types';
+import { Context, Errors, Parse, Field, DefaultValue } from '../../types';
 import { throttleToSinglePromise } from '../../helpers';
 
 function mapSubscriptions(subscriptions: string[]): { [sub: string]: boolean } {
@@ -56,7 +56,7 @@ export type Props<Data extends object> = {
    * Callback fired after validation. Must return true for passed validation,
    * or false for failed validation.
    */
-  onValidate?: (data: Data, errors: Errors, fields: FieldState<FieldInput>[]) => boolean;
+  onValidate?: (data: Data, errors: Errors, fields: FieldState<any>[]) => boolean;
   /** A list of `final-form` subscriptions to listen to. */
   subscriptions?: (keyof FormSubscription)[];
 };
@@ -124,7 +124,7 @@ export default class Form<Data extends object = any> extends React.Component<
   /**
    * Cast a value using the fields `parse` function.
    */
-  castValue(value: FieldInput, parse: Parse): FieldOutput {
+  castValue(value: DefaultValue, parse: Parse<any>): any {
     if (value === null || value === undefined) {
       return '';
     }
@@ -164,7 +164,7 @@ export default class Form<Data extends object = any> extends React.Component<
   /**
    * Return a list of all field states.
    */
-  getFields = (): FieldState<FieldInput>[] => {
+  getFields = (): FieldState<any>[] => {
     if (!this.form) {
       return [];
     }
@@ -326,7 +326,7 @@ export default class Form<Data extends object = any> extends React.Component<
    * Register a new field and set their default value into the data set.
    * Optionally validate the default value if `validateDefaultValue` is true.
    */
-  registerField = <T extends unknown>(field: Field, onUpdate: FieldSubscriber<T>) => {
+  registerField = <T extends unknown>(field: Field<any>, onUpdate: FieldSubscriber<T>) => {
     const { name, isEqual, subscriptions = [], validateFields = [] } = field;
     const unregister = this.form.registerField(name, onUpdate, mapSubscriptions(subscriptions), {
       isEqual,
@@ -352,7 +352,7 @@ export default class Form<Data extends object = any> extends React.Component<
   /**
    * Form mutator to manually set a fields configuration and value.
    */
-  setFieldConfig([name, config]: [string, Field], { fields, formState }: any) {
+  setFieldConfig([name, config]: [string, Field<any>], { fields, formState }: any) {
     const field = fields[name];
     const initial = getIn(formState.initialValues, name);
     const value = typeof initial === 'undefined' ? config.defaultValue : initial;
@@ -410,7 +410,7 @@ export default class Form<Data extends object = any> extends React.Component<
   /**
    * Wrap a validator in a closure to correctly handle error states.
    */
-  wrapValidator(validator?: FieldValidator<FieldInput>): FieldValidator<FieldInput> {
+  wrapValidator(validator?: FieldValidator<any>): FieldValidator<any> {
     return async (value, data) => {
       if (validator) {
         try {

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -19,7 +19,7 @@ import T from '@airbnb/lunar/lib/components/Translate';
 import { getErrorMessage } from '@airbnb/lunar/lib/components/ErrorMessage';
 import FormErrorMessage from '@airbnb/lunar/lib/components/FormErrorMessage';
 import FormContext from '../FormContext';
-import { Context, Errors, Parse, Field, DefaultValue } from '../../types';
+import { Context, Errors, Parse, Field } from '../../types';
 import { throttleToSinglePromise } from '../../helpers';
 
 function mapSubscriptions(subscriptions: string[]): { [sub: string]: boolean } {
@@ -124,18 +124,10 @@ export default class Form<Data extends object = any> extends React.Component<
   /**
    * Cast a value using the fields `parse` function.
    */
-  castValue(value: DefaultValue, parse: Parse<any>): any {
-    if (value === null || value === undefined) {
-      return '';
-    }
-
-    if (typeof value === 'boolean') {
-      return value;
-    }
-
+  castValue(value: any, parse: Parse<any>) {
     if (Array.isArray(value)) {
       // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
-      return (value as any).map(parse);
+      return value.map(parse);
     }
 
     return parse(value);

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -9,6 +9,7 @@ import { Context, Parse, Field, DefaultValue } from '../types';
 // Keep in sync with props!
 export const PROP_NAMES = [
   'defaultValue',
+  'form',
   'isEqual',
   'name',
   'onBatchChange',
@@ -89,7 +90,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
       };
 
       // https://github.com/final-form/final-form#fieldstate
-      // @ts-ignore All other non-critical fields get set on mount
+      // @ts-ignore Other non-critical fields get set on mount
       state: ConnectToFormState = {
         blur() {},
         error: '',
@@ -153,20 +154,20 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
         return error instanceof Error ? error.message : String(error);
       }
 
-      formatValue(defaultValue: DefaultValue): T {
+      formatValue(defaultValue: DefaultValue) {
         const cast = this.props.parse as Parse<T>;
-        let value: any = defaultValue;
+        let value = defaultValue;
 
         if (multiple && !Array.isArray(value)) {
-          value = [value];
+          value = [value] as string[];
         }
 
         if (Array.isArray(value)) {
           // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
-          return (value as any).map(cast);
+          return value.map(cast);
         }
 
-        return cast(value) as any;
+        return cast(value);
       }
 
       omitFormProps(props: Partial<OwnProps>): Props {
@@ -236,7 +237,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
         };
 
         if (!ignoreValue) {
-          props[valueProp as 'value'] = this.formatValue(value);
+          props[valueProp as 'value'] = this.formatValue(value) as T;
         }
 
         return <WrappedComponent {...this.omitFormProps(this.props)} {...props} />;
@@ -246,7 +247,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
     function ConnectToFormWrapper(props: OwnProps) {
       const form = useContext(FormContext);
 
-      return form ? <ConnectToForm {...(props as any)} form={form!} /> : null;
+      return form ? <ConnectToForm {...(props as any)} form={form} /> : null;
     }
 
     return finishHOC('connectToForm', ConnectToFormWrapper, WrappedComponent);

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -155,9 +155,10 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
       }
 
       formatValue(defaultValue: DefaultValue) {
-        const cast = this.props.parse;
+        const cast = this.props.parse as Parse<T> | undefined;
         let value = defaultValue;
 
+        // Some fields dont use the value, so wont have a parser
         if (!cast) {
           return value;
         }
@@ -168,7 +169,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
 
         if (Array.isArray(value)) {
           // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
-          return value.map(cast!);
+          return value.map(cast);
         }
 
         return cast(value);
@@ -210,7 +211,8 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
         }
       };
 
-      private handleUpdate = /* istanbul ignore next */ (state: FieldState<any>) => {
+      // istanbul ignore next
+      private handleUpdate = (state: FieldState<any>) => {
         if (!this.mounted) {
           return;
         }

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -37,7 +37,7 @@ export type Options<T> = {
   ignoreValue?: boolean;
   initialValue: T;
   multiple?: boolean;
-  parse: Parse<T>;
+  parse?: Parse<T>;
   valueProp?: 'value' | 'checked';
 };
 
@@ -155,8 +155,12 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
       }
 
       formatValue(defaultValue: DefaultValue) {
-        const cast = this.props.parse as Parse<T>;
+        const cast = this.props.parse;
         let value = defaultValue;
+
+        if (!cast) {
+          return value;
+        }
 
         if (multiple && !Array.isArray(value)) {
           value = [value] as string[];
@@ -164,7 +168,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
 
         if (Array.isArray(value)) {
           // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
-          return value.map(cast);
+          return value.map(cast!);
         }
 
         return cast(value);
@@ -206,7 +210,7 @@ export default function connectToForm<T>(options: Options<T>) /* infer */ {
         }
       };
 
-      private handleUpdate = (state: FieldState<any>) => {
+      private handleUpdate = /* istanbul ignore next */ (state: FieldState<any>) => {
         if (!this.mounted) {
           return;
         }

--- a/packages/forms/src/helpers.ts
+++ b/packages/forms/src/helpers.ts
@@ -1,9 +1,11 @@
+import { FieldInput } from './types';
+
 export { getIn, setIn } from 'final-form';
 
 /**
  * Return true if the value is primitive.
  */
-export function isPrimitive(value: unknown): boolean {
+export function isPrimitive(value: FieldInput): boolean {
   switch (typeof value) {
     case 'string':
     case 'number':
@@ -18,7 +20,7 @@ export function isPrimitive(value: unknown): boolean {
 /**
  * Return an empty string for non-primitives, otherwise cast to a string.
  */
-export function toString(value: unknown): string {
+export function toString(value: FieldInput): string {
   return isPrimitive(value) ? String(value) : '';
 }
 
@@ -26,7 +28,7 @@ export function toString(value: unknown): string {
  * Return false for non-primitives, otherwise cast to a boolean.
  * Support "true", "on", and "1" (recommended) strings as true boolean values.
  */
-export function toBool(value: unknown): boolean {
+export function toBool(value: FieldInput): boolean {
   if (!isPrimitive(value)) {
     return false;
   }
@@ -41,7 +43,7 @@ export function toBool(value: unknown): boolean {
 /**
  * Return 0 for non-primitive, falsy, or NaN values, otherwise cast to a number.
  */
-export function toNumber(value: unknown): number {
+export function toNumber(value: FieldInput): number {
   if (!value || !isPrimitive(value)) {
     return 0;
   }
@@ -55,7 +57,7 @@ export function toNumber(value: unknown): number {
  * Return "1" for a truthy value and "" for a falsy one.
  * If the value is undefined, return the initial checked state.
  */
-export function fromBool(value: unknown, checked: boolean = true): string {
+export function fromBool(value: FieldInput, checked: boolean = true): string {
   if (typeof value === 'undefined') {
     return checked ? '1' : '';
   }

--- a/packages/forms/src/helpers.ts
+++ b/packages/forms/src/helpers.ts
@@ -1,11 +1,11 @@
-import { FieldInput } from './types';
+import { DefaultValue } from './types';
 
 export { getIn, setIn } from 'final-form';
 
 /**
  * Return true if the value is primitive.
  */
-export function isPrimitive(value: FieldInput): boolean {
+export function isPrimitive(value: DefaultValue): boolean {
   switch (typeof value) {
     case 'string':
     case 'number':
@@ -20,7 +20,7 @@ export function isPrimitive(value: FieldInput): boolean {
 /**
  * Return an empty string for non-primitives, otherwise cast to a string.
  */
-export function toString(value: FieldInput): string {
+export function toString(value: DefaultValue): string {
   return isPrimitive(value) ? String(value) : '';
 }
 
@@ -28,7 +28,7 @@ export function toString(value: FieldInput): string {
  * Return false for non-primitives, otherwise cast to a boolean.
  * Support "true", "on", and "1" (recommended) strings as true boolean values.
  */
-export function toBool(value: FieldInput): boolean {
+export function toBool(value: DefaultValue): boolean {
   if (!isPrimitive(value)) {
     return false;
   }
@@ -43,7 +43,7 @@ export function toBool(value: FieldInput): boolean {
 /**
  * Return 0 for non-primitive, falsy, or NaN values, otherwise cast to a number.
  */
-export function toNumber(value: FieldInput): number {
+export function toNumber(value: DefaultValue): number {
   if (!value || !isPrimitive(value)) {
     return 0;
   }
@@ -57,7 +57,7 @@ export function toNumber(value: FieldInput): number {
  * Return "1" for a truthy value and "" for a falsy one.
  * If the value is undefined, return the initial checked state.
  */
-export function fromBool(value: FieldInput, checked: boolean = true): string {
+export function fromBool(value: DefaultValue, checked: boolean = true): string {
   if (typeof value === 'undefined') {
     return checked ? '1' : '';
   }

--- a/packages/forms/src/helpers.ts
+++ b/packages/forms/src/helpers.ts
@@ -1,11 +1,9 @@
-import { DefaultValue } from './types';
-
 export { getIn, setIn } from 'final-form';
 
 /**
  * Return true if the value is primitive.
  */
-export function isPrimitive(value: DefaultValue): boolean {
+export function isPrimitive(value: unknown): boolean {
   switch (typeof value) {
     case 'string':
     case 'number':
@@ -20,7 +18,7 @@ export function isPrimitive(value: DefaultValue): boolean {
 /**
  * Return an empty string for non-primitives, otherwise cast to a string.
  */
-export function toString(value: DefaultValue): string {
+export function toString(value: unknown): string {
   return isPrimitive(value) ? String(value) : '';
 }
 
@@ -28,7 +26,7 @@ export function toString(value: DefaultValue): string {
  * Return false for non-primitives, otherwise cast to a boolean.
  * Support "true", "on", and "1" (recommended) strings as true boolean values.
  */
-export function toBool(value: DefaultValue): boolean {
+export function toBool(value: unknown): boolean {
   if (!isPrimitive(value)) {
     return false;
   }
@@ -43,7 +41,7 @@ export function toBool(value: DefaultValue): boolean {
 /**
  * Return 0 for non-primitive, falsy, or NaN values, otherwise cast to a number.
  */
-export function toNumber(value: DefaultValue): number {
+export function toNumber(value: unknown): number {
   if (!value || !isPrimitive(value)) {
     return 0;
   }
@@ -57,7 +55,7 @@ export function toNumber(value: DefaultValue): number {
  * Return "1" for a truthy value and "" for a falsy one.
  * If the value is undefined, return the initial checked state.
  */
-export function fromBool(value: DefaultValue, checked: boolean = true): string {
+export function fromBool(value: unknown, checked: boolean = true): string {
   if (typeof value === 'undefined') {
     return checked ? '1' : '';
   }

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -17,7 +17,7 @@ import {
 // string - Autocomplete, DatePickerInput, DateTimeSelect, Input, RadioButtonController, Select, TextArea, ToggleButtonController
 // string[] - CheckBoxController, Multicomplete
 // boolean - CheckBox, RadioButton, Switch
-// File[] - FileInput3
+// File[] - FileInput
 
 export type Context = {
   change: (name: string, value: any, batchValues?: object) => void;

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -23,7 +23,7 @@ export type Context = {
   change: (name: string, value: any, batchValues?: object) => void;
   getFields: () => FieldState<any>[];
   getState: () => FormState<any>;
-  register: (field: Field, onUpdate: FieldSubscriber<any>) => Unsubscribe;
+  register: (field: Field<any>, onUpdate: FieldSubscriber<any>) => Unsubscribe;
   submit: () => Promise<object | undefined>;
 };
 
@@ -31,22 +31,19 @@ export type Errors = {
   [key: string]: string;
 };
 
-export type Parse = (value: FieldInput) => string | boolean;
+export type UnboxParsedValue<T> = T extends (infer U)[] ? U : T;
 
-// Value coming in via `defaultValue`
-export type FieldInput = boolean | string | number | string[] | number[] | null | undefined;
+export type Parse<T> = (value: ParseValue) => UnboxParsedValue<T>;
 
-// Value passed down to `value`
-export type FieldOutput = string | string[] | boolean;
+export type ParseValue = boolean | string | number | null | undefined;
 
-// Value passed as the 1st argument to `onChange`
-export type OnChangeValue = string | string[] | boolean | File[];
+export type DefaultValue = boolean | string | number | string[] | number[] | null | undefined;
 
-export type Field<T = FieldInput> = {
-  defaultValue?: T;
+export type Field<T> = {
+  defaultValue?: DefaultValue;
   isEqual?: IsEqual;
   name: string;
-  parse?: Parse;
+  parse?: Parse<T>;
   subscriptions?: (keyof FieldSubscription)[];
   validateDefaultValue?: boolean;
   validateFields?: string[];

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -31,13 +31,13 @@ export type Errors = {
   [key: string]: string;
 };
 
+export type DefaultValue = boolean | string | string[] | null | undefined;
+
+export type ParseValue = boolean | string | null | undefined;
+
 export type UnboxParsedValue<T> = T extends (infer U)[] ? U : T;
 
 export type Parse<T> = (value: ParseValue) => UnboxParsedValue<T>;
-
-export type ParseValue = boolean | string | number | null | undefined;
-
-export type DefaultValue = boolean | string | number | string[] | number[] | null | undefined;
 
 export type Field<T> = {
   defaultValue?: DefaultValue;
@@ -47,5 +47,5 @@ export type Field<T> = {
   subscriptions?: (keyof FieldSubscription)[];
   validateDefaultValue?: boolean;
   validateFields?: string[];
-  validator: FieldValidator<any>;
+  validator: FieldValidator<T>;
 };

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -8,8 +8,19 @@ import {
   Unsubscribe,
 } from 'final-form';
 
+// value:
+// string - Autocomplete, DatePickerInput, DateTimeSelect, FileInput, Input, RadioButton, RadioButtonController, Select, TextArea, ToggleButtonController
+// string[] - CheckBoxController, Multicomplete
+// boolean - CheckBox, Switch
+
+// onChange:
+// string - Autocomplete, DatePickerInput, DateTimeSelect, Input, RadioButtonController, Select, TextArea, ToggleButtonController
+// string[] - CheckBoxController, Multicomplete
+// boolean - CheckBox, RadioButton, Switch
+// File[] - FileInput3
+
 export type Context = {
-  change: (name: string, value: string, batchValues?: object) => void;
+  change: (name: string, value: any, batchValues?: object) => void;
   getFields: () => FieldState<any>[];
   getState: () => FormState<any>;
   register: (field: Field, onUpdate: FieldSubscriber<any>) => Unsubscribe;
@@ -20,15 +31,24 @@ export type Errors = {
   [key: string]: string;
 };
 
-export type Parse = (value: unknown) => unknown;
+export type Parse = (value: FieldInput) => string | boolean;
 
-export type Field<T = any> = {
-  defaultValue?: boolean | string | number | string[] | number[];
+// Value coming in via `defaultValue`
+export type FieldInput = boolean | string | number | string[] | number[] | null | undefined;
+
+// Value passed down to `value`
+export type FieldOutput = string | string[] | boolean;
+
+// Value passed as the 1st argument to `onChange`
+export type OnChangeValue = string | string[] | boolean | File[];
+
+export type Field<T = FieldInput> = {
+  defaultValue?: T;
   isEqual?: IsEqual;
   name: string;
   parse?: Parse;
   subscriptions?: (keyof FieldSubscription)[];
   validateDefaultValue?: boolean;
   validateFields?: string[];
-  validator: FieldValidator<T>;
+  validator: FieldValidator<any>;
 };

--- a/packages/forms/test/components/Form.test.tsx
+++ b/packages/forms/test/components/Form.test.tsx
@@ -530,7 +530,12 @@ describe('<Form />', () => {
 
   describe('setFieldConfig()', () => {
     it('sets all the correct values', () => {
-      const config = { name: 'foo', defaultValue: 123, validateDefaultValue: true, validator() {} };
+      const config = {
+        name: 'foo',
+        defaultValue: '123',
+        validateDefaultValue: true,
+        validator() {},
+      };
       const fields = { foo: { data: {} } };
       const formState = { initialValues: {}, values: {} };
 
@@ -539,18 +544,18 @@ describe('<Form />', () => {
       expect(fields).toEqual({
         foo: {
           data: { config },
-          initial: 123,
-          value: 123,
+          initial: '123',
+          value: '123',
           touched: true,
         },
       });
 
       expect(formState).toEqual({
         initialValues: {
-          foo: 123,
+          foo: '123',
         },
         values: {
-          foo: 123,
+          foo: '123',
         },
       });
     });

--- a/packages/forms/test/components/Form/Autocomplete.test.tsx
+++ b/packages/forms/test/components/Form/Autocomplete.test.tsx
@@ -1,38 +1,39 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseAutocomplete from '@airbnb/lunar/lib/components/Autocomplete';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import Autocomplete from '../../../src/components/Form/Autocomplete';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<Autocomplete />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <Autocomplete
-          label="Label"
-          accessibilityLabel="Label"
-          name="foo"
-          defaultValue="bar"
-          onLoadItems={() => Promise.resolve([])}
-          validator={() => {}}
-        />,
-      ),
-      'FormAutocomplete',
-      form,
+    const wrapper = mount(
+      <Autocomplete
+        label="Label"
+        accessibilityLabel="Label"
+        name="foo"
+        defaultValue="bar"
+        onLoadItems={() => Promise.resolve([])}
+        validator={() => {}}
+      />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseAutocomplete)).toHaveLength(1);
+    expect(wrapper.find(BaseAutocomplete)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/CheckBox.test.tsx
+++ b/packages/forms/test/components/Form/CheckBox.test.tsx
@@ -1,39 +1,44 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseCheckBox from '@airbnb/lunar/lib/components/CheckBox';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import CheckBox from '../../../src/components/Form/CheckBox';
 import { toBool } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<CheckBox />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<CheckBox label="Label" name="foo" defaultValue="1" validator={() => {}} />),
-      'FormCheckBox',
-      form,
+    const wrapper = mount(
+      <CheckBox label="Label" name="foo" defaultValue="1" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: '1', parse: toBool }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseCheckBox)).toHaveLength(1);
+    expect(wrapper.find(BaseCheckBox)).toHaveLength(1);
   });
 
   it('sets checked prop', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<CheckBox label="Label" name="foo" defaultValue="1" validator={() => {}} />),
-      'FormCheckBox',
-      form,
+    const wrapper = mount(
+      <CheckBox label="Label" name="foo" defaultValue="1" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(wrapper.prop('checked')).toBe(true);
+    expect(wrapper.find(BaseCheckBox).prop('checked')).toBe(true);
   });
 });

--- a/packages/forms/test/components/Form/CheckBoxController.test.tsx
+++ b/packages/forms/test/components/Form/CheckBoxController.test.tsx
@@ -1,59 +1,60 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseCheckBoxController from '@airbnb/lunar/lib/components/CheckBoxController';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import CheckBoxController from '../../../src/components/Form/CheckBoxController';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<CheckBoxController />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <CheckBoxController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
-          {CB => (
-            <div>
-              <CB value="foo" label="Foo" />
-              <CB value="bar" label="Bar" />
-              <CB value="baz" label="Baz" />
-            </div>
-          )}
-        </CheckBoxController>,
-      ),
-      'FormCheckBoxController',
-      form,
+    const wrapper = mount(
+      <CheckBoxController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+        {CB => (
+          <div>
+            <CB value="foo" label="Foo" />
+            <CB value="bar" label="Bar" />
+            <CB value="baz" label="Baz" />
+          </div>
+        )}
+      </CheckBoxController>,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseCheckBoxController)).toHaveLength(1);
+    expect(wrapper.find(BaseCheckBoxController)).toHaveLength(1);
   });
 
   it('passes value as an array', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <CheckBoxController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
-          {CB => (
-            <div>
-              <CB value="foo" label="Foo" />
-              <CB value="bar" label="Bar" />
-              <CB value="baz" label="Baz" />
-            </div>
-          )}
-        </CheckBoxController>,
-      ),
-      'FormCheckBoxController',
-      form,
+    const wrapper = mount(
+      <CheckBoxController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+        {CB => (
+          <div>
+            <CB value="foo" label="Foo" />
+            <CB value="bar" label="Bar" />
+            <CB value="baz" label="Baz" />
+          </div>
+        )}
+      </CheckBoxController>,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(wrapper.prop('value')).toEqual(['bar']);
+    expect(wrapper.find(BaseCheckBoxController).prop('value')).toEqual(['bar']);
   });
 });

--- a/packages/forms/test/components/Form/DatePickerInput.test.tsx
+++ b/packages/forms/test/components/Form/DatePickerInput.test.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseDatePickerInput from '@airbnb/lunar/lib/components/DatePickerInput';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import DatePickerInput from '../../../src/components/Form/DatePickerInput';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<DatePickerInput />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<DatePickerInput label="Label" name="foo" defaultValue="bar" validator={() => {}} />),
-      'FormDatePickerInput',
-      form,
+    const wrapper = mount(
+      <DatePickerInput label="Label" name="foo" defaultValue="bar" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseDatePickerInput)).toHaveLength(1);
+    expect(wrapper.find(BaseDatePickerInput)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/DateTimeSelect.test.tsx
+++ b/packages/forms/test/components/Form/DateTimeSelect.test.tsx
@@ -1,30 +1,33 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseDateTimeSelect from '@airbnb/lunar/lib/components/DateTimeSelect';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import DateTimeSelect from '../../../src/components/Form/DateTimeSelect';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<DateTimeSelect />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
     const date = new Date().toISOString();
-    const wrapper = unwrapHOCs(
-      shallow(<DateTimeSelect label="Label" name="foo" defaultValue={date} validator={() => {}} />),
-      'FormDateTimeSelect',
-      form,
+    const wrapper = mount(
+      <DateTimeSelect label="Label" name="foo" defaultValue={date} validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: date, parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseDateTimeSelect)).toHaveLength(1);
+    expect(wrapper.find(BaseDateTimeSelect)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/FileInput.test.tsx
+++ b/packages/forms/test/components/Form/FileInput.test.tsx
@@ -1,28 +1,31 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseFileInput from '@airbnb/lunar/lib/components/FileInput';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import FileInput from '../../../src/components/Form/FileInput';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<FileInput />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<FileInput label="Label" name="foo" defaultValue="bar" validator={() => {}} />),
-      'FormFileInput',
-      form,
+    const wrapper = mount(
+      <FileInput label="Label" name="foo" defaultValue="bar" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar' }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseFileInput)).toHaveLength(1);
+    expect(wrapper.find(BaseFileInput)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/Input.test.tsx
+++ b/packages/forms/test/components/Form/Input.test.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseInput from '@airbnb/lunar/lib/components/Input';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import Input from '../../../src/components/Form/Input';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<Input />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<Input label="Label" name="foo" defaultValue="bar" validator={() => {}} />),
-      'FormInput',
-      form,
+    const wrapper = mount(
+      <Input label="Label" name="foo" defaultValue="bar" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseInput)).toHaveLength(1);
+    expect(wrapper.find(BaseInput)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/Multicomplete.test.tsx
+++ b/packages/forms/test/components/Form/Multicomplete.test.tsx
@@ -1,38 +1,39 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseMulticomplete from '@airbnb/lunar/lib/components/Multicomplete';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import Multicomplete from '../../../src/components/Form/Multicomplete';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<Multicomplete />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <Multicomplete
-          label="Label"
-          accessibilityLabel="Label"
-          name="foo"
-          defaultValue="bar"
-          onLoadItems={() => Promise.resolve([])}
-          validator={() => {}}
-        />,
-      ),
-      'FormMulticomplete',
-      form,
+    const wrapper = mount(
+      <Multicomplete
+        label="Label"
+        accessibilityLabel="Label"
+        name="foo"
+        defaultValue="bar"
+        onLoadItems={() => Promise.resolve([])}
+        validator={() => {}}
+      />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseMulticomplete)).toHaveLength(1);
+    expect(wrapper.find(BaseMulticomplete)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/RadioButtonController.test.tsx
+++ b/packages/forms/test/components/Form/RadioButtonController.test.tsx
@@ -1,39 +1,40 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseRadioButtonController from '@airbnb/lunar/lib/components/RadioButtonController';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import RadioButtonController from '../../../src/components/Form/RadioButtonController';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<RadioButtonController />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <RadioButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
-          {RB => (
-            <div>
-              <RB value="foo" label="Foo" />
-              <RB value="bar" label="Bar" />
-              <RB value="baz" label="Baz" />
-            </div>
-          )}
-        </RadioButtonController>,
-      ),
-      'FormRadioButtonController',
-      form,
+    const wrapper = mount(
+      <RadioButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+        {RB => (
+          <div>
+            <RB value="foo" label="Foo" />
+            <RB value="bar" label="Bar" />
+            <RB value="baz" label="Baz" />
+          </div>
+        )}
+      </RadioButtonController>,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseRadioButtonController)).toHaveLength(1);
+    expect(wrapper.find(BaseRadioButtonController)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/Select.test.tsx
+++ b/packages/forms/test/components/Form/Select.test.tsx
@@ -1,35 +1,36 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseSelect from '@airbnb/lunar/lib/components/Select';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import Select from '../../../src/components/Form/Select';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<Select />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <Select label="Label" name="foo" defaultValue="bar" validator={() => {}}>
-          <option value="foo">Foo</option>
-          <option value="bar">Bar</option>
-          <option value="baz">Baz</option>
-        </Select>,
-      ),
-      'FormSelect',
-      form,
+    const wrapper = mount(
+      <Select label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+        <option value="baz">Baz</option>
+      </Select>,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseSelect)).toHaveLength(1);
+    expect(wrapper.find(BaseSelect)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/Switch.test.tsx
+++ b/packages/forms/test/components/Form/Switch.test.tsx
@@ -1,39 +1,44 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseSwitch from '@airbnb/lunar/lib/components/Switch';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import Switch from '../../../src/components/Form/Switch';
 import { toBool } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<Switch />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<Switch label="Label" name="foo" defaultValue="1" validator={() => {}} />),
-      'FormSwitch',
-      form,
+    const wrapper = mount(
+      <Switch label="Label" name="foo" defaultValue="1" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: '1', parse: toBool }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseSwitch)).toHaveLength(1);
+    expect(wrapper.find(BaseSwitch)).toHaveLength(1);
   });
 
   it('sets checked prop', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<Switch label="Label" name="foo" defaultValue="1" validator={() => {}} />),
-      'FormSwitch',
-      form,
+    const wrapper = mount(
+      <Switch label="Label" name="foo" defaultValue="1" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(wrapper.prop('checked')).toBe(true);
+    expect(wrapper.find(BaseSwitch).prop('checked')).toBe(true);
   });
 });

--- a/packages/forms/test/components/Form/TextArea.test.tsx
+++ b/packages/forms/test/components/Form/TextArea.test.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseTextArea from '@airbnb/lunar/lib/components/TextArea';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import TextArea from '../../../src/components/Form/TextArea';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<TextArea />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(<TextArea label="Label" name="foo" defaultValue="bar" validator={() => {}} />),
-      'FormTextArea',
-      form,
+    const wrapper = mount(
+      <TextArea label="Label" name="foo" defaultValue="bar" validator={() => {}} />,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseTextArea)).toHaveLength(1);
+    expect(wrapper.find(BaseTextArea)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/components/Form/ToggleButtonController.test.tsx
+++ b/packages/forms/test/components/Form/ToggleButtonController.test.tsx
@@ -1,39 +1,40 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import BaseToggleButtonController from '@airbnb/lunar/lib/components/ToggleButtonController';
-import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import ToggleButtonController from '../../../src/components/Form/ToggleButtonController';
 import { toString } from '../../../src/helpers';
+import { Context } from '../../../src/types';
+import { WrappingFormComponent, createFormContext } from '../../utils';
 
 describe('<ToggleButtonController />', () => {
-  const form = {
-    change() {},
-    getState: () => ({} as any),
-    register: jest.fn(),
-  };
+  let context: Context;
+
+  beforeEach(() => {
+    context = createFormContext();
+  });
 
   it('connects to the form', () => {
-    const wrapper = unwrapHOCs(
-      shallow(
-        <ToggleButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
-          {ProxyButton => (
-            <div>
-              <ProxyButton value="foo">Foo</ProxyButton>
-              <ProxyButton value="bar">Bar</ProxyButton>
-              <ProxyButton value="baz">Baz</ProxyButton>
-            </div>
-          )}
-        </ToggleButtonController>,
-      ),
-      'FormToggleButtonController',
-      form,
+    const wrapper = mount(
+      <ToggleButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+        {ProxyButton => (
+          <div>
+            <ProxyButton value="foo">Foo</ProxyButton>
+            <ProxyButton value="bar">Bar</ProxyButton>
+            <ProxyButton value="baz">Baz</ProxyButton>
+          </div>
+        )}
+      </ToggleButtonController>,
+      {
+        wrappingComponent: WrappingFormComponent,
+        wrappingComponentProps: { context },
+      },
     );
 
-    expect(form.register).toHaveBeenCalledWith(
+    expect(context.register).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'foo', defaultValue: 'bar', parse: toString }),
       expect.anything(),
     );
 
-    expect(wrapper.shallow().find(BaseToggleButtonController)).toHaveLength(1);
+    expect(wrapper.find(BaseToggleButtonController)).toHaveLength(1);
   });
 });

--- a/packages/forms/test/composers/connectToForm.test.tsx
+++ b/packages/forms/test/composers/connectToForm.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
-import connectToForm, { PROP_NAMES } from '../../src/composers/connectToForm';
+import connectToForm, {
+  PROP_NAMES,
+  ConnectToFormWrapperProps,
+  ConnectToFormProps,
+} from '../../src/composers/connectToForm';
 import { Context } from '../../src/types';
 import { toString, toNumber, toBool } from '../../src/helpers';
 import { createFormContext, WrappingFormComponent } from '../utils';
@@ -15,12 +19,6 @@ describe('connectToForm()', () => {
     parse: toString,
   })(BaseField);
 
-  const HocMultiple = connectToForm<string>({
-    initialValue: '',
-    parse: toString,
-    multiple: true,
-  })(BaseField);
-
   const HocChecked = connectToForm<boolean>({
     initialValue: false,
     valueProp: 'checked',
@@ -30,6 +28,11 @@ describe('connectToForm()', () => {
   const HocInitialValue = connectToForm<number>({
     initialValue: 123,
     parse: toNumber,
+  })(BaseField);
+
+  const HocInvalid = connectToForm<string>({
+    initialValue: '',
+    parse: toString,
   })(BaseField);
 
   const props = {
@@ -44,11 +47,19 @@ describe('connectToForm()', () => {
     form = createFormContext();
   });
 
-  function unwrap(element: any): Enzyme.ReactWrapper {
+  function unwrap(
+    element: React.ReactElement<any>,
+  ): Enzyme.ReactWrapper<ConnectToFormWrapperProps<any>> {
     return mount(element, {
       wrappingComponent: WrappingFormComponent,
       wrappingComponentProps: { context: form },
     });
+  }
+
+  function findField(
+    wrapper: Enzyme.ReactWrapper<any, any, any>,
+  ): Enzyme.ReactWrapper<ConnectToFormProps<any>> {
+    return wrapper.find(BaseField);
   }
 
   it('returns an HOC', () => {
@@ -56,13 +67,13 @@ describe('connectToForm()', () => {
     expect((Hoc as any).WrappedComponent).toBe(BaseField);
   });
 
-  it.only('sets `defaultValue` from `initialValue` option', () => {
+  it('sets `defaultValue` from `initialValue` option', () => {
     const wrapper = unwrap(<HocInitialValue name="foo" validator={() => {}} />);
 
     expect(wrapper.find(BaseField).prop('value')).toBe(123);
   });
 
-  it.only('doesnt pass field props to wrapped component', () => {
+  it('doesnt pass field props to wrapped component', () => {
     const wrapper = unwrap(<Hoc {...props} />);
 
     PROP_NAMES.forEach(name => {
@@ -76,7 +87,7 @@ describe('connectToForm()', () => {
     it('sets name and default value into state', () => {
       const wrapper = unwrap(<Hoc {...props} />);
 
-      expect(wrapper.state()).toEqual(
+      expect(wrapper.find('ConnectToForm').state()).toEqual(
         expect.objectContaining({
           error: '',
           invalid: false,
@@ -88,7 +99,8 @@ describe('connectToForm()', () => {
 
     it('registers field on mount', () => {
       const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} unregisterOnUnmount validator={spy} />);
+
+      unwrap(<Hoc {...props} unregisterOnUnmount validator={spy} />);
 
       expect(form.register).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -99,27 +111,18 @@ describe('connectToForm()', () => {
         }),
         expect.anything(),
       );
-
-      expect(typeof (wrapper.instance() as any).unregister).toBe('function');
-    });
-
-    it('sets boolean flag on mount', () => {
-      const wrapper = unwrap(<Hoc {...props} unregisterOnUnmount />);
-
-      expect((wrapper.instance() as any).mounted).toBe(true);
     });
   });
 
   describe('componentDidUpdate()', () => {
     it('re-registers field if name changes', () => {
       const wrapper = unwrap(<Hoc {...props} />);
-      const spy = (wrapper.instance() as any).unregister;
 
       wrapper.setProps({
         name: 'bar',
       });
 
-      expect(spy).toHaveBeenCalled();
+      expect((form as any).unregister).toHaveBeenCalled();
       expect(form.register).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'foo',
@@ -136,12 +139,6 @@ describe('connectToForm()', () => {
         defaultValue: 'bar',
       });
 
-      expect(wrapper.state()).toEqual(
-        expect.objectContaining({
-          value: 'bar',
-        }),
-      );
-
       expect(form.change).toHaveBeenCalledWith('foo', 'bar', {});
     });
   });
@@ -149,101 +146,40 @@ describe('connectToForm()', () => {
   describe('componentWillUnmount()', () => {
     it('unregisters field if `unregisterOnMount` is set', () => {
       const wrapper = unwrap(<Hoc {...props} unregisterOnUnmount />);
-      const spy = (wrapper.instance() as any).unregister;
 
-      wrapper.instance().componentWillUnmount!();
+      wrapper.unmount();
 
-      expect(spy).toHaveBeenCalled();
+      expect((form as any).unregister).toHaveBeenCalled();
     });
 
     it('doesnt unregister field if `unregisterOnMount` is not set', () => {
       const wrapper = unwrap(<Hoc {...props} />);
-      const spy = (wrapper.instance() as any).unregister;
 
-      wrapper.instance().componentWillUnmount!();
+      wrapper.unmount();
 
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('sets mounted boolean to false', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
-
-      wrapper.instance().componentWillUnmount!();
-
-      expect((wrapper.instance() as any).mounted).toBe(false);
-    });
-  });
-
-  describe('formatError()', () => {
-    let formatError: any;
-
-    beforeEach(() => {
-      const wrapper = unwrap(<Hoc {...props} />);
-
-      ({ formatError } = wrapper.instance() as any);
-    });
-
-    it('returns an empty string for falsy', () => {
-      expect(formatError()).toBe('');
-      expect(formatError(null)).toBe('');
-      expect(formatError(false)).toBe('');
-    });
-
-    it('casts truthy value to string', () => {
-      expect(formatError('hi')).toBe('hi');
-      expect(formatError(123)).toBe('123');
-    });
-
-    it('supports `Error` objects', () => {
-      expect(formatError(new Error('hi'))).toBe('hi');
-    });
-  });
-
-  describe('formatValue()', () => {
-    it('casts value using `parse` prop', () => {
-      const wrapper = unwrap(<Hoc {...props} parse={toString} />);
-      const formatValue = (wrapper.instance() as any).formatValue.bind(wrapper.instance());
-
-      expect(formatValue(1)).toBe(1);
-      expect(formatValue('1')).toBe(1);
-      expect(formatValue([1, '2', 3.5])).toEqual(['1', '2', '3.5']);
-    });
-
-    it('converts to an array if requires multiple', () => {
-      const wrapper = unwrap(<HocMultiple {...props} parse={toString} />);
-      const formatValue = (wrapper.instance() as any).formatValue.bind(wrapper.instance());
-
-      expect(formatValue(1)).toEqual([1]);
-      expect(formatValue('1')).toEqual([1]);
-      expect(formatValue([1, '2', 3.5])).toEqual(['1', '2', '3.5']);
+      expect((form as any).unregister).not.toHaveBeenCalled();
     });
   });
 
   describe('handleBlur()', () => {
-    it('calls state and props blur', () => {
+    it('calls `onBlur`', () => {
       const spy = jest.fn();
-      const spyProp = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onBlur={spyProp} />);
-      const event = { type: 'blur' };
+      const wrapper = unwrap(<Hoc {...props} onBlur={spy} />);
+      const event = { type: 'blur' } as React.FocusEvent;
 
-      wrapper.setState({
-        blur: spy,
-      });
+      findField(wrapper).invoke('onBlur')(event);
 
-      wrapper.simulate('blur', event);
-
-      expect(spy).toHaveBeenCalled();
-      expect(spyProp).toHaveBeenCalledWith(event);
+      expect(spy).toHaveBeenCalledWith(event);
     });
   });
 
   describe('handleChange()', () => {
-    it('calls context and props change', () => {
+    it('calls context `change` and `onChange`', () => {
       const spy = jest.fn();
       const wrapper = unwrap(<Hoc {...props} onChange={spy} />);
       const event = { type: 'change' };
 
-      wrapper.simulate('change', 'new value', event);
+      findField(wrapper).invoke('onChange')('new value', event);
 
       expect(spy).toHaveBeenCalledWith('new value', event, undefined);
       expect(form.change).toHaveBeenCalledWith('foo', 'new value', {});
@@ -251,106 +187,39 @@ describe('connectToForm()', () => {
 
     it('can pass batch values using `onBatchChange`', () => {
       const wrapper = unwrap(<Hoc {...props} onBatchChange={() => ({ bar: 'other value' })} />);
+      const event = { type: 'change' };
 
-      wrapper.simulate('change', 'new value');
+      findField(wrapper).invoke('onChange')('new value', event);
 
       expect(form.change).toHaveBeenCalledWith('foo', 'new value', { bar: 'other value' });
     });
   });
 
   describe('handleFocus()', () => {
-    it('calls state and props focus', () => {
+    it('calls `onFocus`', () => {
       const spy = jest.fn();
-      const spyProp = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onFocus={spyProp} />);
-      const event = { type: 'focus' };
+      const wrapper = unwrap(<Hoc {...props} onFocus={spy} />);
+      const event = { type: 'focus' } as React.FocusEvent;
 
-      wrapper.setState({
-        focus: spy,
-      });
+      findField(wrapper).invoke('onFocus')(event);
 
-      wrapper.simulate('focus', event);
-
-      expect(spy).toHaveBeenCalled();
-      expect(spyProp).toHaveBeenCalledWith(event);
-    });
-  });
-
-  describe('handleUpdate()', () => {
-    it('merges with previous state', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
-
-      expect(wrapper.state()).toEqual(
-        expect.objectContaining({
-          error: '',
-          invalid: false,
-          name: 'foo',
-          value: 'baz',
-        }),
-      );
-
-      // @ts-ignore Allow private access
-      wrapper.instance().handleUpdate({
-        name: 'foofoo',
-        value: 'barbar',
-      });
-
-      expect(wrapper.state()).toEqual(
-        expect.objectContaining({
-          error: '',
-          invalid: false,
-          name: 'foofoo',
-          value: 'barbar',
-        }),
-      );
-    });
-
-    it('calls `onStateUpdate` with changed state', () => {
-      const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onStateUpdate={spy} />);
-
-      // @ts-ignore Allow private access
-      wrapper.instance().handleUpdate({
-        name: 'foofoo',
-        value: 'barbar',
-      });
-
-      expect(spy).toHaveBeenCalledWith({
-        name: 'foofoo',
-        value: 'barbar',
-      });
-    });
-
-    it('does nothing if component is not mounted', () => {
-      const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onStateUpdate={spy} />);
-
-      (wrapper.instance() as any).mounted = false;
-
-      // @ts-ignore Allow private access
-      wrapper.instance().handleUpdate({
-        name: 'foofoo',
-        value: 'barbar',
-      });
-
-      expect(spy).not.toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(event);
     });
   });
 
   describe('render()', () => {
     it('passes form and handler props down', () => {
       const wrapper = unwrap(<Hoc {...props} />);
-      const instance: any = wrapper.instance();
 
-      expect(wrapper.props()).toEqual(
+      expect(wrapper.find(BaseField).props()).toEqual(
         expect.objectContaining({
           errorMessage: '',
           invalid: false,
           name: 'foo',
           value: 'baz',
-          onBlur: instance.handleBlur,
-          onChange: instance.handleChange,
-          onFocus: instance.handleFocus,
+          onBlur: expect.any(Function),
+          onChange: expect.any(Function),
+          onFocus: expect.any(Function),
         }),
       );
     });
@@ -358,21 +227,43 @@ describe('connectToForm()', () => {
     it('passes custom props down', () => {
       const wrapper = unwrap(<Hoc {...props} aria-hidden="true" />);
 
-      expect(wrapper.prop('aria-hidden')).toBe('true');
+      expect(wrapper.find(BaseField).prop('aria-hidden')).toBe('true');
     });
 
     it('doesnt pass connect props down', () => {
       const wrapper = unwrap(<Hoc {...props} />);
 
-      expect(wrapper.prop('unregisterOnMount')).toBeUndefined();
-      expect(wrapper.prop('validator')).toBeUndefined();
+      expect(wrapper.find(BaseField).prop('unregisterOnMount')).toBeUndefined();
+      expect(wrapper.find(BaseField).prop('validator')).toBeUndefined();
     });
 
     it('can change value prop used', () => {
-      const wrapper = unwrap(<HocChecked {...props} />);
+      const wrapper = unwrap(<HocChecked {...props} defaultValue />);
 
-      expect(wrapper.prop('value')).toBeUndefined();
-      expect(wrapper.prop('checked')).toBe(true);
+      expect(wrapper.find(BaseField).prop('value')).toBeUndefined();
+      expect(wrapper.find(BaseField).prop('checked')).toBe(true);
+    });
+
+    it('passes down error messages and invalid state', () => {
+      const wrapper = unwrap(
+        <HocInvalid
+          {...props}
+          validator={() => {
+            throw new Error('Oops');
+          }}
+        />,
+      );
+
+      wrapper.find('ConnectToForm').setState({
+        error: new Error('Oops'),
+        invalid: true,
+        touched: true,
+      });
+
+      wrapper.update();
+
+      expect(wrapper.find(BaseField).prop('invalid')).toBe(true);
+      expect(wrapper.find(BaseField).prop('errorMessage')).toBe('Oops');
     });
   });
 });

--- a/packages/forms/test/composers/connectToForm.test.tsx
+++ b/packages/forms/test/composers/connectToForm.test.tsx
@@ -3,7 +3,8 @@ import Enzyme, { shallow } from 'enzyme';
 import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import connectToForm, { PROP_NAMES } from '../../src/composers/connectToForm';
 import { Context } from '../../src/types';
-import { toString, toNumber } from '../../lib/helpers';
+import { toString, toNumber } from '../../src/helpers';
+import Form from '../../src';
 
 describe('connectToForm()', () => {
   function Foo() {
@@ -47,8 +48,18 @@ describe('connectToForm()', () => {
     };
   });
 
+  function WrappingComponent({ children }: { children: NonNullable<React.ReactNode> }) {
+    return <Form onSubmit={() => Promise.resolve()}>{children}</Form>;
+  }
+
   function unwrap(element: any): Enzyme.ShallowWrapper {
-    return unwrapHOCs(shallow(element), 'Foo', form);
+    return unwrapHOCs(
+      shallow(element, {
+        wrappingComponent: WrappingComponent,
+      }),
+      'Foo',
+      form,
+    );
   }
 
   it('returns an HOC', () => {

--- a/packages/forms/test/composers/connectToForm.test.tsx
+++ b/packages/forms/test/composers/connectToForm.test.tsx
@@ -3,16 +3,31 @@ import Enzyme, { shallow } from 'enzyme';
 import { unwrapHOCs } from '@airbnb/lunar-test-utils';
 import connectToForm, { PROP_NAMES } from '../../src/composers/connectToForm';
 import { Context } from '../../src/types';
+import { toString, toNumber } from '../../lib/helpers';
 
 describe('connectToForm()', () => {
   function Foo() {
     return <div />;
   }
 
-  const Hoc = connectToForm()(Foo);
-  const HocMultiple = connectToForm({ multiple: true })(Foo);
-  const HocChecked = connectToForm({ valueProp: 'checked', parse: Boolean })(Foo);
-  const HocInitialValue = connectToForm({ initialValue: 123 })(Foo);
+  const Hoc = connectToForm<string>({
+    initialValue: '',
+    parse: toString,
+  })(Foo);
+
+  const HocMultiple = connectToForm<string>({
+    initialValue: '',
+    parse: toString,
+    multiple: true,
+  })(Foo);
+
+  const HocChecked = connectToForm<boolean>({
+    initialValue: false,
+    valueProp: 'checked',
+    parse: Boolean,
+  })(Foo);
+
+  const HocInitialValue = connectToForm<number>({ initialValue: 123, parse: toNumber })(Foo);
 
   const props = {
     name: 'foo',
@@ -186,21 +201,21 @@ describe('connectToForm()', () => {
 
   describe('formatValue()', () => {
     it('casts value using `parse` prop', () => {
-      const wrapper = unwrap(<Hoc {...props} parse={Number} />);
+      const wrapper = unwrap(<Hoc {...props} parse={toString} />);
       const formatValue = (wrapper.instance() as any).formatValue.bind(wrapper.instance());
 
       expect(formatValue(1)).toBe(1);
       expect(formatValue('1')).toBe(1);
-      expect(formatValue([1, '2', '3.5'])).toEqual([1, 2, 3.5]);
+      expect(formatValue([1, '2', 3.5])).toEqual(['1', '2', '3.5']);
     });
 
     it('converts to an array if requires multiple', () => {
-      const wrapper = unwrap(<HocMultiple {...props} parse={Number} />);
+      const wrapper = unwrap(<HocMultiple {...props} parse={toString} />);
       const formatValue = (wrapper.instance() as any).formatValue.bind(wrapper.instance());
 
       expect(formatValue(1)).toEqual([1]);
       expect(formatValue('1')).toEqual([1]);
-      expect(formatValue([1, '2', '3.5'])).toEqual([1, 2, 3.5]);
+      expect(formatValue([1, '2', 3.5])).toEqual(['1', '2', '3.5']);
     });
   });
 

--- a/packages/forms/test/helpers.test.ts
+++ b/packages/forms/test/helpers.test.ts
@@ -9,6 +9,7 @@ describe('isPrimitive()', () => {
 
   it('returns false otherwise', () => {
     expect(isPrimitive(null)).toBe(false);
+    // @ts-ignore Allow invalid type
     expect(isPrimitive({})).toBe(false);
     expect(isPrimitive([])).toBe(false);
   });
@@ -23,6 +24,7 @@ describe('toString()', () => {
 
   it('returns an empty string for non-primitives', () => {
     expect(toString(null)).toBe('');
+    // @ts-ignore Allow invalid type
     expect(toString({})).toBe('');
     expect(toString([])).toBe('');
   });
@@ -43,6 +45,7 @@ describe('toBool()', () => {
 
   it('returns false for non-primitives', () => {
     expect(toBool(null)).toBe(false);
+    // @ts-ignore Allow invalid type
     expect(toBool({})).toBe(false);
     expect(toBool([])).toBe(false);
   });
@@ -61,6 +64,7 @@ describe('toNumber()', () => {
 
   it('returns 0 for non-primitives', () => {
     expect(toNumber(null)).toBe(0);
+    // @ts-ignore Allow invalid type
     expect(toNumber({})).toBe(0);
     expect(toNumber([])).toBe(0);
   });

--- a/packages/forms/test/utils.tsx
+++ b/packages/forms/test/utils.tsx
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import React from 'react';
+import FormContext from '../src/components/FormContext';
+import { Context } from '../src/types';
+
+export function createFormContext(): Context {
+  return {
+    change: jest.fn(),
+    getFields: () => [],
+    getState: () => ({} as any),
+    register: jest.fn(),
+    submit: jest.fn(() => Promise.resolve({})),
+  };
+}
+
+export function WrappingFormComponent({
+  children,
+  context = null,
+}: {
+  children: React.ReactNode;
+  context?: Context | null;
+}) {
+  return <FormContext.Provider value={context}>{children}</FormContext.Provider>;
+}

--- a/packages/forms/test/utils.tsx
+++ b/packages/forms/test/utils.tsx
@@ -20,10 +20,10 @@ export function createFormContext(): Context & { unregister: () => void } {
 
 export function WrappingFormComponent({
   children,
-  context = null,
+  context,
 }: {
   children: React.ReactNode;
-  context?: Context | null;
+  context: Context;
 }) {
   return <FormContext.Provider value={context}>{children}</FormContext.Provider>;
 }

--- a/packages/forms/test/utils.tsx
+++ b/packages/forms/test/utils.tsx
@@ -4,13 +4,17 @@ import React from 'react';
 import FormContext from '../src/components/FormContext';
 import { Context } from '../src/types';
 
-export function createFormContext(): Context {
+// istanbul ignore next
+export function createFormContext(): Context & { unregister: () => void } {
+  const unregister = jest.fn();
+
   return {
     change: jest.fn(),
     getFields: () => [],
     getState: () => ({} as any),
-    register: jest.fn(),
+    register: jest.fn(() => unregister),
     submit: jest.fn(() => Promise.resolve({})),
+    unregister,
   };
 }
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -24,7 +24,7 @@
     "aesthetic-react": "^1.1.0"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.9.4",
+    "@types/enzyme": "^3.10.3",
     "@types/jest": "^24.0.15",
     "@types/react": "^16.8.22"
   }

--- a/packages/test-utils/src/index.tsx
+++ b/packages/test-utils/src/index.tsx
@@ -26,9 +26,8 @@ export function mountWithStyles<C extends React.Component, P = C['props'], S = C
   props: WrappingProps = {},
 ): Enzyme.ReactWrapper<P, S, C> {
   return mount(element, {
-    // @ts-ignore Not typed yet
     wrappingComponent: WrappingComponent,
-    wrappingProps: props,
+    wrappingComponentProps: props,
   });
 }
 
@@ -38,12 +37,11 @@ export function shallowWithStyles<C extends React.Component, P = C['props'], S =
   props: WrappingProps = {},
 ): Enzyme.ShallowWrapper<P, S, C> {
   const wrapper = shallow(element, {
-    // @ts-ignore Not typed yet
     wrappingComponent: WrappingComponent,
-    wrappingProps: props,
+    wrappingComponentProps: props,
   });
 
-  return self ? wrapper : wrapper.dive();
+  return self ? wrapper : (wrapper.dive() as any);
 }
 
 export function wrapEnv(env: string, callback: () => any): () => any {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,10 +2798,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/enzyme@^3.9.4":
-  version "3.9.4"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.9.4.tgz#08f3ebfa24aa881021693a0fe615d6d2720c07ad"
-  integrity sha512-bQcwt5gcKnekrbci4hcapfE2J6rkkFbHM1l4VobLtSl4ogOfj0lvSxrdS6FftCakmJqqPBqdQCwb5KnlivL6SQ==
+"@types/enzyme@^3.10.3":
+  version "3.10.3"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.3.tgz#02b6c5ac7d0472005944a652e79045e2f6c66804"
+  integrity sha512-f/Kcb84sZOSZiBPCkr4He9/cpuSLcKRyQaEE20Q30Prx0Dn6wcyMAWI0yofL6yvd9Ht9G7EVkQeRqK0n5w8ILw==
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This PR does a few things:

- Updates `connectToForm` to accept a generic, which is the type of the wrapped component's `value` prop. This allows us to guarantee the correct types and values are being passed around.
- Made `initialValue` required and `parse` preferred options so that they can be used in conjunction with the generic mentioned previously.
- Updates `defaultValue` to accept null and undefined values, so that we can do `defaultValue={obj.name}` instead of `defaultValue={obj.name || ''}`.

## Motivation and Context

We lose a lot of type information when connecting to the form, so this tries to bridge that gap. I've been thinking about a hooks API and how it may make this process easier.

## Testing

Unit tests.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
