### PR TITLE
types(DataTable): Update Renderer data shape to allow generics.

### DIFF
--- a/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
+++ b/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
@@ -27,10 +27,10 @@ type ArgumentsFromProps = {
   expandable?: boolean;
 };
 
-export default function renderDataColumns(
+export default function renderDataColumns<T>(
   keys: string[],
   editMode: boolean,
-  onEdit: EditCallback,
+  onEdit: EditCallback<T>,
   {
     columnMetadata,
     showColumnDividers,
@@ -43,15 +43,15 @@ export default function renderDataColumns(
     expandable,
   }: ArgumentsFromProps,
 ) {
-  const renderCell = (key: string, isLeftmost: boolean) => (row: VirtualRow) => {
+  const renderCell = (key: string, isLeftmost: boolean) => (row: VirtualRow<T>) => {
     const { metadata } = row.rowData;
     const { isChild } = metadata;
     const customRenderer = renderers && renderers[key];
     const indentSize = !expandable || !isLeftmost ? 2 : 2.5;
     const spacing = isChild || !((expandable || selectable) && isLeftmost) ? indentSize : 0;
-    const rendererArguments: RendererProps = {
+    const rendererArguments: RendererProps<T> = {
       row,
-      keyName: key,
+      keyName: key as keyof T,
       editMode,
       onEdit,
       zebra: zebra || false,

--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -199,7 +199,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
   private onEdit = (
     row: VirtualRow,
-    key: string,
+    key: string | number,
     newVal: string,
     event: React.SyntheticEvent<EventTarget>,
   ) => {

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -14,14 +14,27 @@ import Button from '../Button';
 import Input from '../Input';
 import Row from '../Row';
 import Spacing from '../Spacing';
-import { SelectedRows, IndexedParentRow } from './types';
+import { SelectedRows, IndexedParentRow, Renderers, RendererProps } from './types';
 
-const renderers = {
+type CustomShape = {
+  name: string;
+  jobTitle: string;
+  tenureDays: number;
+  menu: string;
+  cats: number;
+};
+
+function CustomRenderer({ row, keyName }: RendererProps<CustomShape>) {
+  return <span>{String(row.rowData.data[keyName])}</span>;
+}
+
+const renderers: Renderers<CustomShape> = {
   name: EditableTextRenderer,
   colSpan: ColSpanRenderer,
   cats: CatRenderer,
   tenureDays: TenureRenderer,
   menu: MenuRenderer,
+  custom: CustomRenderer,
 };
 
 const columnMetadata = {

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -24,7 +24,7 @@ export type ChangeLog = {
 
 export type EditCallback<T = RowData> = (
   row: VirtualRow<T>,
-  key: string,
+  key: keyof T,
   newVal: string,
   event: React.SyntheticEvent<EventTarget>,
 ) => void;
@@ -74,7 +74,9 @@ export interface DataTableProps {
   /** Propagated as the 'ref' prop to the underlying react-virtualized Table instance. */
   propagateRef?: TableRef;
   /** Custom renderers mapped to column keys. */
-  renderers?: Renderers;
+  // Any so that consumers can pass any types they want.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  renderers?: Renderers<any>;
   /** Height of table rows, default for table header and column header height. */
   rowHeight?: RowHeightOptions;
   /** If enabled, a special column is rendered to allows rows to be selected. */
@@ -224,7 +226,7 @@ export type RendererProps<T = RowData> = {
   /** Row including row data and metadata. */
   row: VirtualRow<T>;
   /** Key being rendered. */
-  keyName: string;
+  keyName: keyof T;
   /** Whether or not edit mode is enabled. */
   editMode: boolean;
   /** Callback to trigger on cell edit. */
@@ -235,10 +237,10 @@ export type RendererProps<T = RowData> = {
   theme: WithStylesProps['theme'];
 };
 
-export type Renderer = React.ComponentType<RendererProps>;
+export type Renderer<T = RowData> = React.ComponentType<RendererProps<T>>;
 
-export type Renderers = {
-  [key: string]: Renderer;
+export type Renderers<T = RowData> = {
+  [key: string]: Renderer<T>;
 };
 
 export type WidthProperties = {

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -4,7 +4,12 @@ import React from 'react';
 import Enzyme from 'enzyme';
 import { AutoSizer, Grid, Table } from 'react-virtualized';
 import { shallowWithStyles, mountWithStyles } from '@airbnb/lunar-test-utils';
-import DataTable from '../../src/components/DataTable';
+import DataTable, {
+  ParentRow,
+  VirtualRow,
+  DataTableProps,
+  RendererProps,
+} from '../../src/components/DataTable';
 import Input from '../../src/components/Input';
 import FormInput from '../../src/components/private/FormInput';
 import TableHeader from '../../src/components/DataTable/TableHeader';
@@ -12,15 +17,10 @@ import Text from '../../src/components/Text';
 import Translate from '../../src/components/Translate';
 import Button from '../../src/components/Button';
 import Checkbox from '../../src/components/CheckBox';
-import { EditCallback, ParentRow, VirtualRow } from '../../src/components/DataTable/types';
 import { STATUS_OPTIONS } from '../../src/components/DataTable/constants';
 
-type EditableTextRendererProps = {
-  row: VirtualRow;
-  keyName: string;
-  onEdit: EditCallback;
+type EditableTextRendererProps = Omit<RendererProps, 'theme' | 'zebra'> & {
   value: string;
-  editMode: boolean;
 };
 
 type EditableTextRendererState = {
@@ -35,7 +35,7 @@ class InnerEditableTextRenderer extends React.Component<
     value: this.props.value,
   };
 
-  onEdit = (row: VirtualRow, keyName: string) => (
+  onEdit = (row: VirtualRow, keyName: string | number) => (
     newVal: string,
     event: React.SyntheticEvent<EventTarget>,
   ) => {
@@ -65,17 +65,7 @@ class InnerEditableTextRenderer extends React.Component<
   }
 }
 
-function EditableTextRenderer({
-  row,
-  keyName,
-  editMode,
-  onEdit,
-}: {
-  row: VirtualRow;
-  keyName: string;
-  editMode: boolean;
-  onEdit: EditCallback;
-}) {
+function EditableTextRenderer({ row, keyName, editMode, onEdit }: RendererProps) {
   return (
     <InnerEditableTextRenderer
       editMode={editMode}
@@ -615,7 +605,7 @@ function getHeader(wrapper: Enzyme.ShallowWrapper) {
 }
 
 describe('<DataTable /> handles edits', () => {
-  const props = {
+  const props: DataTableProps = {
     data,
     width: 500,
     tableHeaderLabel: 'My Table',


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Minor changes to some types so that the `rowData` property can be properly typed. This assumes the same shape for all renderers.

## Motivation and Context

Unknown is too restrictive.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
