### PR TITLE
fix(Tabs): Persist active tab when back button is used.

### DIFF
--- a/packages/core/src/components/Tabs.story.tsx
+++ b/packages/core/src/components/Tabs.story.tsx
@@ -59,7 +59,7 @@ storiesOf('Core/Tabs', module)
       </Tab>
     </Tabs>
   ))
-  .add('state persisted to hash and following back button.', () => (
+  .add('Persist with hash and back button.', () => (
     <Tabs persistWithHash="tab">
       <Tab key="a" label="Bruce W.">
         <Text>

--- a/packages/core/src/components/Tabs.story.tsx
+++ b/packages/core/src/components/Tabs.story.tsx
@@ -59,6 +59,21 @@ storiesOf('Core/Tabs', module)
       </Tab>
     </Tabs>
   ))
+  .add('state persisted to hash and following back button.', () => (
+    <Tabs persistWithHash="tab">
+      <Tab key="a" label="Bruce W.">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Tab>
+
+      <Tab key="b" label="Clark K.">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Tab>
+    </Tabs>
+  ))
   .add('With scrollable variable height tabs.', () => (
     <div style={{ width: '325px' }}>
       <Tabs scrollable>

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -57,7 +57,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
         });
       }
     }
-  }
+  };
 
   componentDidMount() {
     if (this.props.persistWithHash) {

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -46,11 +46,36 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     selectedKey: this.getDefaultSelectedKey(),
   };
 
+  boundPopstateHandler = this.handlePopstate.bind(this);
+
+  componentDidMount() {
+    if (this.props.persistWithHash) {
+      window.addEventListener('popstate', this.boundPopstateHandler);
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('popstate', this.boundPopstateHandler);
+  }
+
   componentDidUpdate(prevProps: Props) {
     if (this.props.defaultKey !== prevProps.defaultKey) {
       this.setState({
         selectedKey: this.props.defaultKey!,
       });
+    }
+  }
+
+  handlePopstate() {
+    const { persistWithHash } = this.props;
+
+    if (persistWithHash) {
+      const query = this.getHashQuery();
+      if (query.has(persistWithHash)) {
+        this.setState({
+          selectedKey: query.get(persistWithHash)!,
+        });
+      }
     }
   }
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -46,27 +46,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     selectedKey: this.getDefaultSelectedKey(),
   };
 
-  boundPopstateHandler = this.handlePopstate.bind(this);
-
-  componentDidMount() {
-    if (this.props.persistWithHash) {
-      document.addEventListener('popstate', this.boundPopstateHandler);
-    }
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('popstate', this.boundPopstateHandler);
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.defaultKey !== prevProps.defaultKey) {
-      this.setState({
-        selectedKey: this.props.defaultKey!,
-      });
-    }
-  }
-
-  handlePopstate() {
+  handlePopstate = () => {
     const { persistWithHash } = this.props;
 
     if (persistWithHash) {
@@ -76,6 +56,24 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
           selectedKey: query.get(persistWithHash)!,
         });
       }
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.persistWithHash) {
+      document.addEventListener('popstate', this.handlePopstate);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('popstate', this.handlePopstate);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.defaultKey !== prevProps.defaultKey) {
+      this.setState({
+        selectedKey: this.props.defaultKey!,
+      });
     }
   }
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -50,12 +50,12 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
 
   componentDidMount() {
     if (this.props.persistWithHash) {
-      window.addEventListener('popstate', this.boundPopstateHandler);
+      document.addEventListener('popstate', this.boundPopstateHandler);
     }
   }
 
   componentWillUnmount() {
-    window.removeEventListener('popstate', this.boundPopstateHandler);
+    document.removeEventListener('popstate', this.boundPopstateHandler);
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -251,21 +251,48 @@ describe('<Tabs/>', () => {
     ).toBe(true);
   });
 
