### PR TITLE
new(Tabs): Add `secondary` prop and styles.

### DIFF
--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -200,7 +200,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   tabButton_rounded_selected: {
     boxShadow: ui.boxShadowMedium,
     color: color.base,
-    borderColor: color.core.secondary[4],
+    borderColor: color.core.secondary[3],
     backgroundColor: color.core.secondary[3],
     ':hover': {
       backgroundColor: 'none'

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -72,6 +72,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
     } = this.props;
     const trackingName = upperFirst(camelCase(keyName || 'Tab'));
     const noborder = rounded || borderless;
+    const nohover = rounded || (noborder && disabled);
 
     return (
       <span
@@ -79,8 +80,8 @@ export class Tab extends React.Component<Props & WithStylesProps> {
           styles.tab,
           disabled && styles.tab_disabled,
           noborder && styles.tab_noborder,
-          noborder && disabled && styles.tab_disabled_noborder,
-          selected && styles.tab_selected,
+          nohover && styles.tab_nohover,
+          selected && !rounded && styles.tab_selected,
           stretched && styles.tab_stretched,
         )}
       >
@@ -95,8 +96,10 @@ export class Tab extends React.Component<Props & WithStylesProps> {
             role="tab"
             className={cx(
               styles.tabButton,
+              rounded && styles.tabButton_rounded,
               small && styles.tabButton_small,
               selected && styles.tabButton_active,
+              disabled && styles.tabButton_disabled,
             )}
             onClick={disabled ? undefined : this.handleClick}
           >
@@ -140,7 +143,6 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   },
 
   tab_disabled: {
-    ...pattern.disabled,
     borderColor: color.accent.border,
 
     ':hover': {
@@ -148,7 +150,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     },
   },
 
-  tab_disabled_noborder: {
+  tab_nohover: {
     ':hover': {
       borderColor: color.clear,
     },
@@ -173,6 +175,14 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     fontWeight: font.weights.bold,
     borderTopLeftRadius: ui.borderRadius,
     borderTopRightRadius: ui.borderRadius,
+  },
+
+  tabButton_disabled: {
+    ...pattern.disabled
+  },
+
+  tabButton_rounded: {
+
   },
 
   tabButton_small: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -71,8 +71,8 @@ export class Tab extends React.Component<Props & WithStylesProps> {
       styles,
     } = this.props;
     const trackingName = upperFirst(camelCase(keyName || 'Tab'));
-    const noborder = secondary || borderless;
-    const nohover = secondary || (noborder && disabled);
+    const noBorder = secondary || borderless;
+    const noHover = secondary || (noBorder && disabled);
 
     return (
       <span
@@ -80,8 +80,8 @@ export class Tab extends React.Component<Props & WithStylesProps> {
           styles.tab,
           secondary && styles.tab_secondary,
           disabled && styles.tab_disabled,
-          noborder && styles.tab_noborder,
-          nohover && styles.tab_nohover,
+          noBorder && styles.tab_noBorder,
+          noHover && styles.tab_noHover,
           selected && !secondary && styles.tab_selected,
           stretched && styles.tab_stretched,
         )}
@@ -136,7 +136,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     marginBottom: 0
   },
 
-  tab_noborder: {
+  tab_noBorder: {
     borderColor: color.clear,
   },
 
@@ -160,7 +160,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     },
   },
 
