### PR TITLE
ci: Remove Happo and Storybook from Travis.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,18 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git checkout master
-          git config --local user.name ${GIT_USER}
-          git config --locale user.email ${GIT_EMAIL}
+          # git config --local user.name ${GIT_USER}
+          # git config --locale user.email ${GIT_EMAIL}
           git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+      - name: Test
+        run: |
+          echo $GIT_AUTHOR_NAME
+          echo $GIT_AUTHOR_EMAIL
+          echo $GIT_COMMITTER_NAME
+          echo $GIT_COMMITTER_EMAIL
+          echo git config --get user.name
+          echo git config --get user.email
       - uses: ./.github/actions/setup
       # Enable later on!
       # - name: Publish packages to NPM

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git checkout master
-          # git config --global user.name ${GIT_USER}
-          # git config --global user.email ${GIT_EMAIL}
+          git config --local user.name ${GIT_USER}
+          git config --locale user.email ${GIT_EMAIL}
           git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
       - uses: ./.github/actions/setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,10 @@ jobs:
           GIT_USER: ${{ secrets.GIT_USER }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git config --global user.name ${GIT_USER}
-          git config --global user.email ${GIT_EMAIL}
-          git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           git checkout master
+          # git config --global user.name ${GIT_USER}
+          # git config --global user.email ${GIT_EMAIL}
+          git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
       - uses: ./.github/actions/setup
       # Enable later on!

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,10 @@ jobs:
         run: |
           echo $GIT_AUTHOR_NAME
           echo $GIT_AUTHOR_EMAIL
-          echo $GIT_COMMITTER_NAME
-          echo $GIT_COMMITTER_EMAIL
-          echo git config --get user.name
-          echo git config --get user.email
+          echo GIT_COMMITTER_NAME
+          echo GIT_COMMITTER_EMAIL
+          git config --get user.name
+          git config --get user.email
       - uses: ./.github/actions/setup
       # Enable later on!
       # - name: Publish packages to NPM

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,25 @@
 name: Publish
-on:
-  push:
-    branches:
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
+on: push
 jobs:
-  storybook:
-    name: Storybook
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - uses: ./.github/actions/setup
-      - name: Publish Storybook to GitHub Pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          yarn run storybook:build
-          yarn run deploy:ghp
+  # storybook:
+  #   name: Storybook
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 12
+  #     - uses: ./.github/actions/setup
+  #     - name: Publish Storybook to GitHub Pages
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         yarn run storybook:build
+  #         yarn run deploy:ghp
 
   npm:
     name: NPM
@@ -31,12 +32,12 @@ jobs:
       - name: Setup Git and NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EMAIL: ${{ secrets.GITHUB_EMAIL }}
-          GITHUB_USER: ${{ secrets.GITHUB_USER }}
+          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_USER: ${{ secrets.GIT_USER }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git config --global user.name ${GITHUB_USER}
-          git config --global user.email ${GITHUB_EMAIL}
+          git config --global user.name ${GIT_USER}
+          git config --global user.email ${GIT_EMAIL}
           git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           git checkout master
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,21 +29,21 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Setup Git and NPM
+      - name: Checkout master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout master
-          git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
-          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+          git remote set-url origin "https://${GH_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
       - uses: ./.github/actions/setup
       - name: Publish packages to NPM
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_EMAIL }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER }}
         run: |
+          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
           yarn run deploy:npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup Git and NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_USER: ${{ secrets.GIT_USER }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git checkout master
@@ -45,8 +45,8 @@ jobs:
         run: |
           echo $GIT_AUTHOR_NAME
           echo $GIT_AUTHOR_EMAIL
-          echo GIT_COMMITTER_NAME
-          echo GIT_COMMITTER_EMAIL
+          echo $GIT_COMMITTER_NAME
+          echo $GIT_COMMITTER_EMAIL
           git config --get user.name
           git config --get user.email
       - uses: ./.github/actions/setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,49 +1,47 @@
 name: Publish
-# on:
-#   push:
-#     branches:
-#       - master
-on: push
+on:
+  push:
+    branches:
+      - master
 jobs:
-  # storybook:
-  #   name: Storybook
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 12
-  #     - uses: ./.github/actions/setup
-  #     - name: Publish Storybook to GitHub Pages
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       run: |
-  #         yarn run storybook:build
-  #         yarn run deploy:ghp
-
-  npm:
-    name: NPM
+  storybook:
+    name: Storybook
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Checkout master
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git checkout master
-          git remote set-url origin "https://${GH_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
       - uses: ./.github/actions/setup
-      - name: Publish packages to NPM
+      - name: Publish Storybook to GitHub Pages
         env:
-          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_NAME: ${{ secrets.GIT_USER }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.email "${GIT_EMAIL}"
-          git config user.name "${GIT_NAME}"
-          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
-          yarn run deploy:npm
+          yarn run storybook:build
+          yarn run deploy:ghp
+  # npm:
+  #   name: NPM
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 12
+  #     - name: Checkout master
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         git checkout master
+  #         git remote set-url origin "https://${GH_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
+  #     - uses: ./.github/actions/setup
+  #     - name: Publish packages to NPM
+  #       env:
+  #         GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+  #         GIT_NAME: ${{ secrets.GIT_USER }}
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #       run: |
+  #         git config user.email "${GIT_EMAIL}"
+  #         git config user.name "${GIT_NAME}"
+  #         echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+  #         yarn run deploy:npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Checkout master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_NAME: ${{ secrets.GIT_USER }}
         run: |
           git checkout master
           git remote set-url origin "https://${GH_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
+          git config --global user.email "${GIT_EMAIL}"
+          git config --global user.name "${GIT_NAME}"
       - uses: ./.github/actions/setup
       - name: Publish packages to NPM
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER }}
         run: |
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
           yarn run deploy:npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,27 +32,18 @@ jobs:
       - name: Setup Git and NPM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git checkout master
