### PR TITLE
style: Override native agent font styles.

### DIFF
--- a/packages/core/src/components/Link.story.tsx
+++ b/packages/core/src/components/Link.story.tsx
@@ -9,7 +9,7 @@ storiesOf('Core/Link', module)
     inspectComponents: [Link],
   })
   .add('A standard link.', () => <Link href="https://github.com/airbnb/lunar">Link</Link>)
-  .add('A button link.', () => <Link onClick={action('onClick')}>Link</Link>)
+  .add('A button link.', () => <Link onClick={action('onClick')}>Button</Link>)
   .add('With different sizing: small, regular (default), and large.', () => (
     <>
       <Link href="https://github.com/airbnb/lunar" small>
@@ -53,7 +53,13 @@ storiesOf('Core/Link', module)
     </Link>
   ))
   .add('Bold text.', () => (
-    <Link href="https://github.com/airbnb/lunar" bold>
-      Link
-    </Link>
+    <>
+      <Link href="https://github.com/airbnb/lunar" bold>
+        Link
+      </Link>
+      <br />
+      <Link onClick={action('onClick')} bold>
+        Button
+      </Link>
+    </>
   ));

--- a/packages/core/src/themes/global.ts
+++ b/packages/core/src/themes/global.ts
@@ -31,13 +31,17 @@ export default (fontFaces: { [fontFamily: string]: FontFace[] }) => ({ color, fo
         '-webkit-font-smoothing': 'antialiased',
         '-moz-osx-font-smoothing': 'grayscale',
       },
-      'button, input, textarea': {
+      'a, button, input, select, textarea': {
         color: 'inherit',
         backgroundColor: 'inherit',
+        font: 'inherit',
       },
       img: {
         display: 'inline-block',
         verticalAlign: 'middle',
+      },
+      'tracking-boundary': {
+        display: 'block',
       },
     },
     '@font-face': fontFaces,


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Fixes font styles so that they are inherited. For example, `Link` bold tests.

Before:
<img width="111" alt="Screen Shot 2019-08-14 at 2 50 42 PM" src="https://user-images.githubusercontent.com/143744/63059431-4438d500-bea4-11e9-8e47-4e5e9dea030c.png">

After (added a new line):
<img width="84" alt="Screen Shot 2019-08-14 at 3 01 01 PM" src="https://user-images.githubusercontent.com/143744/63059465-59adff00-bea4-11e9-967b-68497b46c436.png">


## Motivation and Context

I've noticed here and there that some styles were missing, or being overridden by browser agent styles, mostly font related stuff.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

Problematic styles (font weight should be 600):

<img width="331" alt="Screen Shot 2019-08-14 at 2 52 13 PM" src="https://user-images.githubusercontent.com/143744/63059483-67638480-bea4-11e9-8449-2ab6ca949285.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