-  tab_nohover: {
+  tab_noHover: {
     ':hover': {
       borderColor: color.clear,
     },

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -193,7 +193,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     paddingBottom: (unit / 8) * 5,
     fontWeight: 'normal',
     justifyContent: 'center',
-    border: `1px solid ${color.clear}`,
+    border: `${ui.borderWidth}px solid ${color.clear}`,
     backgroundColor: color.clear,
     borderRadius: ui.borderRadius,
     ':hover': {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -204,6 +204,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
   tabButton_selected: {
     color: color.accent.textActive,
+    cursor: 'normal', // TODO: fix in buildTheme
   },
 
   tabButton_secondary_selected: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -186,8 +186,8 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   tabButton_secondary: {
     ...pattern.regularButton,
     justifyContent: 'center',
-    border: `2px solid ${color.accent.border}`,
-    borderRadius: ui.borderRadius * 2,
+    border: `1px solid ${color.accent.border}`,
+    borderRadius: ui.borderRadius,
     ':hover': {
       backgroundColor: color.accent.bgHover
     }

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -74,6 +74,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
           styles.tab,
           disabled && styles.tab_disabled,
           borderless && styles.tab_borderless,
+          (disabled && borderless) && styles.tab_disabled_borderless,
           selected && styles.tab_selected,
           stretched && styles.tab_stretched,
         )}
@@ -139,6 +140,12 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
     ':hover': {
       borderColor: color.accent.border,
+    },
+  },
+
+  tab_disabled_borderless: {
+    ':hover': {
+      borderColor: color.clear,
     },
   },
 

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -182,7 +182,9 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   },
 
   tabButton_rounded: {
-
+    ...pattern.regularButton,
+    border: `2px solid ${color.accent.border}`,
+    borderRadius: ui.borderRadius * 2
   },
 
   tabButton_small: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -126,10 +126,14 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     ':last-child': {
       marginRight: 0,
     },
