### PR TITLE
update(List): Add `gutter` prop for space between list items.

### DIFF
--- a/packages/core/src/components/List.story.tsx
+++ b/packages/core/src/components/List.story.tsx
@@ -29,6 +29,27 @@ storiesOf('Core/List', module)
       </Item>
     </List>
   ))
+  .add('List with `gutter`.', () => (
+    <List gutter>
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+    </List>
+  ))
   .add('List with `horizontal`.', () => (
     <List horizontal>
       <Item>
@@ -50,7 +71,27 @@ storiesOf('Core/List', module)
       </Item>
     </List>
   ))
+  .add('List  with `horizontal` and `gutter`.', () => (
+    <List gutter horizontal>
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
 
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+    </List>
+  ))
   .add('List with `horizontal` and `wrap`.', () => (
     <List horizontal wrap>
       <Item>

--- a/packages/core/src/components/List/index.tsx
+++ b/packages/core/src/components/List/index.tsx
@@ -7,6 +7,8 @@ export { Item };
 export type Props = {
   /** List items. */
   children: NonNullable<React.ReactNode>;
+  /** Apply gutters between `li`s. */
+  gutter?: boolean;
   /** Horizontal list. */
   horizontal?: boolean;
   /** Renders an `<ol></ol>`. */
@@ -17,14 +19,16 @@ export type Props = {
 
 class List extends React.Component<Props & WithStylesProps> {
   render() {
-    const { children, cx, horizontal, ordered, styles, wrap } = this.props;
+    const { children, cx, gutter, horizontal, ordered, styles, wrap } = this.props;
     const Tag = ordered ? 'ol' : 'ul';
 
     return (
       <Tag
         className={cx(
           styles.list,
+          !horizontal && gutter && styles.list_gutter,
           horizontal && styles.list_horizontal,
+          horizontal && gutter && styles.list_gutter_horizontal,
           horizontal && wrap && styles.list_horizontal_wrap,
         )}
       >
@@ -44,11 +48,31 @@ class List extends React.Component<Props & WithStylesProps> {
   }
 }
 
-export default withStyles(() => ({
+export default withStyles(({ unit }) => ({
   list: {
     listStyle: 'none',
     margin: 0,
     padding: 0,
+  },
+
+  list_gutter: {
+    '@selectors': {
+      '> li + li': {
+        marginTop: unit / 2,
+      },
+    },
+  },
+
+  list_gutter_horizontal: {
+    '@selectors': {
+      '> li': {
+        marginRight: unit,
+      },
+
+      '> li:last-child': {
+        marginRight: 0,
+      },
+    },
   },
 
   list_horizontal: {

--- a/packages/core/src/components/List/index.tsx
+++ b/packages/core/src/components/List/index.tsx
@@ -57,8 +57,12 @@ export default withStyles(({ unit }) => ({
 
   list_gutter: {
     '@selectors': {
-      '> li + li': {
-        marginTop: unit / 2,
+      '> li': {
+        marginBottom: unit / 2,
+      },
+
+      '> li:last-child': {
+        marginBottom: 0,
       },
     },
   },
@@ -66,6 +70,7 @@ export default withStyles(({ unit }) => ({
   list_gutter_horizontal: {
     '@selectors': {
       '> li': {
+        marginBottom: 0,
         marginRight: unit,
       },
 

--- a/packages/core/test/components/List.test.tsx
+++ b/packages/core/test/components/List.test.tsx
@@ -61,19 +61,33 @@ describe('<List />', () => {
     expect(wrapper.type()).toEqual('ol');
   });
 
-  it('renders a horizontal list', () => {
-    const wrapperDefault = shallowWithStyles(
-      <List>
+  it('renders a list with gutters', () => {
+    const wrapper = shallowWithStyles(
+      <List gutter>
         <Item>Item 1</Item>
       </List>,
     );
 
-    const wrapperHorizontal = shallowWithStyles(
+    expect(wrapper.prop('className')).toContain('list_gutter');
+  });
+
+  it('renders a horizontal list with gutters', () => {
+    const wrapper = shallowWithStyles(
+      <List gutter horizontal>
+        <Item>Item 1</Item>
+      </List>,
+    );
+
+    expect(wrapper.prop('className')).toContain('list_gutter_horizontal');
+  });
+
+  it('renders a horizontal list', () => {
+    const wrapper = shallowWithStyles(
       <List horizontal>
         <Item>Item 1</Item>
       </List>,
     );
 
-    expect(wrapperDefault.prop('className') === wrapperHorizontal.prop('className')).toBe(false);
+    expect(wrapper.prop('className')).toContain('list_horizontal');
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This adds  a `gutter` prop to add margin spacing between child `<li>`s.

## Motivation and Context

After refactoring some code, having some margins between `li` would be nice, without using `List`'s `Item`. 

## Testing

story book
tests

## Screenshots

<img width="660" alt="Storybook 2019-09-25 11-39-11" src="https://user-images.githubusercontent.com/306275/65632461-9cc4bd00-df8e-11e9-9b33-bad5c05564e5.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
