### PR TITLE
fix(Tabs): Listen for `popstate` on window instead of document.

### DIFF
--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -61,12 +61,12 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
 
   componentDidMount() {
     if (this.props.persistWithHash) {
-      document.addEventListener('popstate', this.handlePopstate);
+      window.addEventListener('popstate', this.handlePopstate);
     }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('popstate', this.handlePopstate);
+    window.removeEventListener('popstate', this.handlePopstate);
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -252,8 +252,8 @@ describe('<Tabs/>', () => {
   });
 
   it('Persist with hash and back button.', () => {
-    const addSpy = jest.spyOn(document, 'addEventListener');
-    const rmSpy = jest.spyOn(document, 'removeEventListener');
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const rmSpy = jest.spyOn(window, 'removeEventListener');
 
     const wrapper = unwrap(
       <Tabs persistWithHash="tab">
@@ -272,7 +272,7 @@ describe('<Tabs/>', () => {
     expect(location.hash).toBe('#tab=b');
 
     location.hash = '#tab=a';
-    document.dispatchEvent(new Event('popstate'));
+    window.dispatchEvent(new Event('popstate'));
     expect(wrapper.state('selectedKey')).toBe('a');
 
     // @ts-ignore


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

`popstate` is not fired on document

## Motivation and Context

Followup to https://github.com/airbnb/lunar/pull/190

## Testing

yes.

## Screenshots

no visual changes

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
