### PR TITLE
style(Text): Update line-height.

### DIFF
--- a/packages/core/src/components/Text.story.tsx
+++ b/packages/core/src/components/Text.story.tsx
@@ -9,35 +9,40 @@ storiesOf('Core/Text', module)
   })
   .add('A basic string of text.', () => (
     <Text>
-      <LoremIpsum short />
+      <LoremIpsum />
     </Text>
   ))
   .add('With light, bold, and uppercased emphasis.', () => (
     <>
       <Text light>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
+      <br />
       <Text bold>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
+      <br />
       <Text uppercased>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
     </>
   ))
   .add('With different sizing: micro, small, regular (default), and large.', () => (
     <>
       <Text micro>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
+      <br />
       <Text small>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
+      <br />
       <Text>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
+      <br />
       <Text large>
-        <LoremIpsum short />
+        <LoremIpsum />
       </Text>
     </>
   ))
@@ -63,15 +68,7 @@ storiesOf('Core/Text', module)
   ))
   .add('With truncated.', () => (
     <Text truncated>
-      <div>
-        <LoremIpsum short /> Nam leo erat, lacinia nec porttitor sed, mollis sed nibh. Nam porta sit
-        amet risus quis interdum. Sed feugiat lorem vitae augue blandit, sed mollis mi laoreet.
-        Donec auctor, enim eget tempus auctor, est lorem laoreet nisi, a rutrum dolor quam eget mi.
-        Integer nibh orci, faucibus in dolor ut, maximus euismod erat. Nam efficitur vulputate augue
-        non pretium. Suspendisse vitae dui elit. Aliquam erat volutpat. Curabitur rutrum id elit ut
-        hendrerit. Pellentesque ullamcorper quam a nibh aliquam bibendum. Fusce at fermentum velit.
-        Phasellus malesuada dapibus tincidunt.
-      </div>
+      <LoremIpsum short /> <LoremIpsum />
     </Text>
   ))
   .add('With aligned text.', () => (

--- a/packages/core/src/themes/buildFont.ts
+++ b/packages/core/src/themes/buildFont.ts
@@ -44,7 +44,7 @@ export default function buildFont(fontFamily: string): Theme['font'] {
     textRegular: {
       fontFamily,
       fontSize: 15,
-      lineHeight: 20 / 15,
+      lineHeight: 22 / 15,
       letterSpacing: 0.1,
     },
 
@@ -58,7 +58,7 @@ export default function buildFont(fontFamily: string): Theme['font'] {
     textMicro: {
       fontFamily,
       fontSize: 11,
-      lineHeight: 15 / 11,
+      lineHeight: 16 / 11,
       letterSpacing: 0.3,
     },
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

After seeing the new line-heights out in the wild, we decided to go back to values closer to the original values (dropping the `.5px` on a few).

Also update the `<Text />` story to show more text so the line-height difference is easier to preview.

## Motivation and Context

`20px` was too dense and affected buttons, inputs, and text heavy areas.

## Testing

storybook

## Screenshots

<img width="1067" alt="Storybook 2019-08-02 15-21-04" src="https://user-images.githubusercontent.com/306275/62401831-ace59080-b539-11e9-9ba3-94a646e9e8f3.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
