### PR TITLE
update(AccordionItem): Add `noSpacing` support.

### DIFF
--- a/packages/core/src/components/Accordion.story.tsx
+++ b/packages/core/src/components/Accordion.story.tsx
@@ -54,4 +54,19 @@ storiesOf('Core/Accordion', module)
         </Text>
       </Item>
     </Accordion>
+  ))
+  .add('With no spacing.', () => (
+    <Accordion bordered>
+      <Item noSpacing title="Item 1" id="one">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+
+      <Item noSpacing title="Item 2" id="two">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+    </Accordion>
   ));

--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -13,7 +13,7 @@ export type Props = {
   id: string;
   /** Index amongst a collection of accordion items. */
   index?: number;
-  /** Removes horizontal padding from item title and both horizontal and vertical padding from item body. */
+  /** Removes horizontal the item and top padding from item body. */
   noSpacing?: boolean;
   /** Title of the accordion item. */
   title?: React.ReactNode;
@@ -84,7 +84,7 @@ export default withStyles(
     },
 
     body_noSpacing: {
-      padding: 0,
+      padding: `0 0 ${unit * 2}px`,
     },
 
     body_expanded: {

--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -13,6 +13,8 @@ export type Props = {
   id: string;
   /** Index amongst a collection of accordion items. */
   index?: number;
+  /** Removes horizontal padding from item title and both horizontal and vertical padding from item body. */
+  noSpacing?: boolean;
   /** Title of the accordion item. */
   title?: React.ReactNode;
   /** Callback fired when the accordion item is clicked. */
@@ -27,6 +29,7 @@ export class AccordionItem extends React.Component<Props & WithStylesProps> {
     bordered: false,
     children: null,
     expanded: false,
+    noSpacing: false,
   };
 
   private handleClick = () => {
@@ -36,12 +39,12 @@ export class AccordionItem extends React.Component<Props & WithStylesProps> {
   };
 
   render() {
-    const { cx, bordered, children, expanded, id, styles, theme, title } = this.props;
+    const { cx, bordered, children, expanded, id, noSpacing, styles, theme, title } = this.props;
 
     return (
       <div className={cx(styles.item, bordered && styles.item_bordered)}>
         <button
-          className={cx(styles.title)}
+          className={cx(styles.title, noSpacing && styles.title_noSpacing)}
           aria-controls={`accordion-body-${id}`}
           aria-selected={expanded}
           id={`accordion-title-${id}`}
@@ -56,7 +59,11 @@ export class AccordionItem extends React.Component<Props & WithStylesProps> {
         </button>
 
         <section
-          className={cx(styles.body, expanded && styles.body_expanded)}
+          className={cx(
+            styles.body,
+            expanded && styles.body_expanded,
+            noSpacing && styles.body_noSpacing,
+          )}
           aria-hidden={!expanded}
           aria-labelledby={`accordion-title-${id}`}
           id={`accordion-body-${id}`}
@@ -74,6 +81,10 @@ export default withStyles(
     body: {
       display: 'none',
       padding: `${unit}px ${unit * 2}px ${unit * 2}px`,
+    },
+
+    body_noSpacing: {
+      padding: 0,
     },
 
     body_expanded: {
@@ -95,6 +106,11 @@ export default withStyles(
       padding: unit * 2,
       textAlign: 'left',
       width: '100%',
+    },
+
+    title_noSpacing: {
+      paddingLeft: 0,
+      paddingRight: 0,
     },
 
     titleText: {

--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -13,7 +13,7 @@ export type Props = {
   id: string;
   /** Index amongst a collection of accordion items. */
   index?: number;
-  /** Removes horizontal the item and top padding from item body. */
+  /** Removes horizontal padding from the item and top padding from item body. */
   noSpacing?: boolean;
   /** Title of the accordion item. */
   title?: React.ReactNode;

--- a/packages/core/test/components/Accordion/Item.test.tsx
+++ b/packages/core/test/components/Accordion/Item.test.tsx
@@ -67,6 +67,15 @@ describe('<AccordionItem />', () => {
     expect(wrapper.find('section').prop('className')).toMatch('body_expanded');
   });
 
+  it('renders without spacing', () => {
+    const wrapper = shallowWithStyles(
+      <AccordionItem noSpacing id=".0" index={0} title="Title" onClick={() => {}} />,
+    );
+
+    expect(wrapper.find('button').prop('className')).toMatch('title_noSpacing');
+    expect(wrapper.find('section').prop('className')).toMatch('body_noSpacing');
+  });
+
   it('triggers `onClick` when clicked', () => {
     const spy = jest.fn();
     const wrapper = shallowWithStyles(


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add a `noSpacing` property to `AccordionItem` component. This disables the horizontal padding of the accordion item title and the vertical and horizontal padding of the accordion item body.

## Motivation and Context

Introducing this property allows for consumers to customize how padding works in the accordion without using negative margins. However, even if using negative margins, the consumer has no control over the accordion item title's padding, so this is required to achieve certain designs.

## Testing

Add new test and manually tested in storybook.

## Screenshots

From storybook:
![image](https://user-images.githubusercontent.com/839082/65192452-fb88b480-da2b-11e9-8a93-aa07cbb5a99b.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
