### PR TITLE
fix(Form): Fix `FormContext` not propagating.

### DIFF
--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -19,7 +19,7 @@ import T from '@airbnb/lunar/lib/components/Translate';
 import { getErrorMessage } from '@airbnb/lunar/lib/components/ErrorMessage';
 import FormErrorMessage from '@airbnb/lunar/lib/components/FormErrorMessage';
 import FormContext from '../FormContext';
-import { Context, Errors, Parse, Field } from '../../types';
+import { Errors, Parse, Field } from '../../types';
 import { throttleToSinglePromise } from '../../helpers';
 
 function mapSubscriptions(subscriptions: string[]): { [sub: string]: boolean } {

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -85,8 +85,6 @@ export default class Form<Data extends object = any> extends React.Component<
 
   form: FormApi<Data>;
 
-  formContext?: Context;
-
   registeredFields: { [name: string]: Unsubscribe } = {};
 
   constructor(props: Props<Data>) {
@@ -422,18 +420,16 @@ export default class Form<Data extends object = any> extends React.Component<
     // @ts-ignore Bug: https://github.com/Microsoft/TypeScript/issues/26970
     const content = typeof children === 'function' ? children(this.state!) : children;
 
-    if (!this.formContext) {
-      this.formContext = {
-        change: this.changeValue,
-        getFields: this.getFields,
-        getState: this.getState,
-        register: this.registerField,
-        submit: this.submitForm,
-      };
-    }
-
     return (
-      <FormContext.Provider value={this.formContext}>
+      <FormContext.Provider
+        value={{
+          change: this.changeValue,
+          getFields: this.getFields,
+          getState: this.getState,
+          register: this.registerField,
+          submit: this.submitForm,
+        }}
+      >
         <form
           id={id}
           method={method}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Fixes the form context not propagating to consumers. Was caused by my over optimization in a previous PR.

## Motivation and Context

It breaks consumers that rely on form state.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
