### PR TITLE
fix(Proofreader): Pull spurious, proofread-specific props from being passed to TextArea

### DIFF
--- a/packages/core/src/components/TextArea/Proofreader/index.tsx
+++ b/packages/core/src/components/TextArea/Proofreader/index.tsx
@@ -38,11 +38,11 @@ const LOCALE_TO_LT_LOCALE: { [locale: string]: string } = {
   zh: 'zh-CN',
 };
 
-function isRuleHighlighted(rule: ProofreadRuleMatch) {
+function defaultIsRuleHighlighted(rule: ProofreadRuleMatch) {
   return false;
 }
 
-function isRuleSecondary(rule: ProofreadRuleMatch) {
+function defaultIsRuleSecondary(rule: ProofreadRuleMatch) {
   return false;
 }
 
@@ -80,8 +80,8 @@ export type Snapshot = {
 
 export class Proofreader extends React.Component<Props & WithStylesProps, State, Snapshot> {
   static defaultProps = {
-    isRuleHighlighted,
-    isRuleSecondary,
+    isRuleHighlighted: defaultIsRuleHighlighted,
+    isRuleSecondary: defaultIsRuleSecondary,
     locale: NO_LOCALE,
   };
 
@@ -610,7 +610,17 @@ export class Proofreader extends React.Component<Props & WithStylesProps, State,
   }
 
   render() {
-    const { cx, children, styles, onCheckText, theme, important, ...props } = this.props;
+    const {
+      cx,
+      children,
+      styles,
+      onCheckText,
+      theme,
+      important,
+      isRuleHighlighted,
+      isRuleSecondary,
+      ...props
+    } = this.props;
     const {
       position,
       errors,


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
`isRuleHighlighted` and `isRuleSecondary` were being spuriously passed to BaseTextArea. This change uses spread syntax to pull them out beforehand. 



## Motivation and Context
My previous change https://github.com/airbnb/lunar/pull/82 introduced new proofreader-specific props that BaseTextArea is unaware of. We were still passing them to BaseTextArea though, which created unknown prop warnings that we're now eliminating. 


## Testing

Verified locally that there's no longer an unknown prop warning. 

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
