### PR TITLE
fix: Rewrite stories to remove `@emotion/core` unintended import.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
         with:
           node-version: 12
       - uses: ./.github/actions/setup
-      - name: Using current SHA because no previous SHA
-        if: contains(github.event.before, '0000000000') == true
-        run: echo ::set-env name=PREVIOUS_SHA::"${{ github.event.after }}"
       - name: Using previous SHA
         if: contains(github.event.before, '0000000000') == false
         run: echo ::set-env name=PREVIOUS_SHA::"${{ github.event.before }}"
+      - name: Using master SHA because no previous SHA
+        if: contains(github.event.before, '0000000000') == true
+        run: echo ::set-env name=PREVIOUS_SHA::$(git merge-base origin/master HEAD)
       - name: Run Happo CI
         run: yarn run happo:ci
         env:

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,3 +17,5 @@ addDecorator(withStory);
 addDecorator(withContexts(contexts));
 
 configure(require.context('../packages', true, /\/([A-Za-z0-9]+\.)?story\.tsx?$/), module);
+
+global.action = key => (...args) => console.log(key, ...args);

--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -29,6 +29,9 @@ module.exports = {
       env: {
         node: true,
       },
+      globals: {
+        action: 'readonly',
+      },
       rules: {
         'max-classes-per-file': 'off',
 

--- a/packages/core/src/components/Alert/story.tsx
+++ b/packages/core/src/components/Alert/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import Text from '../Text';
 import MutedButton from '../MutedButton';

--- a/packages/core/src/components/Autocomplete/story.tsx
+++ b/packages/core/src/components/Autocomplete/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Autocomplete from '.';
 
 const items = [

--- a/packages/core/src/components/Breadcrumbs/story.tsx
+++ b/packages/core/src/components/Breadcrumbs/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Breadcrumbs, { Breadcrumb } from '.';
 
 export default {

--- a/packages/core/src/components/Button/story.tsx
+++ b/packages/core/src/components/Button/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import Button from '.';
 

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconChevronRight from '@airbnb/lunar-icons/lib/interface/IconChevronRight';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import lunar from ':storybook/images/lunar-logo.png';

--- a/packages/core/src/components/CheckBox/story.tsx
+++ b/packages/core/src/components/CheckBox/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import CheckBox from '.';
 
 export default {

--- a/packages/core/src/components/CheckBoxController/story.tsx
+++ b/packages/core/src/components/CheckBoxController/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import CheckBoxController from '.';
 import BaseCheckBox from '../CheckBox';
 

--- a/packages/core/src/components/Chip/story.tsx
+++ b/packages/core/src/components/Chip/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconCalendar from '@airbnb/lunar-icons/lib/general/IconCalendar';
 import IconUser from '@airbnb/lunar-icons/lib/general/IconUser';
 import IconCloseAlt from '@airbnb/lunar-icons/lib/interface/IconCloseAlt';

--- a/packages/core/src/components/DangerButton/story.tsx
+++ b/packages/core/src/components/DangerButton/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import DangerButton from '.';
 
 export default {

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconStar from '@airbnb/lunar-icons/lib/interface/IconStar';
 import getData, { generateRandomData } from ':storybook/components/DataTable/DataTableData';
 import TenureRenderer from ':storybook/components/DataTable/DataTableRenderers/TenureRenderer';

--- a/packages/core/src/components/DatePickerInput/story.tsx
+++ b/packages/core/src/components/DatePickerInput/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Spacing from '../Spacing';
 import DatePickerInput from '.';
 import DatePicker from '../DatePicker';

--- a/packages/core/src/components/DateTimeSelect/story.tsx
+++ b/packages/core/src/components/DateTimeSelect/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import DateTimeSelect from '.';
 
 const fixedDate = new Date(2019, 1, 1, 10, 10, 10);

--- a/packages/core/src/components/Dropdown/story.tsx
+++ b/packages/core/src/components/Dropdown/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Button from '../Button';
 import Menu, { Row } from '../Menu';
 import Text from '../Text';

--- a/packages/core/src/components/EmojiPicker/story.tsx
+++ b/packages/core/src/components/EmojiPicker/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import EmojiPicker from '.';
 
 export default {

--- a/packages/core/src/components/EmojiRestrictedPicker/story.tsx
+++ b/packages/core/src/components/EmojiRestrictedPicker/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import EmojiRestrictedPicker from '.';
 
 export default {

--- a/packages/core/src/components/ErrorBoundary/story.tsx
+++ b/packages/core/src/components/ErrorBoundary/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import ErrorBoundary from '.';
 
 function TestComponent() {

--- a/packages/core/src/components/FileInput/story.tsx
+++ b/packages/core/src/components/FileInput/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import FileInput from '.';
 
 export default {

--- a/packages/core/src/components/FocusTrap/story.tsx
+++ b/packages/core/src/components/FocusTrap/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Button from '../Button';
 import Input from '../Input';
 import TextArea from '../TextArea';

--- a/packages/core/src/components/FormActions/story.tsx
+++ b/packages/core/src/components/FormActions/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import FormActions from '.';
 
 export default {

--- a/packages/core/src/components/FormField/story.tsx
+++ b/packages/core/src/components/FormField/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconTranslate from '@airbnb/lunar-icons/lib/interface/IconTranslate';
 import IconCurrency from '@airbnb/lunar-icons/lib/general/IconCurrency';
 import Input from '../Input';

--- a/packages/core/src/components/HierarchyPicker/story.tsx
+++ b/packages/core/src/components/HierarchyPicker/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import HierarchyPicker, { Props } from '.';
 import Button from '../Button';
 

--- a/packages/core/src/components/IconButton/story.tsx
+++ b/packages/core/src/components/IconButton/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconCheck from '@airbnb/lunar-icons/lib/interface/IconCheck';
 import IconButton from '.';
 

--- a/packages/core/src/components/Input/story.tsx
+++ b/packages/core/src/components/Input/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Input from '.';
 
 export default {

--- a/packages/core/src/components/Lightbox/story.tsx
+++ b/packages/core/src/components/Lightbox/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import moon from ':storybook/images/moon.png';
 import space from ':storybook/images/space.jpg';
 import stars from ':storybook/images/stars.jpg';
@@ -64,18 +63,66 @@ class LightboxDemo extends React.Component<Omit<Props, 'onClose'>, { visible: bo
   }
 }
 
-storiesOf('Core/Lightbox', module)
-  .addParameters({
+export default {
+  title: 'Core/Lightbox',
+
+  parameters: {
     inspectComponents: [Lightbox],
-  })
-  .add('Default lightbox', () => <LightboxDemo images={mockImages} />)
-  .add('With set start index', () => <LightboxDemo images={mockImages} startIndex={1} />)
-  .add('With sidebar components', () => <LightboxDemo images={mockImagesWithAside} />)
-  .add('With zoom controls', () => <LightboxDemo showZoomControls images={mockImages} />)
-  .add('With rotate controls', () => <LightboxDemo showRotateControls images={mockImages} />)
-  .add('With zoom and rotate controls', () => (
-    <LightboxDemo showZoomControls showRotateControls images={mockImages} startIndex={1} />
-  ))
-  .add('With all options', () => (
-    <LightboxDemo showZoomControls showRotateControls images={mockImagesWithAside} />
-  ));
+  },
+};
+
+export function defaultLightbox() {
+  return <LightboxDemo images={mockImages} />;
+}
+
+defaultLightbox.story = {
+  name: 'Default lightbox',
+};
+
+export function withSetStartIndex() {
+  return <LightboxDemo images={mockImages} startIndex={1} />;
+}
+
+withSetStartIndex.story = {
+  name: 'With set start index',
+};
+
+export function withSidebarComponents() {
+  return <LightboxDemo images={mockImagesWithAside} />;
+}
+
+withSidebarComponents.story = {
+  name: 'With sidebar components',
+};
+
+export function withZoomControls() {
+  return <LightboxDemo showZoomControls images={mockImages} />;
+}
+
+withZoomControls.story = {
+  name: 'With zoom controls',
+};
+
+export function withRotateControls() {
+  return <LightboxDemo showRotateControls images={mockImages} />;
+}
+
+withRotateControls.story = {
+  name: 'With rotate controls',
+};
+
+export function withZoomAndRotateControls() {
+  return <LightboxDemo showZoomControls showRotateControls images={mockImages} startIndex={1} />;
+}
+
+withZoomAndRotateControls.story = {
+  name: 'With zoom and rotate controls',
+};
+
+export function withAllOptions() {
+  return <LightboxDemo showZoomControls showRotateControls images={mockImagesWithAside} />;
+}
+
+withAllOptions.story = {
+  name: 'With all options',
+};

--- a/packages/core/src/components/Link/story.tsx
+++ b/packages/core/src/components/Link/story.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import Link from '.';
 

--- a/packages/core/src/components/MenuToggle/story.tsx
+++ b/packages/core/src/components/MenuToggle/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconMenuDots from '@airbnb/lunar-icons/lib/interface/IconMenuDots';
 import MenuToggle, { Item } from '.';
 

--- a/packages/core/src/components/MessageItem/story.tsx
+++ b/packages/core/src/components/MessageItem/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconBolt from '@airbnb/lunar-icons/lib/general/IconBolt';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import lunar from ':storybook/images/lunar-logo.png';

--- a/packages/core/src/components/Multicomplete/story.tsx
+++ b/packages/core/src/components/Multicomplete/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Text from '../Text';
 import Multicomplete from '.';
 

--- a/packages/core/src/components/MutedButton/story.tsx
+++ b/packages/core/src/components/MutedButton/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import MutedButton from '.';
 
 export default {

--- a/packages/core/src/components/Pagination/story.tsx
+++ b/packages/core/src/components/Pagination/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Pagination from '.';
 import T from '../Translate';
 

--- a/packages/core/src/components/RadioButton/story.tsx
+++ b/packages/core/src/components/RadioButton/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import lunar from ':storybook/images/lunar-logo.png';
 import RadioButton from '.';
 import Row from '../Row';

--- a/packages/core/src/components/RadioButtonController/story.tsx
+++ b/packages/core/src/components/RadioButtonController/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import RadioButtonController from '.';
 import BaseRadioButton from '../RadioButton';
 

--- a/packages/core/src/components/SecondaryLink/story.tsx
+++ b/packages/core/src/components/SecondaryLink/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import IconAddAlt from '@airbnb/lunar-icons/lib/interface/IconAddAlt';
 import SecondaryLink from '.';
 

--- a/packages/core/src/components/Select/story.tsx
+++ b/packages/core/src/components/Select/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Select from '.';
 
 export default {

--- a/packages/core/src/components/Switch/story.tsx
+++ b/packages/core/src/components/Switch/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Switch from '.';
 
 export default {

--- a/packages/core/src/components/TextArea/story.tsx
+++ b/packages/core/src/components/TextArea/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Prefix from '../FormField/Prefix';
 import TextArea from '.';
 

--- a/packages/core/src/components/ToggleButtonController/story.tsx
+++ b/packages/core/src/components/ToggleButtonController/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import ToggleButtonController from '.';

--- a/packages/core/src/components/TrackingBoundary/story.tsx
+++ b/packages/core/src/components/TrackingBoundary/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import TrackingBoundary from '.';
 

--- a/packages/forms/src/components/Autocomplete.story.tsx
+++ b/packages/forms/src/components/Autocomplete.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import Autocomplete from './Form/Autocomplete';
 

--- a/packages/forms/src/components/CheckBox.story.tsx
+++ b/packages/forms/src/components/CheckBox.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import CheckBox from './Form/CheckBox';
 

--- a/packages/forms/src/components/CheckBoxController.story.tsx
+++ b/packages/forms/src/components/CheckBoxController.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import CheckBoxController from './Form/CheckBoxController';
 

--- a/packages/forms/src/components/DatePickerInput.story.tsx
+++ b/packages/forms/src/components/DatePickerInput.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import DatePickerInput from './Form/DatePickerInput';
 

--- a/packages/forms/src/components/DateTimeSelect.story.tsx
+++ b/packages/forms/src/components/DateTimeSelect.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import DateTimeSelect from './Form/DateTimeSelect';
 

--- a/packages/forms/src/components/FeedbackForm/story.tsx
+++ b/packages/forms/src/components/FeedbackForm/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import FeedbackForm from '.';
 
 export default {

--- a/packages/forms/src/components/FileInput.story.tsx
+++ b/packages/forms/src/components/FileInput.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import FileInput from './Form/FileInput';
 

--- a/packages/forms/src/components/FilterMenu/story.tsx
+++ b/packages/forms/src/components/FilterMenu/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from '../Form';
 import Select from '../Form/Select';
 import CheckBox from '../Form/CheckBox';

--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Button from '@airbnb/lunar/lib/components/Button';
 import ButtonGroup from '@airbnb/lunar/lib/components/ButtonGroup';
 import Text from '@airbnb/lunar/lib/components/Text';

--- a/packages/forms/src/components/FormActions/story.tsx
+++ b/packages/forms/src/components/FormActions/story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from '../Form';
 import FormActions from '.';
 

--- a/packages/forms/src/components/Input.story.tsx
+++ b/packages/forms/src/components/Input.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import Input from './Form/Input';
 

--- a/packages/forms/src/components/Multicomplete.story.tsx
+++ b/packages/forms/src/components/Multicomplete.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import Multicomplete from './Form/Multicomplete';
 

--- a/packages/forms/src/components/RadioButtonController.story.tsx
+++ b/packages/forms/src/components/RadioButtonController.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import RadioButtonController from './Form/RadioButtonController';
 

--- a/packages/forms/src/components/Select.story.tsx
+++ b/packages/forms/src/components/Select.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import Select from './Form/Select';
 

--- a/packages/forms/src/components/Switch.story.tsx
+++ b/packages/forms/src/components/Switch.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import Switch from './Form/Switch';
 

--- a/packages/forms/src/components/TextArea.story.tsx
+++ b/packages/forms/src/components/TextArea.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import Form from './Form';
 import TextArea from './Form/TextArea';
 

--- a/packages/forms/src/components/ToggleButtonController.story.tsx
+++ b/packages/forms/src/components/ToggleButtonController.story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import ButtonGroup from '@airbnb/lunar/lib/components/ButtonGroup';
 import Form from './Form';
 import ToggleButtonController from './Form/ToggleButtonController';

--- a/packages/icons/src/Icons.story.tsx
+++ b/packages/icons/src/Icons.story.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/no-onchange */
 
 import React, { ChangeEvent } from 'react';
-import { action } from '@storybook/addon-actions';
 import { WithIconWrapperProps } from './withIcon';
 import FakeIcon from './FakeIcon';
 

--- a/scripts/convertMarkdownToStories.js
+++ b/scripts/convertMarkdownToStories.js
@@ -10,7 +10,6 @@ const Parser = require('remark-parse/lib/parser');
 function createHeader(packageName, componentName, imports = []) {
   return `import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 ${Array.from(imports).join('\n')}
 import ${componentName} from './${componentName}';
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -8,6 +8,7 @@ declare module '*.png';
 
 declare const __DEV__: boolean;
 declare const jsdom: any;
+declare const action: (key: string) => (...args: unknown[]) => void;
 
 // MONKEY PATCHING
 
@@ -86,5 +87,3 @@ declare namespace NodeJS {
     Notification: Notification;
   }
 }
-
-// declare type GlobalFetch = WindowOrWorkerGlobalScope;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Removes `@storybook` imports from all TS stories, and rewrites the Lightbox story to the new format.

## Motivation and Context

Our `.d.ts` files were including a `/// <reference types="@emotion/core" />` for some odd reason, which would break consumers build. Turns out Storybook is the cause of this, so we had to remove all Storybook references within TS files.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
