### PR TITLE
update(Row, CardContent): Add `minHeight` support. Add `small` image option. Rework CardContent before/after images and increase default size.

### DIFF
--- a/packages/core/src/components/Card.story.tsx
+++ b/packages/core/src/components/Card.story.tsx
@@ -13,6 +13,7 @@ import Card, { Content } from './Card';
 storiesOf('Core/Card', module)
   .addParameters({
     inspectComponents: [Card, Content],
+    happo: { delay: 500 },
   })
   .add('A standard card.', () => (
     <Card>
@@ -67,6 +68,15 @@ storiesOf('Core/Card', module)
       </Content>
     </Card>
   ))
+  .add('With a min height.', () => (
+    <Card>
+      <Content middleAlign minHeight={300}>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  ))
   .add('A card with a top featured image.', () => (
     <Card>
       <Content topImageSrc={stars}>
@@ -85,6 +95,15 @@ storiesOf('Core/Card', module)
       </Content>
     </Card>
   ))
+  .add('A card with a small left featured image.', () => (
+    <Card>
+      <Content small beforeImageSrc={moon}>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  ))
   .add('A card with a left featured image.', () => (
     <Card>
       <Content beforeImageSrc={moon}>
@@ -97,6 +116,15 @@ storiesOf('Core/Card', module)
   .add('A card with a large left featured image.', () => (
     <Card>
       <Content large beforeImageSrc={moon}>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  ))
+  .add('A card with a small right featured image.', () => (
+    <Card>
+      <Content small afterImageSrc={moon}>
         <Text>
           <LoremIpsum />
         </Text>

--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -2,8 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { mutuallyExclusiveProps } from 'airbnb-prop-types';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
+import Image from '../Image';
 import Row from '../Row';
 import Spacing from '../Spacing';
+
+function getSideImageWidth({ large, small }: { large?: boolean; small?: boolean }): number {
+  if (small) {
+    return 80;
+  }
+
+  if (large) {
+    return 195;
+  }
+
+  return 152;
+}
 
 const imageUrlTypePropType = mutuallyExclusiveProps(
   PropTypes.string,
@@ -24,6 +37,8 @@ const beforePropType = mutuallyExclusiveProps(
   'beforeImageSrc',
 );
 
+const imageSizePropType = mutuallyExclusiveProps(PropTypes.bool, 'small', 'large');
+
 export type Props = {
   /** Content to display following the primary content. Takes priority over `afterImageSrc`. */
   after?: React.ReactNode;
@@ -43,6 +58,10 @@ export type Props = {
   maxHeight?: number | string;
   /** Align contents in the middle vertically. */
   middleAlign?: boolean;
+  /** Min height of content. */
+  minHeight?: number | string;
+  /** Whether the image content is small. */
+  small?: boolean;
   /** Top image URL. */
   topImageSrc?: string;
   /** To use with text truncation; overflow is hidden. */
@@ -58,22 +77,26 @@ export class CardContent extends React.Component<Props & WithStylesProps> {
     afterImageSrc: imageUrlTypePropType,
     before: beforePropType,
     beforeImageSrc: imageUrlTypePropType,
+    large: imageSizePropType,
+    small: imageSizePropType,
     topImageSrc: imageUrlTypePropType,
   };
 
   render() {
     const {
-      cx,
       after,
       afterImageSrc,
       before,
       beforeImageSrc,
       children,
       compact,
+      cx,
       large,
       maxHeight,
       middleAlign,
+      minHeight,
       onClick,
+      small,
       styles,
       topImageSrc,
       truncated,
@@ -99,9 +122,14 @@ export class CardContent extends React.Component<Props & WithStylesProps> {
 
     if (!afterContent && afterImageSrc) {
       afterContent = (
-        <div className={cx(styles.imageWrapper, large && styles.imageWrapper_large)}>
-          <img className={cx(styles.image)} alt="" height="100%" src={afterImageSrc} width="100%" />
-        </div>
+        <Image
+          background
+          cover
+          alt=""
+          width={getSideImageWidth({ large, small })}
+          height="100%"
+          src={afterImageSrc}
+        />
       );
     }
 
@@ -120,15 +148,14 @@ export class CardContent extends React.Component<Props & WithStylesProps> {
 
     if (!beforeContent && beforeImageSrc) {
       beforeContent = (
-        <div className={cx(styles.imageWrapper, large && styles.imageWrapper_large)}>
-          <img
-            className={cx(styles.image)}
-            alt=""
-            height="100%"
-            src={beforeImageSrc}
-            width="100%"
-          />
-        </div>
+        <Image
+          background
+          cover
+          alt=""
+          height="100%"
+          width={getSideImageWidth({ large, small })}
+          src={beforeImageSrc}
+        />
       );
     }
 
@@ -146,6 +173,7 @@ export class CardContent extends React.Component<Props & WithStylesProps> {
           before={beforeContent}
           maxHeight={maxHeight}
           middleAlign={middleAlign}
+          minHeight={minHeight}
           truncated={truncated}
         >
           <Spacing
@@ -218,16 +246,6 @@ export default withStyles(({ color, pattern, ui, unit }) => ({
   image: {
     display: 'block',
     objectFit: 'cover',
-  },
-
-  imageWrapper: {
-    height: '100%',
-    width: 80,
-    overflow: 'hidden',
-  },
-
-  imageWrapper_large: {
-    width: 195,
   },
 
   topImage: {

--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -126,8 +126,8 @@ export class CardContent extends React.Component<Props & WithStylesProps> {
           background
           cover
           alt=""
-          width={getSideImageWidth({ large, small })}
           height="100%"
+          width={getSideImageWidth({ large, small })}
           src={afterImageSrc}
         />
       );

--- a/packages/core/src/components/Image.story.tsx
+++ b/packages/core/src/components/Image.story.tsx
@@ -6,7 +6,7 @@ import lunar from ':storybook/images/lunar-logo.png';
 storiesOf('Core/Image', module)
   .addParameters({
     inspectComponents: [Image],
-    happo: { delay: 250 },
+    happo: { delay: 500 },
   })
   .add('default', () => <Image src={lunar} alt="Something descriptive" height={600} />)
   .add('background', () => (

--- a/packages/core/src/components/Image/index.tsx
+++ b/packages/core/src/components/Image/index.tsx
@@ -40,7 +40,7 @@ const styleSheet: StyleSheet = ({ color, ui }) => ({
   fadeIn: {
     animationName: {
       from: {
-        opacity: 0,
+        opacity: 0.1,
       },
 
       to: {

--- a/packages/core/src/components/Image/index.tsx
+++ b/packages/core/src/components/Image/index.tsx
@@ -5,17 +5,19 @@ import useStyles, { StyleSheet } from '../../hooks/useStyles';
 const backgroundAlignPropType = mutuallyExclusiveTrueProps('alignBottom', 'alignTop');
 const objectFitPropType = mutuallyExclusiveTrueProps('contain', 'cover');
 
-const styleSheet: StyleSheet = ({ ui }) => ({
+const styleSheet: StyleSheet = ({ color, ui }) => ({
   background: {
     backgroundPosition: '50% 50%',
     backgroundRepeat: 'no-repeat',
   },
 
   backgroundSize_cover: {
+    backgroundColor: color.accent.bgHover,
     backgroundSize: 'cover',
   },
 
   backgroundSize_contain: {
+    backgroundColor: color.accent.bg,
     backgroundSize: 'contain',
   },
 

--- a/packages/core/src/components/Row.story.tsx
+++ b/packages/core/src/components/Row.story.tsx
@@ -88,4 +88,14 @@ storiesOf('Core/Row', module)
         </Row>
       </div>
     </>
+  ))
+  .add('With a min height.', () => (
+    <Row topline baseline minHeight={200}>
+      <Text>A Row with a Min Height</Text>
+    </Row>
+  ))
+  .add('With a max height.', () => (
+    <Row topline baseline maxHeight={50}>
+      <Text>A Row with a Max Height</Text>
+    </Row>
   ));

--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -18,6 +18,8 @@ export type Props = {
   maxHeight?: number | string;
   /** Align contents in the middle vertically. */
   middleAlign?: boolean;
+  /** Min height of row. */
+  minHeight?: number | string;
   /** Render with vertical padding (24px). */
   spacious?: boolean;
   /** The visibility of the row's topline. */
@@ -42,15 +44,16 @@ export class Row extends React.Component<Props & WithStylesProps> {
 
   render() {
     const {
-      cx,
       after,
       baseline,
       before,
       children,
       compact,
+      cx,
       inline,
       maxHeight,
       middleAlign,
+      minHeight,
       spacious,
       styles,
       topline,
@@ -61,7 +64,7 @@ export class Row extends React.Component<Props & WithStylesProps> {
       <div
         className={cx(
           styles.row,
-          { maxHeight },
+          { maxHeight, minHeight },
           compact && styles.row_compact,
           spacious && styles.row_spacious,
           middleAlign && styles.row_middleAlign,

--- a/packages/core/test/components/Card/Content.test.tsx
+++ b/packages/core/test/components/Card/Content.test.tsx
@@ -17,9 +17,7 @@ describe('<Card />', () => {
     const wrapper = shallowWithStyles(<Content beforeImageSrc={imageUrl}>Sup</Content>);
 
     expect(
-      shallow(wrapper.find(Row).prop('before') as React.ReactElement)
-        .find('img')
-        .prop('src'),
+      (wrapper.find(Row).prop('before')! as React.ReactElement<{ src: string }>).props.src,
     ).toBe(imageUrl);
   });
 
@@ -28,9 +26,7 @@ describe('<Card />', () => {
     const wrapper = shallowWithStyles(<Content afterImageSrc={imageUrl}>Sup</Content>);
 
     expect(
-      shallow(wrapper.find(Row).prop('after') as React.ReactElement)
-        .find('img')
-        .prop('src'),
+      (wrapper.find(Row).prop('after') as React.ReactElement<{ src: string }>)!.props.src,
     ).toBe(imageUrl);
   });
 


### PR DESCRIPTION
to: @Alphy11 

## Description

Remake of https://github.com/airbnb/lunar/pull/195/ since Happo is broken.

> - Changing default size for Content before/after images to be 152px
> - Adding small size for Content before/after images at previous default of 80px
> - Changing the Image to use background so that the card scales with the content of the card, not the image.
> - Add a minHeight to Content
> - Add a minHeight to Row

## Motivation and Context

> The focus of a card is its' content, and we should scale with that rather than the image.  Also, design decided that we should use 152px as the width.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

before:
![image](https://user-images.githubusercontent.com/18182784/65556497-a72a7c80-dee4-11e9-999a-201511b78eec.png)

after:
![image](https://user-images.githubusercontent.com/18182784/65556568-d50fc100-dee4-11e9-9607-3f93fde08a40.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