+
+    userSelect: 'none',
   },
 
   tab_secondary: {
-    marginRight: unit
+    marginRight: unit,
+    borderWidth: 0,
+    marginBottom: 0
   },
 
   tab_noborder: {
@@ -185,10 +189,15 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
   tabButton_secondary: {
     ...pattern.regularButton,
+    paddingTop: unit / 2,
+    paddingBottom: (unit / 8) * 5,
+    fontWeight: 'normal',
     justifyContent: 'center',
-    border: `1px solid ${color.accent.border}`,
+    border: `1px solid ${color.clear}`,
+    backgroundColor: color.clear,
     borderRadius: ui.borderRadius,
     ':hover': {
+      borderColor: color.accent.borderHover,
       backgroundColor: color.accent.bgHover
     }
   },
@@ -198,17 +207,17 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   },
 
   tabButton_secondary_selected: {
-    boxShadow: ui.boxShadowMedium,
-    color: color.base,
-    borderColor: color.core.secondary[3],
-    backgroundColor: color.core.secondary[3],
+    borderColor: color.accent.borderActive,
+    backgroundColor: color.accent.bg,
     ':hover': {
-      backgroundColor: 'none'
-    },
+      borderColor: color.accent.borderActive,
+      backgroundColor: color.accent.bg
+    }
   },
 
   tabButton_disabled: {
-    ...pattern.disabled
+    ...pattern.disabled,
+    pointerEvents: 'none'
   },
 
   tabButton_small: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -78,6 +78,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
       <span
         className={cx(
           styles.tab,
+          rounded && styles.tab_rounded,
           disabled && styles.tab_disabled,
           noborder && styles.tab_noborder,
           nohover && styles.tab_nohover,
@@ -125,6 +126,10 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     ':last-child': {
       marginRight: 0,
     },
+  },
+
+  tab_rounded: {
+    marginRight: unit
   },
 
   tab_noborder: {
@@ -180,6 +185,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
   tabButton_rounded: {
     ...pattern.regularButton,
+    justifyContent: 'center',
     border: `2px solid ${color.accent.border}`,
     borderRadius: ui.borderRadius * 2,
     ':hover': {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -21,8 +21,8 @@ export type Props = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'disabl
   onClick?: (key: string) => void;
   /** Callback fired when the tab is selected. */
   onSelected?: () => void;
-  /** Rounded tab style, implies borderless. */
-  rounded?: boolean;
+  /** Secondary tab style, implies borderless. */
+  secondary?: boolean;
   /** Whether the tab is selected or not. */
   selected?: boolean;
   /** Decrease font size to small. */
@@ -36,7 +36,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
   static defaultProps = {
     borderless: false,
     children: null,
-    rounded: false,
+    secondary: false,
     selected: false,
     small: false,
     stretched: false,
@@ -64,25 +64,25 @@ export class Tab extends React.Component<Props & WithStylesProps> {
       href,
       keyName,
       label,
-      rounded,
+      secondary,
       selected,
       small,
       stretched,
       styles,
     } = this.props;
     const trackingName = upperFirst(camelCase(keyName || 'Tab'));
-    const noborder = rounded || borderless;
-    const nohover = rounded || (noborder && disabled);
+    const noborder = secondary || borderless;
+    const nohover = secondary || (noborder && disabled);
 
     return (
       <span
         className={cx(
           styles.tab,
-          rounded && styles.tab_rounded,
+          secondary && styles.tab_secondary,
           disabled && styles.tab_disabled,
           noborder && styles.tab_noborder,
           nohover && styles.tab_nohover,
-          selected && !rounded && styles.tab_selected,
+          selected && !secondary && styles.tab_selected,
           stretched && styles.tab_stretched,
         )}
       >
@@ -97,9 +97,9 @@ export class Tab extends React.Component<Props & WithStylesProps> {
             role="tab"
             className={cx(
               styles.tabButton,
-              rounded && styles.tabButton_rounded,
+              secondary && styles.tabButton_secondary,
               selected && styles.tabButton_selected,
-              selected && rounded && styles.tabButton_rounded_selected,
+              selected && secondary && styles.tabButton_secondary_selected,
               small && styles.tabButton_small,
               disabled && styles.tabButton_disabled,
             )}
@@ -128,7 +128,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     },
   },
 
-  tab_rounded: {
+  tab_secondary: {
     marginRight: unit
   },
 
@@ -183,7 +183,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     borderTopRightRadius: ui.borderRadius,
   },
 
-  tabButton_rounded: {
+  tabButton_secondary: {
     ...pattern.regularButton,
     justifyContent: 'center',
     border: `2px solid ${color.accent.border}`,
@@ -197,7 +197,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     color: color.accent.textActive,
   },
 
-  tabButton_rounded_selected: {
+  tabButton_secondary_selected: {
     boxShadow: ui.boxShadowMedium,
     color: color.base,
     borderColor: color.core.secondary[3],

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -133,7 +133,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   tab_secondary: {
     marginRight: unit,
     borderWidth: 0,
-    marginBottom: 0
+    marginBottom: 0,
   },
 
   tab_noBorder: {
@@ -198,8 +198,8 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     borderRadius: ui.borderRadius,
     ':hover': {
       borderColor: color.accent.borderHover,
-      backgroundColor: color.accent.bgHover
-    }
+      backgroundColor: color.accent.bgHover,
+    },
   },
 
   tabButton_selected: {
@@ -211,13 +211,13 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     backgroundColor: color.accent.bg,
     ':hover': {
       borderColor: color.accent.borderActive,
-      backgroundColor: color.accent.bg
-    }
+      backgroundColor: color.accent.bg,
+    },
   },
 
   tabButton_disabled: {
     ...pattern.disabled,
-    pointerEvents: 'none'
+    pointerEvents: 'none',
   },
 
   tabButton_small: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -126,8 +126,6 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     ':last-child': {
       marginRight: 0,
     },
-
-    userSelect: 'none',
   },
 
   tab_secondary: {
@@ -211,7 +209,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     backgroundColor: color.accent.bg,
     ':hover': {
       borderColor: color.core.primary[4],
-      backgroundColor: color.core.neutral[1],
+      backgroundColor: color.accent.bgHover,
     },
   },
 

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -192,12 +192,13 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
   },
 
   tabButton_rounded_selected: {
+    boxShadow: ui.boxShadowMedium,
     color: color.base,
-    borderColor: color.core.secondary[2],
-    backgroundColor: color.core.secondary[2],
+    borderColor: color.core.secondary[4],
+    backgroundColor: color.core.secondary[3],
     ':hover': {
       backgroundColor: 'none'
-    }
+    },
   },
 
   tabButton_disabled: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -97,9 +97,9 @@ export class Tab extends React.Component<Props & WithStylesProps> {
             className={cx(
               styles.tabButton,
               rounded && styles.tabButton_rounded,
-              rounded && selected && styles.tabButton_rounded_selected,
+              selected && styles.tabButton_selected,
+              selected && rounded && styles.tabButton_rounded_selected,
               small && styles.tabButton_small,
-              selected && styles.tabButton_active,
               disabled && styles.tabButton_disabled,
             )}
             onClick={disabled ? undefined : this.handleClick}
@@ -187,10 +187,16 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     }
   },
 
+  tabButton_selected: {
+    color: color.accent.textActive,
+  },
+
   tabButton_rounded_selected: {
-    borderColor: color.accent.borderActive,
+    color: color.base,
+    borderColor: color.core.secondary[2],
+    backgroundColor: color.core.secondary[2],
     ':hover': {
-      backgroundColor: 'inherit'
+      backgroundColor: 'none'
     }
   },
 
@@ -200,9 +206,5 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
 
   tabButton_small: {
     ...font.textSmall,
-  },
-
-  tabButton_active: {
-    color: color.accent.textActive,
   },
 }))(Tab);

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -198,21 +198,20 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     borderRadius: ui.borderRadius,
     ':hover': {
       borderColor: color.accent.borderHover,
-      backgroundColor: color.accent.bgHover,
+      backgroundColor: color.core.neutral[1],
     },
   },
 
   tabButton_selected: {
     color: color.accent.textActive,
-    cursor: 'normal', // TODO: fix in buildTheme
   },
 
   tabButton_secondary_selected: {
     borderColor: color.accent.borderActive,
     backgroundColor: color.accent.bg,
     ':hover': {
-      borderColor: color.accent.borderActive,
-      backgroundColor: color.accent.bg,
+      borderColor: color.core.primary[4],
+      backgroundColor: color.core.neutral[1],
     },
   },
 

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -21,6 +21,8 @@ export type Props = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'disabl
   onClick?: (key: string) => void;
   /** Callback fired when the tab is selected. */
   onSelected?: () => void;
