### PR TITLE
fix(FormActions): Fix FormActions error `Cannot add property disabled, object is not extensible`.

### DIFF
--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import Button from '@airbnb/lunar/lib/components/Button';
 import ButtonGroup from '@airbnb/lunar/lib/components/ButtonGroup';
-import FormActions from '@airbnb/lunar/lib/components/FormActions';
 import Text from '@airbnb/lunar/lib/components/Text';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import Input from './Input';
@@ -17,6 +16,7 @@ import ToggleButtonController from './ToggleButtonController';
 import DatePickerInput from './DatePickerInput';
 import DateTimeSelect from './DateTimeSelect';
 import Multicomplete from './Multicomplete';
+import FormActions from '../FormActions';
 import Form from '.';
 
 const fixedDate = new Date(2019, 1, 1, 10, 10, 10);

--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -105,8 +105,6 @@ class UnmountExample extends React.Component<{}, { mounted: boolean }> {
         <Button onClick={this.handleToggleMount}>
           {mounted ? 'Unmount Input' : 'Mount Input'}
         </Button>
-
-        <FormActions showReset />
       </Form>
     );
   }

--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -74,8 +74,8 @@ class UnmountExample extends React.Component<{}, { mounted: boolean }> {
     return (
       <Form
         onFailedSubmit={action('onFailedSubmit')}
-        onSubmit={() => {
-          action('onSubmit')();
+        onSubmit={data => {
+          action('onSubmit')(data);
 
           return Promise.resolve();
         }}
@@ -105,6 +105,8 @@ class UnmountExample extends React.Component<{}, { mounted: boolean }> {
         <Button onClick={this.handleToggleMount}>
           {mounted ? 'Unmount Input' : 'Mount Input'}
         </Button>
+
+        <FormActions showReset />
       </Form>
     );
   }
@@ -122,8 +124,8 @@ export function withAllFields() {
     <Form
       initialValues={values}
       onFailedSubmit={action('onFailedSubmit')}
-      onSubmit={() => {
-        action('onSubmit')();
+      onSubmit={data => {
+        action('onSubmit')(data);
 
         return Promise.resolve();
       }}

--- a/packages/forms/src/components/FormActions/index.tsx
+++ b/packages/forms/src/components/FormActions/index.tsx
@@ -9,16 +9,13 @@ export type Props = Omit<BaseProps, 'disabled' | 'processing'>;
 /** `FormActions` automatically connected to the parent `Form`. */
 export default function FormActions(props: Props) {
   const context = useContext(FormContext);
-  let baseProps: BaseProps = props;
+  const baseProps: BaseProps = { ...props };
 
   if (context) {
     const { submitting, valid }: FormState<unknown> = context.getState();
 
-    baseProps = {
-      ...props,
-      disabled: !valid,
-      processing: submitting,
-    };
+    baseProps.disabled = !valid;
+    baseProps.processing = submitting;
   }
 
   return <BaseFormActions {...baseProps} />;

--- a/packages/forms/src/components/FormActions/index.tsx
+++ b/packages/forms/src/components/FormActions/index.tsx
@@ -9,15 +9,17 @@ export type Props = Omit<BaseProps, 'disabled' | 'processing'>;
 /** `FormActions` automatically connected to the parent `Form`. */
 export default function FormActions(props: Props) {
   const context = useContext(FormContext);
+  let baseProps: BaseProps = props;
 
   if (context) {
     const { submitting, valid }: FormState<unknown> = context.getState();
 
-    Object.assign(props, {
+    baseProps = {
+      ...props,
       disabled: !valid,
       processing: submitting,
-    });
+    };
   }
 
-  return <BaseFormActions {...props} />;
+  return <BaseFormActions {...baseProps} />;
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Tried using FormActions exported from the form package within a Form. Got `Cannot add property disabled, object is not extensible`. Error. Cannot use `Object.assign` on `props`. Updated the story to use the FormActions from the form package, not the core version.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

locally and in storybook

## Screenshots

imported the FormActions from the form package into the form story to reproduce the error:

<img width="1581" alt="Storybook 2019-10-07 16-26-13" src="https://user-images.githubusercontent.com/306275/66356576-49545680-e920-11e9-8fdc-8fef9555847a.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
