### PR TITLE
fix(DataTable): Add spacing to prevent clipping checkbox focus.

### DIFF
--- a/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Column } from 'react-virtualized';
-import T from '@airbnb/lunar/lib/components/Translate';
+import T from '../../Translate';
 import CheckBox from '../../CheckBox';
 import Spacing from '../../Spacing';
 import { ExpandedRow, SelectedRows, VirtualRow } from '../types';

--- a/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
@@ -40,7 +40,7 @@ export default function renderSelectableColumn(
     const spacing = isChild || !expandable ? indentSize : 0;
 
     return (
-      <Spacing left={spacing}>
+      <Spacing all={0.5} left={spacing}>
         <CheckBox
           label=""
           name=""

--- a/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Column } from 'react-virtualized';
+import T from '@airbnb/lunar/lib/components/Translate';
 import CheckBox from '../../CheckBox';
 import Spacing from '../../Spacing';
 import { ExpandedRow, SelectedRows, VirtualRow } from '../types';
@@ -43,7 +44,14 @@ export default function renderSelectableColumn(
       <Spacing all={0.5} left={spacing}>
         <CheckBox
           hideLabel
-          label="Select row"
+          label={T.phrase(
+            'Select row',
+            {},
+            {
+              context: 'Selecting a row from the data table',
+              key: 'lunar.datatable.selectRow',
+            },
+          )}
           indeterminate={isNeutral}
           checked={isSelected}
           onChange={handleSelection(row.rowData)}

--- a/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
@@ -42,8 +42,8 @@ export default function renderSelectableColumn(
     return (
       <Spacing all={0.5} left={spacing}>
         <CheckBox
-          label=""
-          name=""
+          hideLabel
+          label="Select row"
           indeterminate={isNeutral}
           checked={isSelected}
           onChange={handleSelection(row.rowData)}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Before:
<img width="55" alt="Screen Shot 2019-09-17 at 4 30 14 PM" src="https://user-images.githubusercontent.com/8676510/65087206-91a7d680-d969-11e9-81cf-4549c287ec84.png">

After:
<img width="50" alt="Screen Shot 2019-09-17 at 4 37 00 PM" src="https://user-images.githubusercontent.com/8676510/65087217-98cee480-d969-11e9-9366-3979bcc5ecb9.png">


<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
