### PR TITLE
update(DataTable): set display flex to avoid rare header height bug

### DIFF
--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -413,6 +413,7 @@ export default withStyles(
   theme => ({
     table_container: {
       overflowX: 'auto',
+      display: 'flex',
     },
     column_header: {
       borderTop: '1px solid',


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Conglei is running into a bug in superset UI where column headers take up the full width. We investigated, and were unable to discover a cause, but this is a known fix.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
