### PR TITLE
update(RadioButton): support small prop and make children full width

### DIFF
--- a/packages/core/src/components/RadioButton.story.tsx
+++ b/packages/core/src/components/RadioButton.story.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import lunar from ':storybook/images/lunar-logo.png';
 import RadioButton from './RadioButton';
+import Row from './Row';
+import ProfilePhoto from './ProfilePhoto';
 
 storiesOf('Core/RadioButton', module)
   .addParameters({
@@ -86,7 +89,7 @@ storiesOf('Core/RadioButton', module)
       />
     </>
   ))
-  .add('As a large clickable button.', () => (
+  .add('As a clickable button.', () => (
     <RadioButton
       name="radio-basic"
       label="Label"
@@ -94,5 +97,19 @@ storiesOf('Core/RadioButton', module)
       value="foo"
       onChange={action('onChange')}
       button
+      topAlign
     />
+  ))
+  .add('As a small clickable button.', () => (
+    <RadioButton
+      name="radio-basic"
+      label="Label"
+      labelDescription="This is a label description."
+      value="foo"
+      onChange={action('onChange')}
+      button
+      small
+    >
+      <Row after={<ProfilePhoto imageSrc={lunar} title="Photo" small />}>Label from children</Row>
+    </RadioButton>
   ));

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -39,6 +39,7 @@ class BaseRadioButton extends React.Component<Props & WithStylesProps> {
       id,
       invalid,
       indeterminate,
+      small,
       styles,
       ...restProps
     } = this.props;
@@ -92,6 +93,7 @@ class BaseRadioButton extends React.Component<Props & WithStylesProps> {
       id,
       invalid,
       indeterminate,
+      small,
       styles,
     } = this.props;
 
@@ -108,6 +110,7 @@ class BaseRadioButton extends React.Component<Props & WithStylesProps> {
           checked && styles.button_checked,
           invalid && styles.button_invalid,
           disabled && styles.button_disabled,
+          small && styles.button_small,
         )}
       >
         {this.renderRadioButton()}
@@ -175,6 +178,7 @@ export default withStyles(theme => {
 
     children: {
       marginLeft: theme.unit,
+      width: '100%',
     },
   };
 })(BaseRadioButton);

--- a/packages/core/src/themes/buildInputStyles.ts
+++ b/packages/core/src/themes/buildInputStyles.ts
@@ -194,5 +194,9 @@ export default function buildInputStyles({
     button_neutral: {
       ...commonNeutral,
     },
+
+    button_small: {
+      padding: unit * 2,
+    },
   };
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

2 changes:
- support `small` sizing for RadioButton
- make RadioButton children width: 100%.

## Motivation and Context

I have a use case for smaller radio buttons than the current large radio buttons. I was surprised that this was not already supported, as I believe it is already supported for other form fields.

I also extended RadioButton children to ensure it's 100%, as the designs I currently have call for the label to be left-aligned and then something else to be right-aligned (an indicator of a keyboard shortcut that can be used to select the value instead)

## Testing

See screenshots from Storybook below.

## Screenshots

new story in storybook:

![image](https://user-images.githubusercontent.com/673941/63915279-73922a80-c9ea-11e9-91fb-9ede1ac473ce.png)

using a Row with something in the after also shows that the change for width:100% works as intended.

large story, unchanged, for reference:

![image](https://user-images.githubusercontent.com/673941/63915306-80af1980-c9ea-11e9-96f4-665d8880ba4d.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
