### PR TITLE
update(MessageItem): Wrap long titles.

### DIFF
--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -146,7 +146,7 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
             <div>
               <Spacing bottom={0.5}>
                 <div className={cx(styles.title)}>
-                  <Spacing inline bottom={0.5} right={1}>
+                  <Spacing inline right={1}>
                     <Shimmer width={175} height={14} />
                   </Spacing>
 

--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -146,7 +146,7 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
             <div>
               <Spacing bottom={0.5}>
                 <div className={cx(styles.title)}>
-                  <Spacing inline right={1}>
+                  <Spacing inline bottom={0.5} right={1}>
                     <Shimmer width={175} height={14} />
                   </Spacing>
 
@@ -226,7 +226,7 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
           <div>
             <Spacing bottom={0.5}>
               <div className={cx(styles.title)}>
-                <Spacing inline right={1}>
+                <Spacing inline bottom={0.5} right={1}>
                   {onClickTitle ? (
                     <button
                       className={cx(styles.resetButton)}
@@ -243,7 +243,7 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
                 </Spacing>
 
                 {titleTag && (
-                  <Spacing inline right={1}>
+                  <Spacing inline bottom={0.5} right={1}>
                     <div className={cx(styles.tag)}>
                       <Text micro muted>
                         {titleTag}

--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -146,7 +146,9 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
             <div>
               <Spacing bottom={0.5}>
                 <div className={cx(styles.title)}>
-                  <Shimmer width={175} height={14} />
+                  <Spacing inline bottom={0.5} right={1}>
+                    <Shimmer width={175} height={14} />
+                  </Spacing>
 
                   <Text small muted>
                     {timestamp}
@@ -224,30 +226,30 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
           <div>
             <Spacing bottom={0.5}>
               <div className={cx(styles.title)}>
-                {onClickTitle ? (
-                  <button
-                    className={cx(styles.resetButton)}
-                    type="button"
-                    title={titleClickDescription || title}
-                    onClick={onClickTitle}
-                    onMouseUp={removeFocusOnMouseUp}
-                  >
-                    <Text bold truncated>
-                      {formatedTitle}
-                    </Text>
-                  </button>
-                ) : (
-                  <Text bold truncated>
-                    {formatedTitle}
-                  </Text>
-                )}
+                <Spacing inline right={1}>
+                  {onClickTitle ? (
+                    <button
+                      className={cx(styles.resetButton)}
+                      type="button"
+                      title={titleClickDescription || title}
+                      onClick={onClickTitle}
+                      onMouseUp={removeFocusOnMouseUp}
+                    >
+                      <Text bold>{formatedTitle}</Text>
+                    </button>
+                  ) : (
+                    <Text bold>{formatedTitle}</Text>
+                  )}
+                </Spacing>
 
                 {titleTag && (
-                  <div className={cx(styles.tag)}>
-                    <Text micro muted>
-                      {titleTag}
-                    </Text>
-                  </div>
+                  <Spacing inline right={1}>
+                    <div className={cx(styles.tag)}>
+                      <Text micro muted>
+                        {titleTag}
+                      </Text>
+                    </div>
+                  </Spacing>
                 )}
 
                 <Text small muted>
@@ -375,9 +377,8 @@ export default withStyles(({ color, font, ui, unit, pattern }) => ({
   },
 
   title: {
-    display: 'grid',
-    gridGap: unit,
-    gridTemplateColumns: 'auto auto auto auto',
+    display: 'flex',
+    flexWrap: 'wrap',
     alignItems: 'baseline',
     justifyContent: 'flex-start',
   },

--- a/packages/core/src/components/MessageItem/story.tsx
+++ b/packages/core/src/components/MessageItem/story.tsx
@@ -358,3 +358,50 @@ export function withDisableTitleTranslation() {
 withDisableTitleTranslation.story = {
   name: 'With disable title translation.',
 };
+
+export function withAllOfTheThings() {
+  return (
+    <div style={{ display: 'grid', gridGap: 48, gridTemplateColumns: '1fr 1fr' }}>
+      <MessageItem
+        horizontalSpacing
+        info
+        verticalSpacing
+        email="noreply@airbnb.com"
+        formattedTimestamp="Sep 20 10:23AM"
+        imageDescription="Link"
+        imageSrc={lunar}
+        source="email"
+        titleTag="Specialist"
+        title="Long title lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        onClickImage={action('onClickImage')}
+      >
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </MessageItem>
+
+      <MessageItem
+        horizontalSpacing
+        info
+        verticalSpacing
+        email="noreply@airbnb.com"
+        formattedTimestamp="Sep 20 10:23AM"
+        imageDescription="Link"
+        imageSrc={lunar}
+        source="email"
+        titleTag="Specialist"
+        title="Long title lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        titleClickDescription="Real name: Link - Click to chat"
+        onClickTitle={action('onClickTitle')}
+      >
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </MessageItem>
+    </div>
+  );
+}
+
+withAllOfTheThings.story = {
+  name: 'With all of the things.',
+};


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Wrap long titles, instead of squishing everything on one line.

## Motivation and Context

A few use cases where the message item is in a small column, with large titles. The title is important to the message, so disabling truncation. Wrapping tag, time, and source as needed if there's a long title.

## Testing

storybook at various widths
added a new story with all of the things for debugging

## Screenshots

before with grid for title:
<img width="1017" alt="Storybook 2019-09-30 15-46-14" src="https://user-images.githubusercontent.com/306275/65922234-7f7e5d00-e399-11e9-97fb-fb42648e7868.png">

after with flex wrapping:
<img width="1028" alt="Screen Shot 2019-09-30 at 3 42 40 PM" src="https://user-images.githubusercontent.com/306275/65922095-067f0580-e399-11e9-9787-f7ea0933af67.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
