### PR TITLE
update(DataTable): Only render top border when there's a header.

### DIFF
--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -142,5 +142,6 @@ export default withStyles(({ unit, color }) => ({
     justifyContent: 'space-between',
     paddingLeft: 2 * unit,
     paddingRight: 2 * unit,
+    borderBottom: `1px solid ${color.core.neutral[1]}`,
   },
 }))(TableHeader);

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -133,7 +133,7 @@ export function TableHeader({
   );
 }
 
-export default withStyles(({ unit, color }) => ({
+export default withStyles(({ unit, color, ui }) => ({
   tableHeader_inner: {
     background: color.accent.bg,
     display: 'flex',
@@ -142,6 +142,6 @@ export default withStyles(({ unit, color }) => ({
     justifyContent: 'space-between',
     paddingLeft: 2 * unit,
     paddingRight: 2 * unit,
-    borderBottom: `1px solid ${color.core.neutral[1]}`,
+    borderBottom: ui.border,
   },
 }))(TableHeader);

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -410,21 +410,19 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 }
 
 export default withStyles(
-  theme => ({
+  ({ color }) => ({
     table_container: {
       overflowX: 'auto',
     },
     column_header: {
-      borderBottom: '1px solid',
-      borderColor: theme!.color.core.neutral[1],
+      borderBottom: `1px solid ${color.core.neutral[1]}`,
       cursor: 'pointer',
     },
     column: {
       height: 'inherit',
     },
     column_divider: {
-      borderRight: '1px solid',
-      borderColor: theme!.color.core.neutral[1],
+      borderRight: `1px solid ${color.core.neutral[1]}`,
     },
     row: {
       height: '100%',

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -410,19 +410,19 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 }
 
 export default withStyles(
-  ({ color }) => ({
+  ({ color, ui }) => ({
     table_container: {
       overflowX: 'auto',
     },
     column_header: {
-      borderBottom: `1px solid ${color.core.neutral[1]}`,
+      borderBottom: ui.border,
       cursor: 'pointer',
     },
     column: {
       height: 'inherit',
     },
     column_divider: {
-      borderRight: `1px solid ${color.core.neutral[1]}`,
+      borderRight: ui.border,
     },
     row: {
       height: '100%',

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -410,7 +410,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 }
 
 export default withStyles(
-  ({ color, ui }) => ({
+  ({ ui }) => ({
     table_container: {
       overflowX: 'auto',
     },

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -415,7 +415,6 @@ export default withStyles(
       overflowX: 'auto',
     },
     column_header: {
-      borderTop: '1px solid',
       borderBottom: '1px solid',
       borderColor: theme!.color.core.neutral[1],
       cursor: 'pointer',


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
There's a top border on ColumnHeaders to separate them from the header label, but this is unnecessary when the header label is absent and adds extra visual noise.


<!--- Describe your change in detail. -->

## Motivation and Context
Feature request from Ken Chen.


<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
<img width="660" alt="Screen Shot 2019-08-13 at 4 32 03 PM" src="https://user-images.githubusercontent.com/8676510/62984817-6d485f80-bde9-11e9-9db1-9694120c4575.png">
<img width="664" alt="Screen Shot 2019-08-13 at 4 32 09 PM" src="https://user-images.githubusercontent.com/8676510/62984819-6f122300-bde9-11e9-84eb-8fb61564dae8.png">

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
