### PR TITLE
update(Apollo): Add typeDefs to Apollo settings

### DIFF
--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -1,10 +1,9 @@
 import Core from '@airbnb/lunar';
-import { ApolloClient, Resolvers } from 'apollo-client';
+import { ApolloClient, ApolloClientOptions } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloLink } from 'apollo-link';
 import { onError } from 'apollo-link-error';
 import { HttpLink } from 'apollo-link-http';
-import { DocumentNode } from 'graphql';
 import Mutation from './components/Mutation';
 import Query from './components/Query';
 import Provider from './components/Provider';
@@ -17,8 +16,8 @@ export { onError, HttpLink, Mutation, Query, Provider };
 
 export type Settings = {
   links?: ApolloLink[];
-  resolvers?: Resolvers | Resolvers[];
-  typeDefs?: string | string[] | DocumentNode | DocumentNode[];
+  resolvers?: ApolloClientOptions<null>['resolvers'];
+  typeDefs?: ApolloClientOptions<null>['typeDefs'];
 };
 
 class Apollo {

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -4,6 +4,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloLink } from 'apollo-link';
 import { onError } from 'apollo-link-error';
 import { HttpLink } from 'apollo-link-http';
+import { DocumentNode } from 'graphql';
 import Mutation from './components/Mutation';
 import Query from './components/Query';
 import Provider from './components/Provider';
@@ -16,13 +17,15 @@ export { onError, HttpLink, Mutation, Query, Provider };
 
 export type Settings = {
   links?: ApolloLink[];
-  resolvers?: Resolvers;
+  resolvers?: Resolvers | Resolvers[];
+  typeDefs?: string | string[] | DocumentNode | DocumentNode[];
 };
 
 class Apollo {
   settings: Required<Settings> = {
     links: [],
     resolvers: {},
+    typeDefs: '',
   };
 
   protected client?: ApolloClient<{}>;
@@ -41,7 +44,7 @@ class Apollo {
       return;
     }
 
-    const { links, resolvers } = this.settings;
+    const { links, resolvers, typeDefs } = this.settings;
 
     this.client = new ApolloClient({
       cache: new InMemoryCache(),
@@ -49,6 +52,7 @@ class Apollo {
       link: ApolloLink.from(links),
       name: Core.settings.name,
       resolvers,
+      typeDefs,
       version: pkg.version,
     });
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add typeDefs to Apollo settings so we can define the types for local data.
typeDefs example: https://www.apollographql.com/docs/react/data/local-state/#client-side-schema

## Motivation and Context

See above!

## Testing

Suggestions welcome

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
