### PR TITLE
ci: Bring back Happo for PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ matrix:
 jobs:
   include:
     - stage: Tests
-      name: Test @ 8
+      name: Happo
+      script: yarn run happo:ci:travis
+      node_js: '12'
+      if: type = pull_request
+    - name: Test @ 8
       script: yarn run jest:coverage -w 4
       node_js: '8'
     - name: Test @ 10


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Brings back Happo for PRs only, not master.

## Motivation and Context

In my previous PR, I removed Happo and Storybook as it was covered by GH actions. However, actions aren't available for forks yet, so happo never runs on those PRs.

https://github.com/airbnb/lunar/pull/171

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
