### PR TITLE
update(Copy, Chip, Breadcrumb, MenuItem): Add data-tracking-name

### DIFF
--- a/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -24,7 +24,7 @@ export type Props = {
   onClick?: () => void;
   /** Mark the breadcrumb as selected. */
   selected?: boolean;
-  /** Adds a data-tracking-name attribute. */
+  /** A tracking name to identify this component. */
   trackingName?: string;
 };
 
@@ -88,7 +88,7 @@ class Breadcrumb extends React.Component<Props & WithStylesProps> {
           }
           disabled={disabled}
           href={href}
-          data-tracking-name={trackingName}
+          trackingName={trackingName}
           id={id}
           onClick={this.handleClick}
         >

--- a/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -14,7 +14,7 @@ export type Props = {
   highlighted?: boolean;
   /** @ignore */
   horizontal?: boolean;
-  /** Pass an HTML element attribute id */
+  /** Pass an HTML element attribute id. */
   id?: string;
   /** Content to within the Breadcrumb. */
   label: string;
@@ -24,7 +24,7 @@ export type Props = {
   onClick?: () => void;
   /** Mark the breadcrumb as selected. */
   selected?: boolean;
-  /** Adds a data-tracking-name attribute */
+  /** Adds a data-tracking-name attribute. */
   trackingName?: string;
 };
 

--- a/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/core/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -24,6 +24,8 @@ export type Props = {
   onClick?: () => void;
   /** Mark the breadcrumb as selected. */
   selected?: boolean;
+  /** Adds a data-tracking-name attribute */
+  trackingName?: string;
 };
 
 /** A single breadcrumb button. Usually rendered amongst a collection of breadcrumbs. */
@@ -56,6 +58,7 @@ class Breadcrumb extends React.Component<Props & WithStylesProps> {
       onClick,
       selected,
       styles,
+      trackingName,
     } = this.props;
     const clickable = !disabled && (!!href || !!onClick);
     const aria = selected ? { 'aria-current': 'page' } : {};
@@ -85,6 +88,7 @@ class Breadcrumb extends React.Component<Props & WithStylesProps> {
           }
           disabled={disabled}
           href={href}
+          data-tracking-name={trackingName}
           id={id}
           onClick={this.handleClick}
         >

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -19,7 +19,7 @@ export type Props = {
   compact?: boolean;
   /** Disabled / gray. */
   disabled?: boolean;
-  /** Pass an HTML element attribute id */
+  /** Pass an HTML element attribute id. */
   id?: string;
   /** Callback fired when the element is clicked. */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -27,7 +27,7 @@ export type Props = {
   onIconClick?: (event: React.MouseEvent<ButtonOrLinkTypes>) => void;
   /** Profile photo to render to the left of the primary content. */
   profileImageSrc?: string;
-  /** Adds a data-tracking-name attribute */
+  /** Adds a data-tracking-name attribute. */
   trackingName?: string;
 };
 

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -27,7 +27,7 @@ export type Props = {
   onIconClick?: (event: React.MouseEvent<ButtonOrLinkTypes>) => void;
   /** Profile photo to render to the left of the primary content. */
   profileImageSrc?: string;
-  /** A tracking name to identify this component. */
+  /** A tracking name to identify this component when element is clicked. */
   trackingName?: string;
 };
 
@@ -70,6 +70,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
             disabled,
             onClick,
             type: 'button',
+            ...(trackingName && { 'data-tracking-name': trackingName }),
           }
         : {};
 
@@ -89,7 +90,6 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           disabled && styles.chip_disabled,
         )}
         {...props}
-        trackingName={trackingName}
         id={id}
       >
         {shouldRenderBefore && (

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -27,6 +27,8 @@ export type Props = {
   onIconClick?: (event: React.MouseEvent<ButtonOrLinkTypes>) => void;
   /** Profile photo to render to the left of the primary content. */
   profileImageSrc?: string;
+  /** Adds a data-tracking-name attribute */
+  trackingName?: string;
 };
 
 /** Compact component that represents a snippet of information, such as a filter. */
@@ -58,6 +60,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
       onIconClick,
       profileImageSrc,
       styles,
+      trackingName,
     } = this.props;
 
     const Component = onClick ? 'button' : 'div';
@@ -86,6 +89,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           disabled && styles.chip_disabled,
         )}
         {...props}
