### PR TITLE
update(Apollo): Add resolvers to Apollo settings

### DIFF
--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -1,5 +1,5 @@
 import Core from '@airbnb/lunar';
-import { ApolloClient } from 'apollo-client';
+import { ApolloClient, Resolvers } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloLink } from 'apollo-link';
 import { onError } from 'apollo-link-error';
@@ -16,11 +16,13 @@ export { onError, HttpLink, Mutation, Query, Provider };
 
 export type Settings = {
   links?: ApolloLink[];
+  resolvers?: Resolvers;
 };
 
 class Apollo {
   settings: Required<Settings> = {
     links: [],
+    resolvers: {},
   };
 
   protected client?: ApolloClient<any>;

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -41,13 +41,14 @@ class Apollo {
       return;
     }
 
-    const { links } = this.settings;
+    const { links, resolvers } = this.settings;
 
     this.client = new ApolloClient({
       cache: new InMemoryCache(),
       connectToDevTools: __DEV__,
       link: ApolloLink.from(links),
       name: Core.settings.name,
+      resolvers,
       version: pkg.version,
     });
 

--- a/packages/apollo/test/index.test.ts
+++ b/packages/apollo/test/index.test.ts
@@ -18,14 +18,21 @@ describe('Apollo', () => {
   describe('initialize()', () => {
     it('sets settings', () => {
       const link = new HttpLink();
+      const resolvers = {
+        Mutation: {
+          testMutation: () => {},
+        },
+      };
 
       Apollo.initialize({
         links: [link],
+        resolvers,
       });
 
       expect(Apollo.settings).toEqual(
         expect.objectContaining({
           links: [link],
+          resolvers,
         }),
       );
     });


### PR DESCRIPTION
~**WIP:** Not sure what's wrong with my test - creating PR to see if it's a local issue~ 
All checks passed ✅ 

to: @milesj @stefhatcher @hayes @alecklandgraf 

## Description

Adds a resolvers option to Apollo settings.

## Motivation and Context

If an engineer wants to use Lunar's Apollo package and [Apollo's local state](https://www.apollographql.com/docs/react/essentials/local-state/#local-resolvers), they currently cannot set `resolvers` when Apollo initializes. This fixes that.

## Testing

- unit tests

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