+  /** Rounded tab style, implies borderless. */
+  rounded?: boolean;
   /** Whether the tab is selected or not. */
   selected?: boolean;
   /** Decrease font size to small. */
@@ -34,6 +36,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
   static defaultProps = {
     borderless: false,
     children: null,
+    rounded: false,
     selected: false,
     small: false,
     stretched: false,
@@ -61,20 +64,22 @@ export class Tab extends React.Component<Props & WithStylesProps> {
       href,
       keyName,
       label,
+      rounded,
       selected,
       small,
       stretched,
       styles,
     } = this.props;
     const trackingName = upperFirst(camelCase(keyName || 'Tab'));
+    const noborder = rounded || borderless;
 
     return (
       <span
         className={cx(
           styles.tab,
           disabled && styles.tab_disabled,
-          borderless && styles.tab_borderless,
-          (disabled && borderless) && styles.tab_disabled_borderless,
+          noborder && styles.tab_noborder,
+          noborder && disabled && styles.tab_disabled_noborder,
           selected && styles.tab_selected,
           stretched && styles.tab_stretched,
         )}
@@ -118,7 +123,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     },
   },
 
-  tab_borderless: {
+  tab_noborder: {
     borderColor: color.clear,
   },
 
@@ -143,7 +148,7 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     },
   },
 
