### PR TITLE
new(ProfilePhoto): Add `fallbackImageSrc` to render if an image is broken.

### DIFF
--- a/packages/core/src/components/ProfilePhoto.story.tsx
+++ b/packages/core/src/components/ProfilePhoto.story.tsx
@@ -31,4 +31,7 @@ storiesOf('Core/ProfilePhoto', module)
   ))
   .add('Broken image with overflowing alt text.', () => (
     <ProfilePhoto imageSrc="BROKEN_IMAGE" title="Alt title text." large />
+  ))
+  .add('Fallback image src when image is broken.', () => (
+    <ProfilePhoto fallbackImageSrc={lunar} imageSrc="BROKEN_IMAGE" title="Alt title text." large />
   ));

--- a/packages/core/src/components/ProfilePhoto/index.tsx
+++ b/packages/core/src/components/ProfilePhoto/index.tsx
@@ -14,6 +14,8 @@ const namedSizePropType = and([PropTypes.bool, mutuallyExclusiveSizePropType]);
 const unitSizePropType = and([PropTypes.number, mutuallyExclusiveSizePropType]);
 
 export type Props = {
+  /** Fallback image if the image is broken. */
+  fallbackImageSrc?: string;
   /** URL of the image to display. */
   imageSrc: string;
   /** Whether the component should be inline. */
@@ -48,9 +50,19 @@ export class ProfilePhoto extends React.Component<Props & WithStylesProps> {
     square: false,
   };
 
+  private handleError = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    const { fallbackImageSrc } = this.props;
+
+    if (event && fallbackImageSrc) {
+      // eslint-disable-next-line no-param-reassign
+      (event.currentTarget || event.target).src = fallbackImageSrc;
+    }
+  };
+
   render() {
     const {
       cx,
+      fallbackImageSrc,
       imageSrc,
       inline,
       macro,
@@ -100,6 +112,7 @@ export class ProfilePhoto extends React.Component<Props & WithStylesProps> {
           src={imageSrc}
           alt={title}
           title={title}
+          onError={fallbackImageSrc ? this.handleError : undefined}
         />
       </div>
     );


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Provides an option to give a fallback image when the original image source fails to load.

## Motivation and Context

Sometimes, you don't want to see the broken image, but fallback to a generic user image.

## Testing

storybook

## Screenshots

<img width="1025" alt="Screen Shot 2019-08-22 at 3 14 32 PM" src="https://user-images.githubusercontent.com/306275/63555888-95297880-c4f7-11e9-88d4-5e13244479bc.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
