### PR TITLE
update(SortCarets): Clean up styles. Add tests and story.

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -94,11 +94,16 @@ export default function ColumnLabels({
                   {label}
                 </Text>
               </span>
+
               {label && sortable && (
-                <SortCarets
-                  enableUp={sort === SortDirection.ASC}
-                  enableDown={sort === SortDirection.DESC}
-                />
+                <Spacing inline left={0.5}>
+                  <SortCarets
+                    down
+                    up
+                    enableDown={sort === SortDirection.DESC}
+                    enableUp={sort === SortDirection.ASC}
+                  />
+                </Spacing>
               )}
             </div>
           </div>

--- a/packages/core/src/components/SortCarets.story.tsx
+++ b/packages/core/src/components/SortCarets.story.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import SortCarets from './SortCarets';
+
+storiesOf('Core/SortCarets', module)
+  .addParameters({
+    inspectComponents: [SortCarets],
+  })
+  .add('With up and down carets.', () => <SortCarets down up />)
+  .add('With only up.', () => <SortCarets up />)
+  .add('With only down.', () => <SortCarets down />)
+  .add('Active up caret.', () => <SortCarets down up enableUp />)
+  .add('Active down caret.', () => <SortCarets down up enableDown />);

--- a/packages/core/src/components/SortCarets/index.tsx
+++ b/packages/core/src/components/SortCarets/index.tsx
@@ -29,7 +29,7 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
     return (
       up && (
         <span className={cx(styles.caret, enableUp ? styles.caret_active : styles.caret_inactive)}>
-          <IconCaretUp decorative size="2em" />
+          <IconCaretUp decorative size="1.6em" />
         </span>
       )
     );
@@ -43,7 +43,7 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
         <span
           className={cx(styles.caret, enableDown ? styles.caret_active : styles.caret_inactive)}
         >
-          <IconCaretDown decorative size="2em" />
+          <IconCaretDown decorative size="1.6em" />
         </span>
       )
     );
