### PR TITLE
fix(DataTable): Subtract header height from `autoHeight` only when a header exists.

### DIFF
--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -406,7 +406,8 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
               <Table
                 height={
                   autoHeight
-                    ? height - getHeight(rowHeight, tableHeaderHeight)
+                    ? height -
+                      (this.shouldRenderTableHeader() ? getHeight(rowHeight, tableHeaderHeight) : 0)
                     : this.getTableHeight(expandedData)
                 }
                 width={this.props.width || width}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
I messed up in https://github.com/airbnb/lunar/pull/144 and added logic to subtract `tableHeaderHeight` from the autoHeight measurement unconditionally.

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing
Tested in storybook.
<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
