### PR TITLE
update(DataTable): Only render top border when there's a header.

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -5,12 +5,14 @@ import Spacing from '../Spacing';
 import Text from '../Text';
 import { WithStylesProps } from '../../composers/withStyles';
 import { caseColumnLabel, getHeight } from './helpers';
+import shouldRenderTableHeader from './helpers/shouldRenderTableHeader';
 import {
   ColumnLabelCase,
   ColumnMetadata,
   ColumnToLabel,
   HeightOptions,
   RowHeightOptions,
+  HeaderButton,
 } from './types';
 
 // Theses anys are required to match the param types from react-virtualized
@@ -38,6 +40,9 @@ export default function ColumnLabels({
   selectable,
   columnMetadata,
   columnLabelCase,
+  editable,
+  extraHeaderButtons,
+  tableHeaderLabel,
 }: {
   cx: WithStylesProps['cx'];
   styles: WithStylesProps['styles'];
@@ -49,6 +54,9 @@ export default function ColumnLabels({
   selectable?: boolean;
   columnMetadata?: ColumnMetadata;
   columnLabelCase?: ColumnLabelCase;
+  editable: boolean;
+  extraHeaderButtons: HeaderButton[];
+  tableHeaderLabel: string;
 }) {
   return ({ className, columns, style }: ColumnLabelsProps) => {
     const leftmostIdx = Number(expandable) + Number(selectable);
@@ -80,7 +88,7 @@ export default function ColumnLabels({
 
       const newHeader = (
         <Spacing left={indent ? 2 : 0}>
-          <div style={heightStyle} className={cx(showDivider && styles && styles.column_divider)}>
+          <div style={heightStyle} className={cx(showDivider && styles && styles.columnDivider)}>
             <div
               style={
                 columnMetadata && columnMetadata[key] && columnMetadata[key].rightAlign
@@ -112,7 +120,13 @@ export default function ColumnLabels({
       <div
         role="row"
         style={style}
-        className={cx(className, styles && styles.column_header, styles && styles.row)}
+        className={cx(
+          className,
+          shouldRenderTableHeader(editable!, extraHeaderButtons!, tableHeaderLabel!) &&
+            styles.columnHeader_topBorder,
+          styles.columnHeader,
+          styles.row,
+        )}
       >
         {newColumns}
       </div>

--- a/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
+++ b/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
@@ -72,7 +72,7 @@ export default function renderDataColumns(
 
     return (
       <div className={cx(styles && styles.row)}>
-        <div className={cx(styles && styles.row_inner)}>
+        <div className={cx(styles && styles.rowInner)}>
           <Spacing left={spacing} right={2}>
             {contents || ''}
           </Spacing>
@@ -109,7 +109,7 @@ export default function renderDataColumns(
         cellRenderer={renderCell(key, isLeftmost)}
         className={cx(
           styles && styles.column,
-          showColumnDividers && !isRightmost && styles && styles.column_divider,
+          showColumnDividers && !isRightmost && styles && styles.columnDivider,
         )}
       />
     );

--- a/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
@@ -18,7 +18,7 @@ export default function renderExpandableColumn(
     if (children && children.length > 0) {
       return (
         <div
-          className={cx(styles.expand_caret)}
+          className={cx(styles.expandCaret)}
           role="button"
           tabIndex={0}
           onClick={expandRow(originalIndex)}

--- a/packages/core/src/components/DataTable/helpers/shouldRenderTableHeader.ts
+++ b/packages/core/src/components/DataTable/helpers/shouldRenderTableHeader.ts
@@ -1,0 +1,9 @@
+import { HeaderButton } from '../types';
+
+export default function shouldRenderTableHeader(
+  editable: boolean,
+  extraHeaderButtons: HeaderButton[],
+  tableHeaderLabel: string,
+) {
+  return editable || extraHeaderButtons!.length > 0 || !!tableHeaderLabel;
+}

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -4,6 +4,7 @@ import memoize from 'lodash/memoize';
 import sortData from './helpers/sortData';
 import expandData from './helpers/expandData';
 import { indexData } from './helpers/indexData';
+import shouldRenderTableHeader from './helpers/shouldRenderTableHeader';
 import {
   ChangeLog,
   DataTableProps,
@@ -134,12 +135,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     const { columnHeaderHeight, rowHeight } = this.props;
 
     return getHeight(rowHeight, columnHeaderHeight);
-  };
-
-  private shouldRenderTableHeader = () => {
-    const { editable, extraHeaderButtons, tableHeaderLabel } = this.props;
-
-    return editable || extraHeaderButtons!.length > 0 || !!tableHeaderLabel;
   };
 
   private sort = ({
@@ -353,12 +348,15 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     const {
       cx,
       data,
+      editable,
       expandable,
+      extraHeaderButtons,
       filterData,
       propagateRef,
       rowHeight,
       selectable,
       styles,
+      tableHeaderLabel,
     } = this.props;
 
     const { expandedRows, sortBy, sortDirection, editMode, selectedRows } = this.state;
@@ -371,12 +369,12 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
     return (
       <div>
-        {this.shouldRenderTableHeader() && (
+        {shouldRenderTableHeader(editable!, extraHeaderButtons!, tableHeaderLabel!) && (
           <AutoSizer disableHeight>
             {({ width }: { width: number }) => this.renderTableHeader(width)}
           </AutoSizer>
         )}
-        <div className={cx(styles.table_container)}>
+        <div className={cx(styles.tableContainer)}>
           <AutoSizer disableHeight>
             {({ width }: { width: number }) => (
               <Table
@@ -411,19 +409,21 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
 export default withStyles(
   theme => ({
-    table_container: {
+    tableContainer: {
       overflowX: 'auto',
     },
-    column_header: {
-      borderTop: '1px solid',
+    columnHeader: {
       borderBottom: '1px solid',
       borderColor: theme!.color.core.neutral[1],
       cursor: 'pointer',
     },
+    columnHeader_topBorder: {
+      borderTop: '1px solid',
+    },
     column: {
       height: 'inherit',
     },
-    column_divider: {
+    columnDivider: {
       borderRight: '1px solid',
       borderColor: theme!.color.core.neutral[1],
     },
@@ -432,10 +432,10 @@ export default withStyles(
       display: 'flex',
       alignItems: 'center',
     },
-    row_inner: {
+    rowInner: {
       width: '100%',
     },
-    expand_caret: {
+    expandCaret: {
       cursor: 'pointer',
     },
   }),


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
There's a top border on `ColumnHeaders` to separate them from the header label, but this is unnecessary when the header label is absent and adds extra visual noise.

<!--- Describe your change in detail. -->

## Motivation and Context
Feature request from Ken Chen.

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
<img width="660" alt="Screen Shot 2019-08-13 at 4 32 03 PM" src="https://user-images.githubusercontent.com/8676510/62984429-01192c00-bde8-11e9-9db2-287874ef8cdb.png">
<img width="664" alt="Screen Shot 2019-08-13 at 4 32 09 PM" src="https://user-images.githubusercontent.com/8676510/62984432-02e2ef80-bde8-11e9-8647-835699b00ae5.png">


<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
