### PR TITLE
fix(ImageViewer): Fix icon path from src to lib.

### DIFF
--- a/packages/core/src/components/ImageViewer/RotateControls.tsx
+++ b/packages/core/src/components/ImageViewer/RotateControls.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
-import IconRotateLeft from '@airbnb/lunar-icons/src/interface/IconRotateLeft';
-import IconRotateRight from '@airbnb/lunar-icons/src/interface/IconRotateRight';
+import IconRotateLeft from '@airbnb/lunar-icons/lib/interface/IconRotateLeft';
+import IconRotateRight from '@airbnb/lunar-icons/lib/interface/IconRotateRight';
 import IconButton from '../IconButton';
 import ButtonGroup from '../ButtonGroup';
 import T from '../Translate';

--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import IconAdd from '@airbnb/lunar-icons/src/interface/IconAdd';
-import IconRemove from '@airbnb/lunar-icons/src/interface/IconRemove';
+import IconAdd from '@airbnb/lunar-icons/lib/interface/IconAdd';
+import IconRemove from '@airbnb/lunar-icons/lib/interface/IconRemove';
 import Button from '../Button';
 import IconButton from '../IconButton';
 import ButtonGroup from '../ButtonGroup';


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Whoops! The links to icons in Rotate and Zoom controls were `src` when they should have been `lib`.

## Testing

## Screenshots

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
