### PR TITLE
fix(DataTable): Add back `propagateRef` prop.

### DIFF
--- a/packages/core/src/components/DataTable/index.tsx
+++ b/packages/core/src/components/DataTable/index.tsx
@@ -439,6 +439,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       dynamicRowHeight,
       expandable,
       filterData,
+      propagateRef,
       rowHeight,
       selectable,
       styles,
@@ -476,6 +477,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
               {this.shouldRenderTableHeader() && this.renderTableHeader(width)}
               <div className={cx(styles.table_container, { width })}>
                 <Table
+                  ref={propagateRef}
                   height={tableHeight}
                   width={this.props.width || width}
                   rowCount={expandedData.length}

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -761,6 +761,6 @@ describe('<DataTable />', () => {
     const ref = React.createRef<Table>();
     mountWithStyles(<DataTable data={data} propagateRef={ref} />);
 
-    expect(ref.current).toBeDefined();
+    expect(ref.current).not.toBeNull();
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @schillerk 

## Description

This adds back the `propagateRef` prop which was deleted [here](https://github.com/airbnb/lunar/pull/173/files#diff-e7a1b99de444068e45a6cc8b0c4fe2c9L411), and fixed the test for it which clearly did not work 😛 . 

## Motivation and Context

Don't break things.

## Testing

- [x] CI (verified fixed test failed when I remove the `ref` prop)

## Screenshots

NA

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
