### PR TITLE
fix(Dropdown): Remove prop type restrictions.

### DIFF
--- a/packages/core/src/components/Dropdown/index.tsx
+++ b/packages/core/src/components/Dropdown/index.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { mutuallyExclusiveProps } from 'airbnb-prop-types';
+import { Block } from 'aesthetic';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
-
-const PositionShape = PropTypes.oneOfType([
-  PropTypes.number.isRequired,
-  PropTypes.string.isRequired,
-]);
-
-const leftRightProp = mutuallyExclusiveProps(PositionShape, 'left', 'right');
-const topBottomProp = mutuallyExclusiveProps(PositionShape, 'top', 'bottom');
 
 export type Props = {
   /** Bottom offset. */
@@ -42,13 +33,6 @@ export type Props = {
 
 /** An abstract component for displaing menus and overlays over content. */
 class Dropdown extends React.PureComponent<Props & WithStylesProps> {
-  static propTypes = {
-    bottom: topBottomProp,
-    left: leftRightProp,
-    right: leftRightProp,
-    top: topBottomProp,
-  };
-
   static defaultProps = {
     fixed: false,
     visible: false,
@@ -105,7 +89,7 @@ class Dropdown extends React.PureComponent<Props & WithStylesProps> {
       onClickOutside,
       ...props
     } = this.props;
-    const style: React.CSSProperties = {
+    const style: Block = {
       position: fixed ? 'fixed' : 'absolute',
       zIndex: zIndex || 'auto',
       ...props,
@@ -124,7 +108,7 @@ class Dropdown extends React.PureComponent<Props & WithStylesProps> {
     return (
       <div
         ref={this.ref}
-        className={cx(style as any)}
+        className={cx(style)}
         tabIndex={tabIndex}
         onBlur={onBlur}
         onFocus={onFocus}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Removes the prop type restrictions. Not sure why these were here since its valid to define them in parallel.

## Motivation and Context

I have a use case where I need to define left and right at the same time, yet it currently errors.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