-          # git config --local user.name ${GIT_USER}
-          # git config --locale user.email ${GIT_EMAIL}
           git remote set-url origin "https://${GITHUB_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
-      - name: Test
-        run: |
-          echo $GIT_AUTHOR_NAME
-          echo $GIT_AUTHOR_EMAIL
-          echo $GIT_COMMITTER_NAME
-          echo $GIT_COMMITTER_EMAIL
-          git config --get user.name
-          git config --get user.email
       - uses: ./.github/actions/setup
-      # Enable later on!
-      # - name: Publish packages to NPM
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     yarn run deploy:npm
+      - name: Publish packages to NPM
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER }}
+        run: |
+          yarn run deploy:npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Checkout master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
-          GIT_NAME: ${{ secrets.GIT_USER }}
         run: |
           git checkout master
           git remote set-url origin "https://${GH_TOKEN}@github.com/airbnb/lunar.git" > /dev/null 2>&1
-          git config --global user.email "${GIT_EMAIL}"
-          git config --global user.name "${GIT_NAME}"
       - uses: ./.github/actions/setup
       - name: Publish packages to NPM
         env:
+          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+          GIT_NAME: ${{ secrets.GIT_USER }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          git config user.email "${GIT_EMAIL}"
+          git config user.name "${GIT_NAME}"
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
           yarn run deploy:npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,7 @@ matrix:
 jobs:
   include:
     - stage: Tests
-      name: Happo
-      script: yarn run happo:ci:travis
-      node_js: '12'
-      if: type = pull_request OR branch = master
-    - name: Test @ 8
+      name: Test @ 8
       script: yarn run jest:coverage -w 4
       node_js: '8'
     - name: Test @ 10
@@ -36,16 +32,6 @@ jobs:
     - name: Lint @ 12
       script: yarn run lint:errors
       node_js: '12'
-    - stage: Publish Storybook
-      script: skip
-      node_js: '12'
-      if: branch = master
-      deploy:
-        provider: script
-        script: yarn run deploy:ghp
-        skip_cleanup: true
-        on:
-          branch: master
     - stage: Release Packages
       script: skip
       node_js: '12'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "prettier --write ./*.{md,json} \"./packages/*/{src,test}/**/*.{ts,tsx,js,jsx,gql,graphql,yml,yaml,md}\"",
     "release": "yarn run build && lerna publish",
     "release:publish": "lerna publish from-git --yes",
-    "release:version": "lerna version --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push",
+    "release:version": "lerna version --yes --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push",
     "sg": "NODE_ENV=development yarn run storybook",
     "test": "yarn run jest:coverage",
     "type": "tsc --build && yarn run clean:story",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "prettier --write ./*.{md,json} \"./packages/*/{src,test}/**/*.{ts,tsx,js,jsx,gql,graphql,yml,yaml,md}\"",
     "release": "yarn run build && lerna publish",
     "release:publish": "lerna publish from-git --yes",
-    "release:version": "lerna version --yes --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push",
+    "release:version": "lerna version --yes --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push --preid alpha",
     "sg": "NODE_ENV=development yarn run storybook",
     "test": "yarn run jest:coverage",
     "type": "tsc --build && yarn run clean:story",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "prettier --write ./*.{md,json} \"./packages/*/{src,test}/**/*.{ts,tsx,js,jsx,gql,graphql,yml,yaml,md}\"",
     "release": "yarn run build && lerna publish",
     "release:publish": "lerna publish from-git --yes",
-    "release:version": "lerna version --yes --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push --preid alpha",
+    "release:version": "lerna version --conventional-commits --changelog-preset conventional-changelog-beemo --create-release github --push",
     "sg": "NODE_ENV=development yarn run storybook",
     "test": "yarn run jest:coverage",
     "type": "tsc --build && yarn run clean:story",


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

We're doing double builds on master. Since Happo/Storybook is also built from GitHub actions, let's just use those instead. 

## Motivation and Context

This should speed up the releases process a bit.

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
