### PR TITLE
fix(Tooltip): Fix cannot read property getBoundingClientRect of null.

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -7,7 +7,7 @@ import NotchedBox, { NOTCH_SIZE, NOTCH_SPACING } from '../NotchedBox';
 import Text from '../Text';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 
-const defaultTargetRect: ClientRect = {
+const EMPTY_TARGET_RECT: ClientRect = {
   bottom: 0,
   height: 0,
   left: 0,
@@ -67,7 +67,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     labelID: uuid(),
     open: false,
     tooltipHeight: 0,
-    targetRect: document.body ? document.body.getBoundingClientRect() : defaultTargetRect,
+    targetRect: EMPTY_TARGET_RECT,
   };
 
   containerRef = React.createRef<HTMLSpanElement>();
@@ -84,6 +84,13 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     }
 
     return null;
+  }
+
+  componentDidMount() {
+    // eslint-disable-next-line
+    this.setState({
+      targetRect: document.body.getBoundingClientRect(),
+    });
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -7,6 +7,15 @@ import NotchedBox, { NOTCH_SIZE, NOTCH_SPACING } from '../NotchedBox';
 import Text from '../Text';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 
+const defaultTargetRect: ClientRect = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+};
+
 export type Props = {
   /** Width of the tooltip in units. */
   width?: number;
@@ -58,7 +67,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     labelID: uuid(),
     open: false,
     tooltipHeight: 0,
-    targetRect: document.body.getBoundingClientRect(),
+    targetRect: document.body ? document.body.getBoundingClientRect() : defaultTargetRect,
   };
 
   containerRef = React.createRef<HTMLSpanElement>();

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -87,7 +87,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   }
 
   componentDidMount() {
-    // eslint-disable-next-line
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({
       targetRect: document.body.getBoundingClientRect(),
     });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Fixes a JS error where body content is not fully loaded (null) and `getBoundingClientRect` is called. Not sure how, but seeing this error.

## Motivation and Context

Fixing errors.

## Testing

Works still in the styleguide.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
