### PR TITLE
fix(DataTable): Add back 100% width cell style.

### DIFF
--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -532,6 +532,7 @@ export default withStyles(
     },
     row: {
       whiteSpace: 'normal',
+      width: '100%', // this is important for consumers who need full-width cells
     },
     expand_caret: {
       cursor: 'pointer',


### PR DESCRIPTION
to: @milesj @stefhatcher @schillerk 

## Description

This adds back a 100% width style to `DataTable` cells that was removed [here](https://github.com/airbnb/lunar/pull/173/files#diff-e7a1b99de444068e45a6cc8b0c4fe2c9L466).

## Motivation and Context

This is needed if consumers need 100% width cell content, it's not possible to override without hacking css selector style overrides in `withStyles` (i.e., a cell renderer cannot set its own `width: '100%'` to fix it).

## Testing

- [x] functional `DataTable` stories
- [ ] CI

## Screenshots

Didn't see any visual difference with examples with vs without this style.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
