### PR TITLE
update(Row): Add inline prop.

### DIFF
--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -35,7 +35,12 @@ storiesOf('Core/Row', module)
     </Row>
   ))
   .add('With inline.', () => (
-    <Row inline middleAlign after={<IconAddAlt decorative />}>
+    <Row
+      inline
+      middleAlign
+      before={<img src="http://via.placeholder.com/50x50" alt="" />}
+      after={<IconAddAlt decorative />}
+    >
       <Text>Inline row with after content, middle aligned.</Text>
     </Row>
   ))

--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
-import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import Text from './Text';
 import Button from './Button';
 import Row from './Row';

--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
+import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import Text from './Text';
 import Button from './Button';
 import Row from './Row';
@@ -34,7 +35,7 @@ storiesOf('Core/Row', module)
     </Row>
   ))
   .add('With inline.', () => (
-    <Row inline middleAlign after={<img src="http://via.placeholder.com/50x50" alt="" />}>
+    <Row inline middleAlign after={<IconAddAlt decorative />}>
       <Text>Inline row with after content, middle aligned.</Text>
     </Row>
   ))

--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -26,11 +26,16 @@ storiesOf('Core/Row', module)
   ))
   .add('Both before and after content.', () => (
     <Row
+      middleAlign
       before={<img src="http://via.placeholder.com/50x50" alt="" />}
       after={<Button>Take an action</Button>}
-      middleAlign
     >
       <Text>This row has both before and after, and is aligned in the middle vertically.</Text>
+    </Row>
+  ))
+  .add('With inline.', () => (
+    <Row inline middleAlign after={<img src="http://via.placeholder.com/50x50" alt="" />}>
+      <Text>Inline row with after content, middle aligned.</Text>
     </Row>
   ))
   .add('With long content.', () => (
@@ -52,15 +57,15 @@ storiesOf('Core/Row', module)
   .add('All line options.', () => (
     <>
       <div>
-        <Row after={<Button>Take an action</Button>} topline spacious>
+        <Row topline spacious after={<Button>Take an action</Button>}>
           <Text>A row where only topline is true.</Text>
         </Row>
 
-        <Row after={<Button>Take an action</Button>} topline baseline spacious>
+        <Row topline baseline spacious after={<Button>Take an action</Button>}>
           <Text>A row with both topline and baseline.</Text>
         </Row>
 
-        <Row after={<Button>Take an action</Button>} baseline spacious>
+        <Row baseline spacious after={<Button>Take an action</Button>}>
           <Text>A row where only baseline is true.</Text>
         </Row>
       </div>
@@ -69,15 +74,15 @@ storiesOf('Core/Row', module)
   .add('All padding options.', () => (
     <>
       <div>
-        <Row after={<Button>Take an action</Button>} topline spacious>
+        <Row topline spacious after={<Button>Take an action</Button>}>
           <Text>A row with spacious padding.</Text>
         </Row>
 
-        <Row after={<Button>Take an action</Button>} topline baseline compact>
+        <Row topline baseline compact after={<Button>Take an action</Button>}>
           <Text>A row with compact padding.</Text>
         </Row>
 
-        <Row after={<Button>Take an action</Button>} baseline>
+        <Row baseline after={<Button>Take an action</Button>}>
           <Text>A row with no padding.</Text>
         </Row>
       </div>

--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -35,12 +35,7 @@ storiesOf('Core/Row', module)
     </Row>
   ))
   .add('With inline.', () => (
-    <Row
-      inline
-      middleAlign
-      before={<img src="http://via.placeholder.com/50x50" alt="" />}
-      after={<IconAddAlt decorative />}
-    >
+    <Row inline middleAlign after={<IconAddAlt decorative />}>
       <Text>Inline row with after content, middle aligned.</Text>
     </Row>
   ))
@@ -80,12 +75,12 @@ storiesOf('Core/Row', module)
   .add('All padding options.', () => (
     <>
       <div>
-        <Row topline spacious after={<Button>Take an action</Button>}>
-          <Text>A row with spacious padding.</Text>
+        <Row spacious topline after={<Button>Take an action</Button>}>
+          <Text>A row with spacious vertical padding (24px).</Text>
         </Row>
 
-        <Row topline baseline compact after={<Button>Take an action</Button>}>
-          <Text>A row with compact padding.</Text>
+        <Row compact baseline topline after={<Button>Take an action</Button>}>
+          <Text>A row with compact vertical padding (12px).</Text>
         </Row>
 
         <Row baseline after={<Button>Take an action</Button>}>

--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
+import { AutoSizer } from 'react-virtualized';
 
 export type Props = {
   /** The contents following the primary contents. */
@@ -62,7 +63,6 @@ export class Row extends React.Component<Props & WithStylesProps> {
         className={cx(
           styles.row,
           { maxHeight },
-          inline && styles.row_inline,
           compact && styles.row_compact,
           spacious && styles.row_spacious,
           middleAlign && styles.row_middleAlign,
@@ -70,13 +70,18 @@ export class Row extends React.Component<Props & WithStylesProps> {
           topline && styles.row_topline,
         )}
       >
-        {before && (
-          <div className={cx(compact ? styles.before_compact : styles.before)}>{before}</div>
-        )}
+        {before && <div className={cx(styles.before, inline && styles.inline)}>{before}</div>}
 
-        <div className={cx(styles.primary, truncated && styles.primary_truncated)}>{children}</div>
+        <div
+          className={cx(
+            inline ? styles.inline : styles.primary,
+            truncated && styles.primary_truncated,
+          )}
+        >
+          {children}
+        </div>
 
-        {after && <div className={cx(compact ? styles.after_compact : styles.after)}>{after}</div>}
+        {after && <div className={cx(styles.after, inline && styles.inline)}>{after}</div>}
       </div>
     );
   }
@@ -85,10 +90,6 @@ export class Row extends React.Component<Props & WithStylesProps> {
 export default withStyles(({ ui, unit }) => ({
   row: {
     display: 'flex',
-  },
-
-  row_inline: {
-    display: 'inline-flex',
   },
 
   row_compact: {
@@ -114,21 +115,13 @@ export default withStyles(({ ui, unit }) => ({
   },
 
   after: {
-    paddingLeft: unit * 2,
-    flexShrink: 0,
-  },
-
-  after_compact: {
     paddingLeft: unit,
+    flexShrink: 0,
   },
 
   before: {
-    paddingRight: unit * 2,
-    flexShrink: 0,
-  },
-
-  before_compact: {
     paddingRight: unit,
+    flexShrink: 0,
   },
 
   primary: {
@@ -138,5 +131,10 @@ export default withStyles(({ ui, unit }) => ({
 
   primary_truncated: {
     overflow: 'hidden',
+  },
+
+  inline: {
+    display: 'inline-flex',
+    alignSelf: 'initial',
   },
 }))(Row);

--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -12,6 +12,8 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Render with reduced vertical padding. */
   compact?: boolean;
+  /** Render as an inline element. */
+  inline?: boolean;
   /** Max height of row. */
   maxHeight?: number | string;
   /** Align contents in the middle vertically. */
@@ -32,6 +34,7 @@ export class Row extends React.Component<Props & WithStylesProps> {
     before: null,
     compact: false,
     flat: false,
+    inline: false,
     middleAlign: false,
     topline: false,
     truncated: false,
@@ -45,6 +48,7 @@ export class Row extends React.Component<Props & WithStylesProps> {
       before,
       children,
       compact,
+      inline,
       maxHeight,
       middleAlign,
       spacious,
@@ -58,6 +62,7 @@ export class Row extends React.Component<Props & WithStylesProps> {
         className={cx(
           styles.row,
           { maxHeight },
+          inline && styles.row_inline,
           compact && styles.row_compact,
           spacious && styles.row_spacious,
           middleAlign && styles.row_middleAlign,
@@ -80,6 +85,10 @@ export class Row extends React.Component<Props & WithStylesProps> {
 export default withStyles(({ ui, unit }) => ({
   row: {
     display: 'flex',
+  },
+
+  row_inline: {
+    display: 'inline-flex',
   },
 
   row_compact: {

--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
-import { AutoSizer } from 'react-virtualized';
 
 export type Props = {
   /** The contents following the primary contents. */
@@ -13,7 +12,7 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Render with reduced vertical padding. */
   compact?: boolean;
-  /** Render as an inline element. */
+  /** Render content as inline. */
   inline?: boolean;
   /** Max height of row. */
   maxHeight?: number | string;

--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -10,7 +10,7 @@ export type Props = {
   before?: React.ReactNode;
   /** The primary contents to render. */
   children: NonNullable<React.ReactNode>;
-  /** Render with reduced vertical padding. */
+  /** Render with reduced vertical padding (12px). */
   compact?: boolean;
   /** Render content as inline. */
   inline?: boolean;
@@ -18,7 +18,7 @@ export type Props = {
   maxHeight?: number | string;
   /** Align contents in the middle vertically. */
   middleAlign?: boolean;
-  /** Render with vertical padding. */
+  /** Render with vertical padding (24px). */
   spacious?: boolean;
   /** The visibility of the row's topline. */
   topline?: boolean;
@@ -69,7 +69,17 @@ export class Row extends React.Component<Props & WithStylesProps> {
           topline && styles.row_topline,
         )}
       >
-        {before && <div className={cx(styles.before, inline && styles.inline)}>{before}</div>}
+        {before && (
+          <div
+            className={cx(
+              styles.before,
+              inline && styles.inline,
+              (inline || compact) && styles.before_compact,
+            )}
+          >
+            {before}
+          </div>
+        )}
 
         <div
           className={cx(
@@ -80,7 +90,17 @@ export class Row extends React.Component<Props & WithStylesProps> {
           {children}
         </div>
 
-        {after && <div className={cx(styles.after, inline && styles.inline)}>{after}</div>}
+        {after && (
+          <div
+            className={cx(
+              styles.after,
+              inline && styles.inline,
+              (inline || compact) && styles.after_compact,
+            )}
+          >
+            {after}
+          </div>
+        )}
       </div>
     );
   }
@@ -114,13 +134,21 @@ export default withStyles(({ ui, unit }) => ({
   },
 
   after: {
-    paddingLeft: unit,
+    paddingLeft: unit * 2,
     flexShrink: 0,
   },
 
+  after_compact: {
+    paddingLeft: unit,
+  },
+
   before: {
-    paddingRight: unit,
+    paddingRight: unit * 2,
     flexShrink: 0,
+  },
+
+  before_compact: {
+    paddingRight: unit,
   },
 
   primary: {

--- a/packages/core/test/components/Row.test.tsx
+++ b/packages/core/test/components/Row.test.tsx
@@ -15,6 +15,12 @@ describe('<Row />', () => {
     expect(wrapper.prop('className')).toMatch('row_topline');
   });
 
+  it('renders as inline', () => {
+    const wrapper = shallowWithStyles(<Row inline>PRIMARY</Row>);
+
+    expect(wrapper.prop('className')).toMatch('row_inline');
+  });
+
   it('renders as compact', () => {
     const wrapper = shallowWithStyles(<Row compact>PRIMARY</Row>);
 

--- a/packages/core/test/components/Row.test.tsx
+++ b/packages/core/test/components/Row.test.tsx
@@ -18,7 +18,7 @@ describe('<Row />', () => {
   it('renders as inline', () => {
     const wrapper = shallowWithStyles(<Row inline>PRIMARY</Row>);
 
-    expect(wrapper.prop('className')).toMatch('row_inline');
+    expect(wrapper.find('div > div').prop('className')).toMatch('inline');
   });
 
   it('renders as compact', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds an inline prop, switching the row from being display flex, to flex-inline. When it's inline, its column spacing is the same as compact (8px).

## Motivation and Context

Need it! Handy for after content to be right up against main content with middle alignment as an option!

## Testing

- added test
- added story

## Screenshots

<img width="865" alt="Screen Shot 2019-07-23 at 4 55 11 PM" src="https://user-images.githubusercontent.com/306275/61755127-0e07aa00-ad6b-11e9-9e7a-5ab34c25adbd.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
