### PR TITLE
Ks tooltip hover

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -28,7 +28,7 @@ export type Props = {
 
 export type State = {
   labelID: string;
-  hoveringButton: boolean;
+  hoveringTarget: boolean;
   hoveringTooltip: boolean;
   tooltipHeight: number;
   targetRect: ClientRect;
@@ -57,7 +57,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
   state = {
     labelID: uuid(),
-    hoveringButton: false,
+    hoveringTarget: false,
     hoveringTooltip: false,
     tooltipHeight: 0,
     targetRect: document.body.getBoundingClientRect(),
@@ -72,7 +72,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   static getDerivedStateFromProps({ disabled }: Props) {
     if (disabled) {
       return {
-        hoveringButton: false,
+        hoveringTarget: false,
       };
     }
 
@@ -130,14 +130,14 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   private handleEnter = (element: string) => () => {
     const { current } = this.containerRef;
     const { disabled, onShow } = this.props;
-    const { hoveringTooltip, hoveringButton } = this.state;
+    const { hoveringTooltip, hoveringTarget } = this.state;
 
     /* istanbul ignore if: refs are hard */
     if (current) {
       this.setState({ targetRect: current.getBoundingClientRect() });
     }
 
-    const open = hoveringTooltip || hoveringButton;
+    const open = hoveringTooltip || hoveringTarget;
     if (!disabled && !open) {
       this.setState({
         [`hovering${element}`]: true,
@@ -168,7 +168,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
       underlined,
       inverted,
     } = this.props;
-    const { hoveringButton, hoveringTooltip, targetRect, tooltipHeight, labelID } = this.state;
+    const { hoveringTarget, hoveringTooltip, targetRect, tooltipHeight, labelID } = this.state;
     const { unit } = theme!;
     const width = widthProp! * unit;
     const { align, above } = this.bestPosition(targetRect);
@@ -184,14 +184,14 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     };
     const distance = halfNotch + 1;
 
-    const open = hoveringButton || hoveringTooltip;
+    const open = hoveringTarget || hoveringTooltip;
 
     return (
       <span
         className={cx(styles.container)}
         ref={this.containerRef}
-        onMouseEnter={this.handleEnter('Button')}
-        onMouseLeave={this.handleClose('Button')}
+        onMouseEnter={this.handleEnter('Target')}
+        onMouseLeave={this.handleClose('Target')}
         onMouseDown={this.handleMouseDown}
       >
         <div aria-labelledby={labelID} className={cx(!disabled && underlined && styles.underlined)}>

--- a/packages/core/test/components/Tooltip.test.tsx
+++ b/packages/core/test/components/Tooltip.test.tsx
@@ -20,7 +20,7 @@ describe('<Tooltip />', () => {
 
   it('opens up when hovered', () => {
     childContainer.simulate('mouseenter');
-    expect(wrapper.state('open')).toBeTruthy();
+    expect(wrapper.state('hoveringTarget')).toBeTruthy();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -43,7 +43,8 @@ describe('<Tooltip />', () => {
 
     it('does not up when hovered', () => {
       childContainer.simulate('mouseenter');
-      expect(wrapper.state('open')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTarget')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTooltip')).not.toBeTruthy();
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -60,17 +61,19 @@ describe('<Tooltip />', () => {
 
     it('closes when child exited', () => {
       childContainer.simulate('mouseleave');
-      expect(wrapper.state('open')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTarget')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTooltip')).not.toBeTruthy();
     });
 
     it('closes when child mousedowned', () => {
       childContainer.simulate('mousedown');
-      expect(wrapper.state('open')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTarget')).not.toBeTruthy();
+      expect(wrapper.state('hoveringTooltip')).not.toBeTruthy();
     });
 
     it('supports changing content', () => {
       wrapper.setProps({ content: 'whatever' });
-      expect(wrapper.state('open')).toBeTruthy();
+      expect(wrapper.state('hoveringTarget')).toBeTruthy();
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -81,7 +84,7 @@ describe('<Tooltip />', () => {
 
       it('does not close when child mousedowned', () => {
         childContainer.simulate('mousedown');
-        expect(wrapper.state('open')).toBeTruthy();
+        expect(wrapper.state('hoveringTarget')).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
This is kind of messy, basically we want to:
- Let users hover over tooltips without the tooltip closing
- Add an invisible border to increase the hoverable area

Downsides are:
- This removes the Overlay wrapper
- Still not a11y friendly

I can fix tests, but wanted to have the design discussion first.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