@@ -64,18 +64,20 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
 export default withStyles(({ color }) => ({
   caret_container: {
     display: 'inline-block',
+    width: '.8em',
+    height: '1.2em',
   },
 
   caret: {
     display: 'block',
     position: 'relative',
-    width: '1em',
-    height: '1em',
+    width: '.8em',
+    height: '.6em',
     overflow: 'hidden',
 
     '@selectors': {
       '> svg': {
-        margin: '-.5em',
+        margin: '-.4em',
       },
     },
   },

--- a/packages/core/src/components/SortCarets/index.tsx
+++ b/packages/core/src/components/SortCarets/index.tsx
@@ -28,7 +28,13 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
 
     return (
       up && (
-        <span className={cx(styles.caret, enableUp ? styles.caret_active : styles.caret_inactive)}>
+        <span
+          className={cx(
+            styles.caret,
+            styles.caret_up,
+            enableUp ? styles.caret_active : styles.caret_inactive,
+          )}
+        >
           <IconCaretUp decorative size="1.6em" />
         </span>
       )
@@ -41,7 +47,11 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
     return (
       down && (
         <span
-          className={cx(styles.caret, enableDown ? styles.caret_active : styles.caret_inactive)}
+          className={cx(
+            styles.caret,
+            styles.caret_down,
+            enableDown ? styles.caret_active : styles.caret_inactive,
+          )}
         >
           <IconCaretDown decorative size="1.6em" />
         </span>
@@ -50,10 +60,10 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
   }
 
   render() {
-    const { cx, styles } = this.props;
+    const { cx, styles, up, down } = this.props;
 
     return (
-      <span className={cx(styles.caret_container)}>
+      <span className={cx(styles.container, up && down && styles.container_full)}>
         {this.renderCaretUp()}
         {this.renderCaretDown()}
       </span>
@@ -61,23 +71,41 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
   }
 }
 
-export default withStyles(({ color }) => ({
-  caret_container: {
+export default withStyles(({ color, unit }) => ({
+  container: {
     display: 'inline-block',
-    width: '.8em',
-    height: '1.2em',
+    verticalAlign: 'middle',
+    marginTop: -1,
+    width: unit * 1.5,
+    height: unit,
+  },
+
+  container_full: {
+    height: unit * 2,
   },
 
   caret: {
     display: 'block',
     position: 'relative',
-    width: '.8em',
-    height: '.6em',
+    width: unit * 1.5,
+    height: unit,
     overflow: 'hidden',
+  },
 
+  caret_up: {
     '@selectors': {
       '> svg': {
         margin: '-.4em',
+        marginTop: '-.5em',
+      },
+    },
+  },
+
+  caret_down: {
+    '@selectors': {
+      '> svg': {
+        margin: '-.4em',
+        marginTop: '-.6em',
       },
     },
   },

--- a/packages/core/src/components/SortCarets/index.tsx
+++ b/packages/core/src/components/SortCarets/index.tsx
@@ -7,34 +7,28 @@ export type Props = {
   /** Whether or not to display the bottom caret. */
   down?: boolean;
   /** If enabled, the caret is more pronounced. */
-  enableDown: boolean;
+  enableDown?: boolean;
   /** If enabled, the caret is more pronounced. */
-  enableUp: boolean;
+  enableUp?: boolean;
   /** Whether or not to display the top caret. */
   up?: boolean;
 };
 
-/** Carets to indicate sorting on DataTable. */
+/** Carets to indicate sorting on a table. */
 export class SortCarets extends React.Component<Props & WithStylesProps> {
   static defaultProps = {
-    down: true,
+    down: false,
     enableDown: false,
     enableUp: false,
-    up: true,
+    up: false,
   };
 
   renderCaretUp() {
-    const { cx, down, up, enableUp, styles } = this.props;
+    const { cx, up, enableUp, styles } = this.props;
 
     return (
       up && (
-        <span
-          className={cx(
-            down && styles.caret_up,
-            styles.caret,
-            enableUp ? styles.caret_active : styles.caret_inactive,
-          )}
-        >
+        <span className={cx(styles.caret, enableUp ? styles.caret_active : styles.caret_inactive)}>
           <IconCaretUp decorative size="2em" />
         </span>
       )
@@ -42,16 +36,12 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
   }
 
   renderCaretDown() {
-    const { cx, down, up, enableDown, styles } = this.props;
+    const { cx, down, enableDown, styles } = this.props;
 
     return (
       down && (
         <span
-          className={cx(
-            up && styles.caret_down,
-            styles.caret,
-            enableDown ? styles.caret_active : styles.caret_inactive,
-          )}
+          className={cx(styles.caret, enableDown ? styles.caret_active : styles.caret_inactive)}
         >
           <IconCaretDown decorative size="2em" />
         </span>
@@ -71,24 +61,30 @@ export class SortCarets extends React.Component<Props & WithStylesProps> {
   }
 }
 
-export default withStyles((theme: WithStylesProps['theme']) => ({
+export default withStyles(({ color }) => ({
   caret_container: {
-    marginRight: 0.5 * theme!.unit,
+    display: 'inline-block',
   },
+
   caret: {
+    display: 'block',
     position: 'relative',
-    right: 0.5 * theme!.unit,
+    width: '1em',
+    height: '1em',
+    overflow: 'hidden',
+
+    '@selectors': {
+      '> svg': {
+        margin: '-.5em',
+      },
+    },
   },
+
   caret_inactive: {
-    color: theme!.color.core.neutral[3],
+    color: color.core.neutral[3],
   },
+
   caret_active: {
-    color: theme!.color.core.neutral[4],
-  },
-  caret_up: {
-    bottom: -11,
-  },
-  caret_down: {
-    bottom: 11,
+    color: color.core.neutral[4],
   },
 }))(SortCarets);

--- a/packages/core/test/components/SortCarets.test.tsx
+++ b/packages/core/test/components/SortCarets.test.tsx
@@ -34,13 +34,13 @@ describe('<SortCarets />', () => {
         .find('span')
         .at(1)
         .prop('className'),
-    ).toBe('caret caret_active');
+    ).toMatch('caret_active');
     expect(
       wrapper
         .find('span')
         .at(2)
         .prop('className'),
-    ).toBe('caret caret_inactive');
+    ).toMatch('caret_inactive');
   });
 
   it('sets active on down caret', () => {
@@ -51,12 +51,12 @@ describe('<SortCarets />', () => {
         .find('span')
         .at(1)
         .prop('className'),
-    ).toBe('caret caret_inactive');
+    ).toMatch('caret_inactive');
     expect(
       wrapper
         .find('span')
         .at(2)
         .prop('className'),
-    ).toBe('caret caret_active');
+    ).toMatch('caret_active');
   });
 });

--- a/packages/core/test/components/SortCarets.test.tsx
+++ b/packages/core/test/components/SortCarets.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallowWithStyles } from '@airbnb/lunar-test-utils';
+import IconCaretUp from '@airbnb/lunar-icons/lib/interface/IconCaretUp';
+import IconCaretDown from '@airbnb/lunar-icons/lib/interface/IconCaretDown';
+import SortCarets from '../../src/components/SortCarets';
+
+describe('<SortCarets />', () => {
+  it('renders up caret', () => {
+    const wrapper = shallowWithStyles(<SortCarets up />);
+
+    expect(wrapper.find(IconCaretUp)).toHaveLength(1);
+    expect(wrapper.find(IconCaretDown)).toHaveLength(0);
+  });
+
+  it('renders down caret', () => {
+    const wrapper = shallowWithStyles(<SortCarets down />);
+
+    expect(wrapper.find(IconCaretUp)).toHaveLength(0);
+    expect(wrapper.find(IconCaretDown)).toHaveLength(1);
+  });
+
+  it('renders both carets', () => {
+    const wrapper = shallowWithStyles(<SortCarets down up />);
+
+    expect(wrapper.find(IconCaretUp)).toHaveLength(1);
+    expect(wrapper.find(IconCaretDown)).toHaveLength(1);
+  });
+
+  it('sets active on up caret', () => {
+    const wrapper = shallowWithStyles(<SortCarets down up enableUp />);
+
+    expect(
+      wrapper
+        .find('span')
+        .at(1)
+        .prop('className'),
+    ).toBe('caret caret_active');
+    expect(
+      wrapper
+        .find('span')
+        .at(2)
+        .prop('className'),
+    ).toBe('caret caret_inactive');
+  });
+
+  it('sets active on down caret', () => {
+    const wrapper = shallowWithStyles(<SortCarets down up enableDown />);
+
+    expect(
+      wrapper
+        .find('span')
+        .at(1)
+        .prop('className'),
+    ).toBe('caret caret_inactive');
+    expect(
+      wrapper
+        .find('span')
+        .at(2)
+        .prop('className'),
+    ).toBe('caret caret_active');
+  });
+});


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
cc: @schillerk 

## Description

Noticed the `SortCarets` kind of break down in some designs as the sizing isn't restrictive. This updates to be explicit.

<img width="253" alt="Screen Shot 2019-08-14 at 1 46 04 PM" src="https://user-images.githubusercontent.com/143744/63055047-e1dad700-be99-11e9-8812-593ea569159d.png">

## Motivation and Context

Just a little polish.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
