### PR TITLE
style(ImageViewer): Move flexbox from outer to inner div

### DIFF
--- a/packages/core/src/components/ImageViewer/index.tsx
+++ b/packages/core/src/components/ImageViewer/index.tsx
@@ -146,10 +146,6 @@ export default withStyles(({ ui }) => ({
   container: {
     border: ui.border,
     cursor: 'move',
-    display: 'flex',
-    align: 'center',
-    alignItems: 'center',
-    justifyContent: 'center',
     overflow: 'hidden',
   },
 
@@ -158,6 +154,11 @@ export default withStyles(({ ui }) => ({
   },
 
   image: {
-    display: 'inline-block',
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    align: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 }))(ImageViewer);

--- a/packages/core/src/components/ImageViewer/index.tsx
+++ b/packages/core/src/components/ImageViewer/index.tsx
@@ -157,7 +157,6 @@ export default withStyles(({ ui }) => ({
     width: '100%',
     height: '100%',
     display: 'flex',
-    align: 'center',
     alignItems: 'center',
     justifyContent: 'center',
   },


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Moved the use of flexbox for ImageViewer from outer div to inner div, and set width and height to 100%. There are no visual or functional changes.

## Motivation and Context

This fix is needed for the ImageViewer to be used in the Lightbox.

## Testing

- [x] storybook

## Screenshots

No visual changes

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