+        data-tracking-name={trackingName}
         id={id}
       >
         {shouldRenderBefore && (

--- a/packages/core/src/components/Chip/index.tsx
+++ b/packages/core/src/components/Chip/index.tsx
@@ -27,7 +27,7 @@ export type Props = {
   onIconClick?: (event: React.MouseEvent<ButtonOrLinkTypes>) => void;
   /** Profile photo to render to the left of the primary content. */
   profileImageSrc?: string;
-  /** Adds a data-tracking-name attribute. */
+  /** A tracking name to identify this component. */
   trackingName?: string;
 };
 
@@ -89,7 +89,7 @@ export class Chip extends React.Component<Props & WithStylesProps> {
           disabled && styles.chip_disabled,
         )}
         {...props}
-        data-tracking-name={trackingName}
+        trackingName={trackingName}
         id={id}
       >
         {shouldRenderBefore && (

--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -8,7 +8,7 @@ import Link from '../Link';
 export type Props = {
   /** Custom element to trigger the click. */
   children?: React.ReactElement;
-  /** Pass an HTML element attribute id to the Link */
+  /** Pass an HTML element attribute id to the Link. */
   id?: string;
   /** String of text to be copied to the clipboard. */
   text: string;
@@ -16,7 +16,7 @@ export type Props = {
   onCopy?: (text: string, copied: boolean) => void;
   /** Custom prompt message to display in the tooltip. */
   prompt?: React.ReactNode;
-  /** Adds a data-tracking-name attribute */
+  /** Adds a data-tracking-name attribute. */
   trackingName?: string;
   /** Add an underline to the element. */
   underlined?: boolean;

--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -16,6 +16,8 @@ export type Props = {
   onCopy?: (text: string, copied: boolean) => void;
   /** Custom prompt message to display in the tooltip. */
   prompt?: React.ReactNode;
+  /** Adds a data-tracking-name attribute */
+  trackingName?: string;
   /** Add an underline to the element. */
   underlined?: boolean;
 };
@@ -54,10 +56,10 @@ export default class Copy extends React.Component<Props, State> {
   };
 
   render() {
-    const { prompt, children, id, underlined } = this.props;
+    const { prompt, children, id, trackingName, underlined } = this.props;
     const element = children || (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <Link id={id}>
+      <Link data-tracking-name={trackingName} id={id}>
         <IconCopy decorative />
       </Link>
     );

--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -16,7 +16,7 @@ export type Props = {
   onCopy?: (text: string, copied: boolean) => void;
   /** Custom prompt message to display in the tooltip. */
   prompt?: React.ReactNode;
-  /** Adds a data-tracking-name attribute. */
+  /** A tracking name to identify this component. */
   trackingName?: string;
   /** Add an underline to the element. */
   underlined?: boolean;
@@ -59,7 +59,7 @@ export default class Copy extends React.Component<Props, State> {
     const { prompt, children, id, trackingName, underlined } = this.props;
     const element = children || (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <Link data-tracking-name={trackingName} id={id}>
+      <Link trackingName={trackingName} id={id}>
         <IconCopy decorative />
       </Link>
     );

--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -34,6 +34,8 @@ export type Props = {
   tabIndex?: number;
   /** Tip to display after the item. */
   tip?: React.ReactNode;
+  /** Adds a data-tracking-name attribute */
+  trackingName?: string;
 };
 
 /** An interactive item within a menu. */
@@ -92,6 +94,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
       submenu,
       tabIndex,
       tip,
+      trackingName,
     } = this.props;
     const { showSubmenu } = this.state;
     const after = submenu ? (
@@ -119,6 +122,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
           beforeIcon={icon}
           disabled={disabled}
           href={href}
+          data-tracking-name={trackingName}
           id={id}
           onClick={onClick}
           openInNewWindow={openInNewWindow}

--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -34,7 +34,7 @@ export type Props = {
   tabIndex?: number;
   /** Tip to display after the item. */
   tip?: React.ReactNode;
-  /** Adds a data-tracking-name attribute. */
+  /** A tracking name to identify this component. */
   trackingName?: string;
 };
 
@@ -122,7 +122,7 @@ export class MenuItem extends React.Component<Props & WithStylesProps> {
           beforeIcon={icon}
           disabled={disabled}
           href={href}
-          data-tracking-name={trackingName}
+          trackingName={trackingName}
           id={id}
           onClick={onClick}
           openInNewWindow={openInNewWindow}

--- a/packages/core/src/components/Menu/Item.tsx
+++ b/packages/core/src/components/Menu/Item.tsx
@@ -18,7 +18,7 @@ export type Props = {
   href?: string;
   /** An icon to display before the item. */
   icon?: React.ReactNode;
-  /** Pass an HTML element attribute id */
+  /** Pass an HTML element attribute id. */
   id?: string;
   /** Click handler. */
   onClick?: () => void;
@@ -34,7 +34,7 @@ export type Props = {
   tabIndex?: number;
   /** Tip to display after the item. */
   tip?: React.ReactNode;
-  /** Adds a data-tracking-name attribute */
+  /** Adds a data-tracking-name attribute. */
   trackingName?: string;
 };
 

--- a/packages/core/src/components/private/ButtonOrLink.tsx
+++ b/packages/core/src/components/private/ButtonOrLink.tsx
@@ -28,6 +28,8 @@ export type Props = {
   openInNewWindow?: boolean;
   /** Rel attribute override for if the component has an href */
   rel?: string;
+  /** Add a data-tracking-name attribute. */
+  trackingName?: string;
   /** When a button, the type of button. */
   type?: 'button' | 'submit' | 'reset';
 };
@@ -73,6 +75,7 @@ export default class ButtonOrLink extends React.Component<Props> {
       loading,
       openInNewWindow,
       rel,
+      trackingName,
       type,
       ...restProps
     } = this.props;
@@ -98,7 +101,13 @@ export default class ButtonOrLink extends React.Component<Props> {
 
     return (
       // @ts-ignore [ts] JSX element type 'Component' does not have any construct or call signatures. [2604]
-      <Tag {...restProps} {...props} onClick={this.handleClick} onMouseUp={this.handleMouseUp}>
+      <Tag
+        {...restProps}
+        {...props}
+        data-tracking-name={trackingName}
+        onClick={this.handleClick}
+        onMouseUp={this.handleMouseUp}
+      >
         {!loading && beforeIcon && (
           <IconAffix before flex={flexAlign}>
             {beforeIcon}

--- a/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -38,10 +38,16 @@ describe('<Breadcrumb/>', () => {
 
   it('renders a passed id for tracking', () => {
     const wrapper = shallowWithStyles(
-      <Breadcrumb id="tracking-breadcrump" onClick={() => {}} label="Breadcrumb" />,
+      <Breadcrumb
+        id="tracking-breadcrump"
+        trackingName="tracking-name"
+        onClick={() => {}}
+        label="Breadcrumb"
+      />,
     );
 
     expect(wrapper.find(ButtonOrLink).prop('id')).toBe('tracking-breadcrump');
+    expect(wrapper.find(ButtonOrLink).prop('data-tracking-name')).toBe('tracking-name');
   });
 
   it('renders an icon', () => {

--- a/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/packages/core/test/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -47,7 +47,7 @@ describe('<Breadcrumb/>', () => {
     );
 
     expect(wrapper.find(ButtonOrLink).prop('id')).toBe('tracking-breadcrump');
-    expect(wrapper.find(ButtonOrLink).prop('data-tracking-name')).toBe('tracking-name');
+    expect(wrapper.find(ButtonOrLink).prop('trackingName')).toBe('tracking-name');
   });
 
   it('renders an icon', () => {

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -19,7 +19,7 @@ describe('<Chip />', () => {
     expect(wrapper.prop('onClick')).toBe(onClick);
   });
 
-  it('passed an id for tracking', () => {
+  it('add data-tracking-name when clickable', () => {
     const onClick = () => {};
     const wrapper = shallowWithStyles(
       <Chip onClick={onClick} id="tracking-chip" trackingName="tracking-chip-name">
@@ -27,7 +27,28 @@ describe('<Chip />', () => {
       </Chip>,
     );
     expect(wrapper.prop('id')).toBe('tracking-chip');
-    expect(wrapper.prop('trackingName')).toBe('tracking-chip-name');
+    expect(wrapper.find('button').prop('id')).toBe('tracking-chip');
+    expect(wrapper.find('button').prop('data-tracking-name')).toBe('tracking-chip-name');
+  });
+
+  it('doesnt add data-tracking-name when not clickable', () => {
+    const wrapper = shallowWithStyles(
+      <Chip id="tracking-chip" trackingName="tracking-chip-name">
+        Potato
+      </Chip>,
+    );
+    expect(
+      wrapper
+        .find('div')
+        .first()
+        .prop('id'),
+    ).toBe('tracking-chip');
+    expect(
+      wrapper
+        .find('div')
+        .find({ id: 'tracking-chip' })
+        .prop('data-tracking-name'),
+    ).toBeUndefined();
   });
 
   it('renders an after icon if provided', () => {

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -27,7 +27,7 @@ describe('<Chip />', () => {
       </Chip>,
     );
     expect(wrapper.prop('id')).toBe('tracking-chip');
-    expect(wrapper.prop('data-tracking-name')).toBe('tracking-chip-name');
+    expect(wrapper.prop('trackingName')).toBe('tracking-chip-name');
   });
 
   it('renders an after icon if provided', () => {

--- a/packages/core/test/components/Chip.test.tsx
+++ b/packages/core/test/components/Chip.test.tsx
@@ -22,11 +22,12 @@ describe('<Chip />', () => {
   it('passed an id for tracking', () => {
     const onClick = () => {};
     const wrapper = shallowWithStyles(
-      <Chip onClick={onClick} id="tracking-chip">
+      <Chip onClick={onClick} id="tracking-chip" trackingName="tracking-chip-name">
         Potato
       </Chip>,
     );
     expect(wrapper.prop('id')).toBe('tracking-chip');
+    expect(wrapper.prop('data-tracking-name')).toBe('tracking-chip-name');
   });
 
   it('renders an after icon if provided', () => {

--- a/packages/core/test/components/Copy.test.tsx
+++ b/packages/core/test/components/Copy.test.tsx
@@ -23,11 +23,11 @@ describe('<Copy />', () => {
     expect(wrapper.find(Link)).toHaveLength(1);
   });
 
-  it('can add an id and data-tracking-name to the Link', () => {
+  it('can add an id and trackingName to the Link', () => {
     const wrapper = shallow(<Copy text="foo" id="tracking-id" trackingName="tracking-name" />);
 
     expect(wrapper.find(Link).prop('id')).toBe('tracking-id');
-    expect(wrapper.find(Link).prop('data-tracking-name')).toBe('tracking-name');
+    expect(wrapper.find(Link).prop('trackingName')).toBe('tracking-name');
   });
 
   it('can customize the child', () => {

--- a/packages/core/test/components/Copy.test.tsx
+++ b/packages/core/test/components/Copy.test.tsx
@@ -23,10 +23,11 @@ describe('<Copy />', () => {
     expect(wrapper.find(Link)).toHaveLength(1);
   });
 
-  it('can add an id to the Link', () => {
-    const wrapper = shallow(<Copy text="foo" id="tracking-id" />);
+  it('can add an id and data-tracking-name to the Link', () => {
+    const wrapper = shallow(<Copy text="foo" id="tracking-id" trackingName="tracking-name" />);
 
     expect(wrapper.find(Link).prop('id')).toBe('tracking-id');
+    expect(wrapper.find(Link).prop('data-tracking-name')).toBe('tracking-name');
   });
 
   it('can customize the child', () => {

--- a/packages/core/test/components/Menu/Item.test.tsx
+++ b/packages/core/test/components/Menu/Item.test.tsx
@@ -54,7 +54,7 @@ describe('<MenuItem />', () => {
 
     expect(wrapper.find(ButtonOrLink).prop('disabled')).toBe(true);
     expect(wrapper.find(ButtonOrLink).prop('id')).toBe('tracking-id');
-    expect(wrapper.find(ButtonOrLink).prop('data-tracking-name')).toBe('tracking-name');
+    expect(wrapper.find(ButtonOrLink).prop('trackingName')).toBe('tracking-name');
   });
 
   it('passes icon to underlying button', () => {

--- a/packages/core/test/components/Menu/Item.test.tsx
+++ b/packages/core/test/components/Menu/Item.test.tsx
@@ -40,12 +40,21 @@ describe('<MenuItem />', () => {
 
   it('passes props to underlying button', () => {
     const wrapper = shallowWithStyles(
-      <Item disabled openInNewWindow href="/" tabIndex={0} id="tracking-item">
+      <Item
+        disabled
+        openInNewWindow
+        href="/"
+        tabIndex={0}
+        id="tracking-id"
+        trackingName="tracking-name"
+      >
         Foo
       </Item>,
     );
 
     expect(wrapper.find(ButtonOrLink).prop('disabled')).toBe(true);
+    expect(wrapper.find(ButtonOrLink).prop('id')).toBe('tracking-id');
+    expect(wrapper.find(ButtonOrLink).prop('data-tracking-name')).toBe('tracking-name');
   });
 
   it('passes icon to underlying button', () => {

--- a/packages/core/test/components/private/ButtonOrLink.test.tsx
+++ b/packages/core/test/components/private/ButtonOrLink.test.tsx
@@ -27,6 +27,12 @@ describe('<ButtonOrLink />', () => {
     expect(wrapper.prop('disabled')).toBe(true);
   });
 
+  it('adds data-tracking-name when trackingName is passed', () => {
+    const wrapper = shallow(<ButtonOrLink trackingName="tracking-button">Child</ButtonOrLink>);
+
+    expect(wrapper.prop('data-tracking-name')).toBe('tracking-button');
+  });
+
   it('disables the button when loading', () => {
     const wrapper = shallow(<ButtonOrLink loading>Child</ButtonOrLink>);
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds `trackingName` which will follow our convention of adding a `data-tracking-name` attribute on button and anchor elements. 

## Motivation and Context

`id` should be unique across the page. When `id` is used in reusable components, it can be difficult or impossible for consumers to provide a unique `id`. Adding `data-tracking-name` is a better alternative for tracking. 

https://www.w3.org/TR/html4/struct/global.html#h-7.5.2

Future PRs can add `trackingName` and `data-tracking-name` as needed to provide tracking context for analytics. 

## Testing

Updated tests. 

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
