### PR TITLE
update(MenuToggle): Add `disabled` support.

### DIFF
--- a/packages/core/src/components/MenuToggle.story.tsx
+++ b/packages/core/src/components/MenuToggle.story.tsx
@@ -76,4 +76,9 @@ storiesOf('Core/MenuToggle', module)
     <MenuToggle small accessibilityLabel="Actions" toggleLabel="Actions" zIndex={10}>
       {children}
     </MenuToggle>
+  ))
+  .add('As disabled.', () => (
+    <MenuToggle disabled accessibilityLabel="Actions" toggleLabel="Actions" zIndex={10}>
+      {children}
+    </MenuToggle>
   ));

--- a/packages/core/src/components/MenuToggle.story.tsx
+++ b/packages/core/src/components/MenuToggle.story.tsx
@@ -77,7 +77,7 @@ storiesOf('Core/MenuToggle', module)
       {children}
     </MenuToggle>
   ))
-  .add('As disabled.', () => (
+  .add('With disabled.', () => (
     <MenuToggle disabled accessibilityLabel="Actions" toggleLabel="Actions" zIndex={10}>
       {children}
     </MenuToggle>

--- a/packages/core/src/components/MenuToggle/index.tsx
+++ b/packages/core/src/components/MenuToggle/index.tsx
@@ -53,8 +53,8 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
   };
 
   static defaultProps = {
-    disabled: false,
     closeOnClick: false,
+    disabled: false,
     ignoreClickOutside: false,
     inverted: false,
     large: false,

--- a/packages/core/src/components/MenuToggle/index.tsx
+++ b/packages/core/src/components/MenuToggle/index.tsx
@@ -15,6 +15,8 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** If true, will close the menu on click of an item. */
   closeOnClick?: boolean;
+  /** Mark the menu as disabled. */
+  disabled?: boolean;
   /** Props to pass to the `Dropdown` component. */
   dropdownProps?: Partial<DropdownProps>;
   /** If true, will not close the menu when an outside element is clicked. */
@@ -51,6 +53,7 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
   };
 
   static defaultProps = {
+    disabled: false,
     closeOnClick: false,
     ignoreClickOutside: false,
     inverted: false,
@@ -123,6 +126,7 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
       accessibilityLabel,
       children,
       closeOnClick,
+      disabled,
       dropdownProps = { right: 0 },
       inverted,
       large,
@@ -144,11 +148,16 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
     return (
       <div className={cx(styles.container)} ref={this.ref}>
         {toggleIcon ? (
-          <IconButton aria-label={accessibilityLabel} onClick={this.handleToggleMenu}>
+          <IconButton
+            disabled={disabled}
+            aria-label={accessibilityLabel}
+            onClick={this.handleToggleMenu}
+          >
             {toggleIcon}
           </IconButton>
         ) : (
           <Button
+            disabled={disabled}
             afterIcon={<ExpandableIcon expanded={opened} size={iconSize} />}
             inverted={inverted}
             large={large}

--- a/packages/core/test/components/MenuToggle.test.tsx
+++ b/packages/core/test/components/MenuToggle.test.tsx
@@ -188,4 +188,14 @@ describe('<MenuToggle />', () => {
 
     expect(onHide).toHaveBeenCalled();
   });
+
+  it('renders disabled button', () => {
+    const wrapper = shallowWithStyles(
+      <MenuToggle disabled accessibilityLabel="Foo" toggleLabel="Foo">
+        <Item>Child</Item>
+      </MenuToggle>,
+    );
+
+    expect(wrapper.find(Button).prop('disabled')).toBe(true);
+  });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add a `disabled` property to `MenuToggle` which disables the entire menu dropdown.

## Motivation and Context

Currently it is only possible to disable each `MenuItem` individually - but if you want to disable the `MenuToggle` dropdown itself, you cannot.

## Testing

Added new test and tested in storybook.

## Screenshots

Disabled (from storybook):
![image](https://user-images.githubusercontent.com/839082/65187679-48b35900-da21-11e9-92de-5af4812524ea.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
