### PR TITLE
style(Modal): Increase modal body height when scrollable is set.

### DIFF
--- a/packages/core/src/components/Modal.story.tsx
+++ b/packages/core/src/components/Modal.story.tsx
@@ -76,6 +76,7 @@ class ModalDemo extends React.Component<
           >
             <Text>
               <LoremIpsum />
+              <LoremIpsum />
               {(showLarge || !showSmall) && showScrollable && (
                 <>
                   <LoremIpsum /> <LoremIpsum />

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -84,7 +84,7 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
       title,
     } = this.props;
 
-    const showLargeContent = large || !small || !!image;
+    const showLargeContent = large || !!image;
 
     const innerContent = (
       <ModalInnerContent
@@ -108,7 +108,7 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
         className={cx(
           styles.content,
           small && styles.content_small,
-          (large || !!image) && styles.content_large,
+          showLargeContent && styles.content_large,
           fluid && styles.content_fluid,
         )}
       >

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -74,7 +74,8 @@ function ModalInnerContent({
           !withHeader && styles.body_paddingTop,
           !withFooter && styles.body_paddingBottom,
           scrollable && styles.body_scrollable,
-          scrollable && (!small || large) && styles.body_scrollableLarge,
+          scrollable && small && styles.body_scrollableSmall,
+          scrollable && large && styles.body_scrollableLarge,
         )}
       >
         {children}
@@ -156,6 +157,10 @@ export default withStyles(({ color, ui, unit }) => ({
       height: unit / 2,
       background: color.accent.bg,
     },
+  },
+
+  body_scrollableSmall: {
+    maxHeight: 160,
   },
 
   body_scrollableLarge: {

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -74,8 +74,8 @@ function ModalInnerContent({
           !withHeader && styles.body_paddingTop,
           !withFooter && styles.body_paddingBottom,
           scrollable && styles.body_scrollable,
-          scrollable && small && styles.body_scrollableSmall,
-          scrollable && large && styles.body_scrollableLarge,
+          small && scrollable && styles.body_scrollableSmall,
+          large && scrollable && styles.body_scrollableLarge,
         )}
       >
         {children}

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -144,7 +144,7 @@ export default withStyles(({ color, ui, unit }) => ({
 
   body_scrollable: {
     paddingBottom: unit * 3,
-    maxHeight: 160,
+    maxHeight: 300,
     overflow: 'auto',
 
     ':before': {
@@ -159,7 +159,7 @@ export default withStyles(({ color, ui, unit }) => ({
   },
 
   body_scrollableLarge: {
-    maxHeight: 300,
+    maxHeight: 500,
   },
 
   footer: {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Increasing the max height for scrollable content at the different modal sizes.

small: 160px
regular: 300px
large: 500px

## Motivation and Context

Needing more content to show

## Testing

Storybook

## Screenshots

<img width="1309" alt="Storybook 2019-07-24 14-42-57" src="https://user-images.githubusercontent.com/306275/61831130-c4c66180-ae21-11e9-80da-9099344ffa35.png">
<img width="1309" alt="Storybook 2019-07-24 14-54-20" src="https://user-images.githubusercontent.com/306275/61831578-102d3f80-ae23-11e9-874f-30d3c43ae9b4.png">
<img width="1309" alt="Storybook 2019-07-24 14-43-57" src="https://user-images.githubusercontent.com/306275/61831126-c4c66180-ae21-11e9-9081-d0805fbbc0b3.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
