### PR TITLE
update(Copy, MenuItem): Allow id to pass through to Link for tracking

### DIFF
--- a/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -14,6 +14,8 @@ export type Props = {
   highlighted?: boolean;
   /** @ignore */
   horizontal?: boolean;
+  /** Pass an HTML element attribute id */
+  id?: string;
   /** Content to within the Breadcrumb. */
   label: string;
   /** Render an anchor link with a URL instead of a button. */
@@ -48,6 +50,7 @@ class Breadcrumb extends React.Component<Props & WithStylesProps> {
       disabled,
       hideIcon,
       highlighted,
+      id,
       label,
       href,
       onClick,
@@ -82,6 +85,7 @@ class Breadcrumb extends React.Component<Props & WithStylesProps> {
           }
           disabled={disabled}
           href={href}
+          id={id}
           onClick={this.handleClick}
         >
           {label}

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -19,6 +19,8 @@ export type Props = {
   compact?: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
+  /** Pass an HTML element attribute id */
+  id?: string;
   /** Callback fired when the element is clicked. */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Callback fired when the icon is clicked (requires an icon). */
@@ -51,6 +53,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
       children,
       compact,
       disabled,
+      id,
       onClick,
       onIconClick,
       profileImageSrc,
@@ -83,6 +86,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           disabled && styles.chip_disabled,
         )}
         {...props}
+        id={id}
       >
         {shouldRenderBefore && (
           <div className={cx(styles.chipItem, styles.sideContent)}>

--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -8,6 +8,8 @@ import Link from '../Link';
 export type Props = {
   /** Custom element to trigger the click. */
   children?: React.ReactElement;
+  /** Pass an HTML element attribute id to the Link */
+  id?: string;
   /** String of text to be copied to the clipboard. */
   text: string;
   /** Callback fired when text is copied. */
@@ -52,10 +54,10 @@ export default class Copy extends React.Component<Props, State> {
   };
 
   render() {
-    const { prompt, children, underlined } = this.props;
+    const { prompt, children, id, underlined } = this.props;
     const element = children || (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <Link>
+      <Link id={id}>
         <IconCopy decorative />
       </Link>
     );

--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -18,6 +18,8 @@ export type Props = {
   href?: string;
   /** An icon to display before the item. */
   icon?: React.ReactNode;
+  /** Pass an HTML element attribute id */
+  id?: string;
   /** Click handler. */
   onClick?: () => void;
   /** Opens links in a new window. */
@@ -81,6 +83,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
       highlighted,
       href,
       icon,
+      id,
       onClick,
       openInNewWindow,
       role,
@@ -116,6 +119,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
           beforeIcon={icon}
           disabled={disabled}
           href={href}
+          id={id}
           onClick={onClick}
           openInNewWindow={openInNewWindow}
           role={role}

--- a/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -36,6 +36,14 @@ describe('<Breadcrumb/>', () => {
     expect(wrapper.find(ButtonOrLink).prop('disabled')).toBeTruthy();
   });
 
+  it('renders a passed id for tracking', () => {
+    const wrapper = shallowWithStyles(
+      <Breadcrumb id="tracking-breadcrump" onClick={() => {}} label="Breadcrumb" />,
+    );
+
+    expect(wrapper.find(ButtonOrLink).prop('id')).toBe('tracking-breadcrump');
+  });
+
   it('renders an icon', () => {
     const wrapper = shallowWithStyles(<Breadcrumb onClick={() => {}} label="Breadcrumb" />);
 

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -19,6 +19,16 @@ describe('<Chip />', () => {
     expect(wrapper.prop('onClick')).toBe(onClick);
   });
 
+  it('passed an id for tracking', () => {
+    const onClick = () => {};
+    const wrapper = shallowWithStyles(
+      <Chip onClick={onClick} id="tracking-chip">
+        Potato
+      </Chip>,
+    );
+    expect(wrapper.prop('id')).toBe('tracking-chip');
+  });
+
   it('renders an after icon if provided', () => {
     const icon = <IconCheck />;
     const wrapper = shallowWithStyles(<Chip afterIcon={icon}>Sour Cream and Onion</Chip>);

--- a/packages/core/test/components/Copy.test.tsx
+++ b/packages/core/test/components/Copy.test.tsx
@@ -23,6 +23,12 @@ describe('<Copy />', () => {
     expect(wrapper.find(Link)).toHaveLength(1);
   });
 
+  it('can add an id to the Link', () => {
+    const wrapper = shallow(<Copy text="foo" id="tracking-id" />);
+
+    expect(wrapper.find(Link).prop('id')).toBe('tracking-id');
+  });
+
   it('can customize the child', () => {
     const child = <button type="button">Click</button>;
     const wrapper = shallow(<Copy text="foo">{child}</Copy>);

--- a/packages/core/test/components/Menu/Item.test.tsx
+++ b/packages/core/test/components/Menu/Item.test.tsx
@@ -40,7 +40,7 @@ describe('<MenuItem />', () => {
 
   it('passes props to underlying button', () => {
     const wrapper = shallowWithStyles(
-      <Item disabled openInNewWindow href="/" tabIndex={0}>
+      <Item disabled openInNewWindow href="/" tabIndex={0} id="tracking-item">
         Foo
       </Item>,
     );


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes 

## Description

Allows passing an `id` prop to `Copy`, which is passed through to `Link`

## Motivation and Context

Links and Buttons with an `id` can be tracked easier. 

## Testing

Updated tests. 

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