-  tab_disabled_borderless: {
+  tab_disabled_noborder: {
     ':hover': {
       borderColor: color.clear,
     },

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -97,6 +97,7 @@ export class Tab extends React.Component<Props & WithStylesProps> {
             className={cx(
               styles.tabButton,
               rounded && styles.tabButton_rounded,
+              rounded && selected && styles.tabButton_rounded_selected,
               small && styles.tabButton_small,
               selected && styles.tabButton_active,
               disabled && styles.tabButton_disabled,
@@ -177,14 +178,24 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     borderTopRightRadius: ui.borderRadius,
   },
 
-  tabButton_disabled: {
-    ...pattern.disabled
-  },
-
   tabButton_rounded: {
     ...pattern.regularButton,
     border: `2px solid ${color.accent.border}`,
-    borderRadius: ui.borderRadius * 2
+    borderRadius: ui.borderRadius * 2,
+    ':hover': {
+      backgroundColor: color.accent.bgHover
+    }
+  },
+
+  tabButton_rounded_selected: {
+    borderColor: color.accent.borderActive,
+    ':hover': {
+      backgroundColor: 'inherit'
+    }
+  },
+
+  tabButton_disabled: {
+    ...pattern.disabled
   },
 
   tabButton_small: {

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -198,20 +198,21 @@ export default withStyles(({ color, font, pattern, unit, ui, transition }) => ({
     borderRadius: ui.borderRadius,
     ':hover': {
       borderColor: color.accent.borderHover,
-      backgroundColor: color.core.neutral[1],
+      backgroundColor: color.accent.bgHover,
     },
   },
 
   tabButton_selected: {
     color: color.accent.textActive,
+    cursor: 'normal', // TODO: fix in buildTheme
   },
 
   tabButton_secondary_selected: {
     borderColor: color.accent.borderActive,
     backgroundColor: color.accent.bg,
     ':hover': {
-      borderColor: color.core.primary[4],
-      backgroundColor: color.core.neutral[1],
+      borderColor: color.accent.borderActive,
+      backgroundColor: color.accent.bg,
     },
   },
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -188,12 +188,8 @@ export default withBoundary('Tabs')(
     },
 
     nav_secondary: {
-      padding: unit / 2,
       alignItems: 'center',
-      overflow: 'auto',
       borderWidth: 0,
-      borderRadius: ui.borderRadius,
-      backgroundColor: color.accent.bgHover,
     },
 
     panel: {

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -19,8 +19,8 @@ export type Props = {
   onChange?: (key: string) => void;
   /** Persist the selected tab through the defined URL hash. */
   persistWithHash?: string;
-  /** Rounded tab style, implies borderless. */
-  rounded?: boolean;
+  /** Secondary tab style, implies borderless. */
+  secondary?: boolean;
   /** Wrap tabs in a scrollable region. */
   scrollable?: boolean;
   /** Stretch tabs to fill the full width. */
@@ -40,7 +40,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     defaultKey: '',
     onChange() {},
     persistWithHash: '',
-    rounded: false,
+    secondary: false,
     scrollable: false,
     stretched: false,
   };
@@ -113,9 +113,9 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
   };
 
   render() {
-    const { cx, borderless, children, rounded, scrollable, stretched, styles } = this.props;
+    const { cx, borderless, children, secondary, scrollable, stretched, styles } = this.props;
     const { selectedKey } = this.state;
-    const noborder = borderless || rounded;
+    const noborder = borderless || secondary;
 
     // Generate content
     let content = null;
@@ -140,7 +140,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
           return React.cloneElement(child as React.ReactElement<TabProps>, {
             borderless,
             keyName: String(key),
-            rounded,
+            secondary,
             selected,
             stretched,
             onClick: this.handleClick,

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -40,8 +40,8 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     defaultKey: '',
     onChange() {},
     persistWithHash: '',
-    secondary: false,
     scrollable: false,
+    secondary: false,
     stretched: false,
   };
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -181,7 +181,10 @@ export default withBoundary('Tabs')(
     },
 
     nav_secondary: {
-      padding: unit,
+      padding: unit / 2,
+      overflow: 'auto',
+      borderWidth: 0,
+      borderRadius: ui.borderRadius,
       backgroundColor: color.accent.bgHover
     },
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -120,7 +120,14 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     // Generate content
     let content = null;
     const nav = (
-      <nav role="tablist" className={cx(styles.nav, noBorder && styles.nav_noBorder, secondary && styles.nav_secondary)}>
+      <nav
+        role="tablist"
+        className={cx(
+          styles.nav,
+          noBorder && styles.nav_noBorder,
+          secondary && styles.nav_secondary,
+        )}
+      >
         {React.Children.map(children, (child, i) => {
           if (!child) {
             return null;
@@ -186,7 +193,7 @@ export default withBoundary('Tabs')(
       overflow: 'auto',
       borderWidth: 0,
       borderRadius: ui.borderRadius,
-      backgroundColor: color.accent.bgHover
+      backgroundColor: color.accent.bgHover,
     },
 
     panel: {

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -115,12 +115,12 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
   render() {
     const { cx, borderless, children, secondary, scrollable, stretched, styles } = this.props;
     const { selectedKey } = this.state;
-    const noborder = borderless || secondary;
+    const noBorder = borderless || secondary;
 
     // Generate content
     let content = null;
     const nav = (
-      <nav role="tablist" className={cx(styles.nav, noborder && styles.nav_noborder, secondary && styles.nav_secondary)}>
+      <nav role="tablist" className={cx(styles.nav, noBorder && styles.nav_noBorder, secondary && styles.nav_secondary)}>
         {React.Children.map(children, (child, i) => {
           if (!child) {
             return null;
@@ -176,7 +176,7 @@ export default withBoundary('Tabs')(
       display: 'flex',
     },
 
-    nav_noborder: {
+    nav_noBorder: {
       borderColor: color.clear,
     },
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -19,6 +19,8 @@ export type Props = {
   onChange?: (key: string) => void;
   /** Persist the selected tab through the defined URL hash. */
   persistWithHash?: string;
+  /** Rounded tab style, implies borderless. */
+  rounded?: boolean;
   /** Wrap tabs in a scrollable region. */
   scrollable?: boolean;
   /** Stretch tabs to fill the full width. */
@@ -38,6 +40,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     defaultKey: '',
     onChange() {},
     persistWithHash: '',
+    rounded: false,
     scrollable: false,
     stretched: false,
   };
@@ -110,13 +113,14 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
   };
 
   render() {
-    const { cx, borderless, children, scrollable, stretched, styles } = this.props;
+    const { cx, borderless, children, rounded, scrollable, stretched, styles } = this.props;
     const { selectedKey } = this.state;
+    const noborder = borderless || rounded;
 
     // Generate content
     let content = null;
     const nav = (
-      <nav role="tablist" className={cx(styles.nav, borderless && styles.nav_borderless)}>
+      <nav role="tablist" className={cx(styles.nav, noborder && styles.nav_noborder)}>
         {React.Children.map(children, (child, i) => {
           if (!child) {
             return null;
@@ -136,6 +140,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
           return React.cloneElement(child as React.ReactElement<TabProps>, {
             borderless,
             keyName: String(key),
+            rounded,
             selected,
             stretched,
             onClick: this.handleClick,
@@ -171,7 +176,7 @@ export default withBoundary('Tabs')(
       display: 'flex',
     },
 
-    nav_borderless: {
+    nav_noborder: {
       borderColor: color.clear,
     },
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -182,6 +182,7 @@ export default withBoundary('Tabs')(
 
     nav_secondary: {
       padding: unit / 2,
+      alignItems: 'center',
       overflow: 'auto',
       borderWidth: 0,
       borderRadius: ui.borderRadius,

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -120,7 +120,7 @@ export class Tabs extends React.Component<Props & WithStylesProps, State> {
     // Generate content
     let content = null;
     const nav = (
-      <nav role="tablist" className={cx(styles.nav, noborder && styles.nav_noborder)}>
+      <nav role="tablist" className={cx(styles.nav, noborder && styles.nav_noborder, secondary && styles.nav_secondary)}>
         {React.Children.map(children, (child, i) => {
           if (!child) {
             return null;
@@ -178,6 +178,11 @@ export default withBoundary('Tabs')(
 
     nav_noborder: {
       borderColor: color.clear,
+    },
+
+    nav_secondary: {
+      padding: unit,
+      backgroundColor: color.accent.bgHover
     },
 
     panel: {

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -43,23 +43,23 @@ smallTabsStretched.story = {
 export function secondaryTabs() {
   return (
     <Tabs secondary>
-      <Tab key="a" label="Lorem">
+      <Tab small key="a" label="Lorem">
         <Text>
           <LoremIpsum short />
         </Text>
       </Tab>
-      <Tab key="b" label="Ipsum">
+      <Tab small key="b" label="Ipsum">
         <Text>
           <LoremIpsum medium />
         </Text>
       </Tab>
-      <Tab key="c" disabled label="Dolor" />
+      <Tab small key="c" disabled label="Dolor" />
     </Tabs>
   );
 }
 
 secondaryTabs.story = {
-  name: 'Secondary tabs.',
+  name: 'Secondary small tabs.',
 };
 
 export function secondaryTabsStretched() {

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -40,6 +40,20 @@ smallTabsStretched.story = {
   name: 'Small tabs stretched.',
 };
 
+export function secondaryTabs() {
+  return (
+    <Tabs secondary>
+      <Tab key="a" small label="Bruce W." />
+      <Tab key="b" small label="Clark K." />
+      <Tab key="c" small label="Peter P." />
+    </Tabs>
+  );
+}
+
+secondaryTabs.story = {
+  name: 'Secondary tabs.',
+};
+
 export function borderlessTabsWithIcons() {
   return (
     <Tabs borderless>

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -69,17 +69,17 @@ secondaryTabs.story = {
 export function secondarySmallTabs() {
   return (
     <Tabs secondary>
-      <Tab small key="a" label="Lorem" beforeIcon={<IconAdd decorative />}>
+      <Tab key="a" small label="Lorem" beforeIcon={<IconAdd decorative />}>
         <Text>
           <LoremIpsum short />
         </Text>
       </Tab>
-      <Tab small key="b" label="Ipsum">
+      <Tab key="b" small label="Ipsum">
         <Text>
           <LoremIpsum medium />
         </Text>
       </Tab>
-      <Tab small key="c" disabled label="Dolor" />
+      <Tab key="c" disabled small label="Dolor" />
     </Tabs>
   );
 }

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -223,3 +223,40 @@ export function withScrollableVariableHeightTabs() {
 withScrollableVariableHeightTabs.story = {
   name: 'With scrollable variable height tabs.',
 };
+
+
+export function withScrollableVariableHeightSecondaryTabs() {
+  return (
+    <div style={{ width: '325px' }}>
+      <Tabs scrollable secondary>
+        <Tab
+          key="a"
+          label={
+            <>
+              Bruce
+              <br />
+              Wayne
+            </>
+          }
+        />
+        <Tab key="b" label="Clark K." />
+        <Tab
+          key="c"
+          label={
+            <>
+              Peter
+              <br />
+              Parker
+            </>
+          }
+        />
+        <Tab key="d" label="Tony S." />
+        <Tab key="e" label="Bruce B." />
+      </Tabs>
+    </div>
+  );
+}
+
+withScrollableVariableHeightSecondaryTabs.story = {
+  name: 'With scrollable variable height secondary tabs.',
+};

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -224,7 +224,6 @@ withScrollableVariableHeightTabs.story = {
   name: 'With scrollable variable height tabs.',
 };
 
-
 export function withScrollableVariableHeightSecondaryTabs() {
   return (
     <div style={{ width: '325px' }}>

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -43,15 +43,45 @@ smallTabsStretched.story = {
 export function secondaryTabs() {
   return (
     <Tabs secondary>
-      <Tab key="a" small label="Bruce W." />
-      <Tab key="b" small label="Clark K." />
-      <Tab key="c" small label="Peter P." />
+      <Tab key="a" label="Lorem">
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Tab>
+      <Tab key="b" label="Ipsum">
+        <Text>
+          <LoremIpsum medium />
+        </Text>
+      </Tab>
+      <Tab key="c" disabled label="Dolor" />
     </Tabs>
   );
 }
 
 secondaryTabs.story = {
   name: 'Secondary tabs.',
+};
+
+export function secondaryTabsStretched() {
+  return (
+    <Tabs secondary stretched>
+      <Tab key="a" label="Lorem">
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Tab>
+      <Tab key="b" label="Ipsum">
+        <Text>
+          <LoremIpsum medium />
+        </Text>
+      </Tab>
+      <Tab key="c" disabled label="Dolor" />
+    </Tabs>
+  );
+}
+
+secondaryTabsStretched.story = {
+  name: 'Secondary stretched tabs.',
 };
 
 export function borderlessTabsWithIcons() {

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -43,7 +43,33 @@ smallTabsStretched.story = {
 export function secondaryTabs() {
   return (
     <Tabs secondary>
-      <Tab small key="a" label="Lorem">
+      <Tab key="a" label="Lorem is an example">
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Tab>
+      <Tab key="b" label="Ipsum">
+        <Text>
+          <LoremIpsum medium />
+        </Text>
+      </Tab>
+      <Tab key="c" disabled label="Dolor" />
+      <Tab key="d" label="another" beforeIcon={<IconAdd decorative size="1.25em" />} />
+      <Tab key="e" label="amazing item" />
+      <Tab key="f" label="to be clicked " />
+      <Tab key="g" label="and selected" />
+    </Tabs>
+  );
+}
+
+secondaryTabs.story = {
+  name: 'Secondary tabs.',
+};
+
+export function secondarySmallTabs() {
+  return (
+    <Tabs secondary>
+      <Tab small key="a" label="Lorem" beforeIcon={<IconAdd decorative />}>
         <Text>
           <LoremIpsum short />
         </Text>
@@ -58,7 +84,7 @@ export function secondaryTabs() {
   );
 }
 
-secondaryTabs.story = {
+secondarySmallTabs.story = {
   name: 'Secondary small tabs.',
 };
 

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -82,7 +82,7 @@ export default function buildTheme(
       },
       disabled: {
         opacity: disabledOpacity,
-        cursor: 'default',
+        cursor: 'normal',
       },
       focused: {
         borderColor: accent.borderActive,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -82,7 +82,7 @@ export default function buildTheme(
       },
       disabled: {
         opacity: disabledOpacity,
-        cursor: 'normal',
+        cursor: 'default',
       },
       focused: {
         borderColor: accent.borderActive,

--- a/packages/core/test/components/Tab.test.tsx
+++ b/packages/core/test/components/Tab.test.tsx
@@ -38,6 +38,16 @@ describe('<Tab/>', () => {
     expect(wrapper.prop('className')).toMatch('tab_disabled');
   });
 
+  it('renders secondary', () => {
+    const wrapper = shallowWithStyles(
+      <Tab secondary keyName="default" label="Tab" onClick={() => {}} />,
+    );
+
+    const className = wrapper.prop('className');
+    expect(className).toMatch('tab_secondary');
+    expect(className).toMatch('tab_noBorder');
+  });
+
   it('renders selected', () => {
     const wrapper = shallowWithStyles(
       <Tab selected keyName="default" label="Tab" onClick={() => {}} />,

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -251,6 +251,21 @@ describe('<Tabs/>', () => {
     ).toBe(true);
   });
 
+  it('it passes the secondary prop to Tab children', () => {
+    const wrapper = unwrap(
+      <Tabs secondary>
+        <Tab key="a" label="One" />
+      </Tabs>,
+    );
+
+    expect(
+      wrapper
+        .find(Tab)
+        .at(0)
+        .prop('secondary'),
+    ).toBe(true);
+  });
+
   it('Persist with hash and back button.', () => {
     const addSpy = jest.spyOn(window, 'addEventListener');
     const rmSpy = jest.spyOn(window, 'removeEventListener');


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
@adamirl 

## Description

`<Tabs secondary>`

## Motivation and Context

Alternate tab style

## Testing

2 unit tests

## Screenshots

<img width="821" alt="Screen Shot 2019-10-09 at 12 39 08 PM" src="https://user-images.githubusercontent.com/205004/66514373-d1a63900-ea91-11e9-874d-bae369f55e8e.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