-  it('adds popstate listener when persistWithHash', () => {
-    const addSpy = jest.spyOn(document, 'addEventListener');
-    const rmSpy = jest.spyOn(document, 'removeEventListener');
+  describe('when persistWithHash', () => {
+    it('adds popstate listener', () => {
+      const addSpy = jest.spyOn(document, 'addEventListener');
+      const rmSpy = jest.spyOn(document, 'removeEventListener');
+  
+      const wrapper = unwrap(
+        <Tabs persistWithHash="tab">
+          <Tab key="a" label="One" />
+        </Tabs>,
+      );
+  
+      expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+    
+      // @ts-ignore
+      wrapper.instance().componentWillUnmount();
+  
+      expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+    });
 
-    const wrapper = unwrap(
-      <Tabs persistWithHash="tab">
-        <Tab key="a" label="One" />
-      </Tabs>,
-    );
+    it('triggers popstate listener', () => {
+      const wrapper = unwrap(
+        <Tabs persistWithHash="tab">
+          <Tab key="a" label="One" />
+          <Tab key="b" label="Two" />
+        </Tabs>,
+      );
 
-    expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+      wrapper
+        .find(Tab)
+        .at(0)
+        .simulate('click', 'a');
+      expect(wrapper.state('selectedKey')).toBe('a');
 
-    // @ts-ignore
-    wrapper.instance().componentWillUnmount();
+      wrapper
+        .find(Tab)
+        .at(1)
+        .simulate('click', 'b');
+      expect(wrapper.state('selectedKey')).toBe('b');
 
-    expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+      location.hash = '#tab=a';
+      document.dispatchEvent(new Event('popstate'));
+      expect(wrapper.state('selectedKey')).toBe('a');
+    });
   });
 });

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -252,8 +252,8 @@ describe('<Tabs/>', () => {
   });
 
   it('adds popstate listener when persistWithHash', () => {
-    const addSpy = jest.spyOn(window, 'addEventListener');
-    const rmSpy = jest.spyOn(window, 'removeEventListener');
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const rmSpy = jest.spyOn(document, 'removeEventListener');
 
     const wrapper = unwrap(
       <Tabs persistWithHash="tab">

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -280,15 +280,10 @@ describe('<Tabs/>', () => {
 
       wrapper
         .find(Tab)
-        .at(0)
-        .simulate('click', 'a');
-      expect(wrapper.state('selectedKey')).toBe('a');
-
-      wrapper
-        .find(Tab)
         .at(1)
         .simulate('click', 'b');
       expect(wrapper.state('selectedKey')).toBe('b');
+      expect(location.hash).toBe('#tab=b');
 
       location.hash = '#tab=a';
       document.dispatchEvent(new Event('popstate'));

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -250,4 +250,22 @@ describe('<Tabs/>', () => {
         .prop('borderless'),
     ).toBe(true);
   });
+
+  it('adds popstate listener when persistWithHash', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const rmSpy = jest.spyOn(document, 'addEventListener');
+
+    const wrapper = unwrap(
+      <Tabs persistWithHash="tab">
+        <Tab key="a" label="One" />
+      </Tabs>,
+    );
+
+    expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function), true);
+
+    // @ts-ignore
+    wrapper.instance().componentWillUnmount();
+
+    expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function), true);
+  });
 });

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -252,8 +252,8 @@ describe('<Tabs/>', () => {
   });
 
   it('adds popstate listener when persistWithHash', () => {
-    const addSpy = jest.spyOn(document, 'addEventListener');
-    const rmSpy = jest.spyOn(document, 'addEventListener');
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const rmSpy = jest.spyOn(window, 'removeEventListener');
 
     const wrapper = unwrap(
       <Tabs persistWithHash="tab">
@@ -261,11 +261,11 @@ describe('<Tabs/>', () => {
       </Tabs>,
     );
 
-    expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function), true);
+    expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
 
     // @ts-ignore
     wrapper.instance().componentWillUnmount();
 
-    expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function), true);
+    expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
   });
 });

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -251,43 +251,33 @@ describe('<Tabs/>', () => {
     ).toBe(true);
   });
 
-  describe('when persistWithHash', () => {
-    it('adds popstate listener', () => {
-      const addSpy = jest.spyOn(document, 'addEventListener');
-      const rmSpy = jest.spyOn(document, 'removeEventListener');
-  
-      const wrapper = unwrap(
-        <Tabs persistWithHash="tab">
-          <Tab key="a" label="One" />
-        </Tabs>,
-      );
-  
-      expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
-    
-      // @ts-ignore
-      wrapper.instance().componentWillUnmount();
-  
-      expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
-    });
+  it('Persist with hash and back button.', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const rmSpy = jest.spyOn(document, 'removeEventListener');
 
-    it('triggers popstate listener', () => {
-      const wrapper = unwrap(
-        <Tabs persistWithHash="tab">
-          <Tab key="a" label="One" />
-          <Tab key="b" label="Two" />
-        </Tabs>,
-      );
+    const wrapper = unwrap(
+      <Tabs persistWithHash="tab">
+        <Tab key="a" label="One" />
+        <Tab key="b" label="Two" />
+      </Tabs>,
+    );
 
-      wrapper
-        .find(Tab)
-        .at(1)
-        .simulate('click', 'b');
-      expect(wrapper.state('selectedKey')).toBe('b');
-      expect(location.hash).toBe('#tab=b');
+    expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
 
-      location.hash = '#tab=a';
-      document.dispatchEvent(new Event('popstate'));
-      expect(wrapper.state('selectedKey')).toBe('a');
-    });
+    wrapper
+      .find(Tab)
+      .at(1)
+      .simulate('click', 'b');
+    expect(wrapper.state('selectedKey')).toBe('b');
+    expect(location.hash).toBe('#tab=b');
+
+    location.hash = '#tab=a';
+    document.dispatchEvent(new Event('popstate'));
+    expect(wrapper.state('selectedKey')).toBe('a');
+
+    // @ts-ignore
+    wrapper.instance().componentWillUnmount();
+
+    expect(rmSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

if `persistWithHash`, listen for `popstate`

## Motivation and Context

When navigating thru tabs, users want the browser Back button to be functional

## Testing

Please advise

## Screenshots

no visual changes

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
