### PR TITLE
style(EmojiPicker): Tighten up header spacing

### DIFF
--- a/packages/core/src/components/EmojiPicker/index.tsx
+++ b/packages/core/src/components/EmojiPicker/index.tsx
@@ -232,9 +232,8 @@ export default withStyles(({ ui, unit, color, font, pattern }) => ({
     textTransform: 'uppercase',
     color: color.accent.text,
     background: color.accent.bg,
-    borderTopLeftRadius: ui.borderRadius,
-    borderTopRightRadius: ui.borderRadius,
-    padding: `${unit * 0.75}px 0`,
+    padding: `${unit}px 0`,
+    lineHeight: 1,
   },
 
   emojisHeader_sticky: {
@@ -250,6 +249,7 @@ export default withStyles(({ ui, unit, color, font, pattern }) => ({
     flexWrap: 'nowrap',
     margin: 0,
     padding: 0,
+    lineHeight: 1,
     listStyle: 'none',
     justifyContent: 'space-between',
   },
@@ -295,11 +295,12 @@ export default withStyles(({ ui, unit, color, font, pattern }) => ({
     borderRadius: '50%',
     width: 12,
     height: 12,
-    lineHeight: 0,
     padding: 0,
+    margin: 0,
     marginLeft: unit / 2,
     overflow: 'hidden',
     cursor: 'pointer',
+    display: 'block',
     opacity: 0.75,
 
     ':hover': {
@@ -312,7 +313,7 @@ export default withStyles(({ ui, unit, color, font, pattern }) => ({
   },
 
   skinTone_active: {
-    background: 'white !important',
+    backgroundColor: 'white !important',
     opacity: 1,
   },
 

--- a/packages/core/src/components/EmojiPicker/index.tsx
+++ b/packages/core/src/components/EmojiPicker/index.tsx
@@ -313,7 +313,7 @@ export default withStyles(({ ui, unit, color, font, pattern }) => ({
   },
 
   skinTone_active: {
-    backgroundColor: 'white !important',
+    backgroundColor: color.accent.bg,
     opacity: 1,
   },
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Noticed the skin tone selection was off.

## Motivation and Context

It was ugly.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

Before: (shadow coming from another app, not lunar)
<img width="306" alt="Screen Shot 2019-09-11 at 1 28 37 PM" src="https://user-images.githubusercontent.com/143744/64732700-2311d700-d498-11e9-9e54-0c60bbbf211a.png">

After:
<img width="334" alt="Screen Shot 2019-09-11 at 1 26 25 PM" src="https://user-images.githubusercontent.com/143744/64732709-273df480-d498-11e9-9a38-5f30621c2b44.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
