### PR TITLE
update(DataTable): add columnHeaderBold prop

### DIFF
--- a/packages/core/src/components/DataTable.story.tsx
+++ b/packages/core/src/components/DataTable.story.tsx
@@ -174,6 +174,13 @@ storiesOf('Core/DataTable', module)
       <DataTable data={getData()} keys={['name', 'jobTitle', 'tenureDays']} />
     </div>
   ))
+  .add('A standard table with bold column headers.', () => (
+    <DataTable
+      columnHeaderBold
+      data={getData()}
+      keys={['name', 'jobTitle']}
+    />
+  ))
   .add('A standard table with initial sorting.', () => (
     <DataTable
       data={getData()}
@@ -269,6 +276,7 @@ storiesOf('Core/DataTable', module)
     <DataTable
       selectable
       expandable
+      columnHeaderBold
       showColumnDividers
       showRowDividers
       zebra

--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -29,6 +29,7 @@ type ColumnLabelsProps = {
     we clone them from props (children[0] = label, children[1] = carets), build around their data. */
 export default function ColumnLabels({
   cx,
+  columnHeaderBold,
   styles,
   columnToLabel = {},
   showColumnDividers,
@@ -43,6 +44,7 @@ export default function ColumnLabels({
   styles: WithStylesProps['styles'];
   columnToLabel?: ColumnToLabel;
   showColumnDividers?: boolean;
+  columnHeaderBold?: boolean;
   rowHeight?: RowHeightOptions;
   columnHeaderHeight?: HeightOptions;
   expandable?: boolean;
@@ -59,6 +61,10 @@ export default function ColumnLabels({
 
     const rightAlignmentStyle: React.CSSProperties = {
       justifyContent: 'flex-end',
+    };
+
+    const borderBottomStyle: React.CSSProperties = {
+      borderBottom: '1px solid gray',
     };
 
     const newColumns = columns.map((col: React.ReactElement, idx: number) => {
@@ -90,7 +96,7 @@ export default function ColumnLabels({
               className={cx(styles && styles.row)}
             >
               <span>
-                <Text micro muted>
+                <Text micro={!columnHeaderBold} muted={!columnHeaderBold} bold={columnHeaderBold}>
                   {label}
                 </Text>
               </span>
@@ -117,7 +123,12 @@ export default function ColumnLabels({
       <div
         role="row"
         style={style}
-        className={cx(className, styles && styles.column_header, styles && styles.row)}
+        className={cx(
+          className,
+          styles && styles.column_header,
+          styles && styles.row,
+          styles && columnHeaderBold && styles.column_header_bold,
+        )}
       >
         {newColumns}
       </div>

--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -63,10 +63,6 @@ export default function ColumnLabels({
       justifyContent: 'flex-end',
     };
 
-    const borderBottomStyle: React.CSSProperties = {
-      borderBottom: '1px solid gray',
-    };
-
     const newColumns = columns.map((col: React.ReactElement, idx: number) => {
       const { children } = col.props;
       const key = children[0].props.children;

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -33,6 +33,7 @@ export type Props = {
 
 /** Header for the DataTable that displays a title and Table-level buttons. */
 export function TableHeader({
+  bold,
   cx,
   editable,
   editMode,

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -33,7 +33,6 @@ export type Props = {
 
 /** Header for the DataTable that displays a title and Table-level buttons. */
 export function TableHeader({
-  bold,
   cx,
   editable,
   editMode,

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -41,6 +41,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   static defaultProps: Pick<DataTableProps, DefaultDataTableProps> = {
     autoHeight: false,
     columnHeaderHeight: undefined,
+    columnHeaderBold: false,
     columnLabelCase: '',
     columnMetadata: {},
     columnToLabel: {},
@@ -446,6 +447,9 @@ export default withStyles(
     column_header: {
       borderBottom: ui.border,
       cursor: 'pointer',
+    },
+    column_header_bold: {
+      borderBottomWidth: ui.borderWidthThick,
     },
     column: {
       height: 'inherit',

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -41,7 +41,7 @@ export type DefaultDataTableProps = keyof DataTableProps;
 export interface DataTableProps {
   /** If enabled height will be inferred from parent. */
   autoHeight?: boolean;
-  /** Apply bold style to column headers. */
+  /** Apply bold style and thicker border to column headers. */
   columnHeaderBold?: boolean;
   /** Height of the column header. */
   columnHeaderHeight?: HeightOptions;

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -41,6 +41,8 @@ export type DefaultDataTableProps = keyof DataTableProps;
 export interface DataTableProps {
   /** If enabled height will be inferred from parent. */
   autoHeight?: boolean;
+  /** Apply bold style to column headers. */
+  columnHeaderBold?: boolean;
   /** Height of the column header. */
   columnHeaderHeight?: HeightOptions;
   /** Change all column label keys to UPPERCASE or Title Case or Sentence case */


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @piewell @schillerk 

## Description

Adds a `columnHeaderBold` prop to make headers bolder and more bordery.

## Motivation and Context

requested by @adamirl 

## Testing

none yet, please advise

## Screenshots

<img width="844" alt="Screen Shot 2019-09-06 at 3 12 22 PM" src="https://user-images.githubusercontent.com/205004/64463516-2af90200-d0b9-11e9-9650-8cec4ab1506f.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
