### PR TITLE
update(NotchedBox): Update default background color to `color.accent.bg`.

### DIFF
--- a/packages/core/src/components/NotchedBox/index.tsx
+++ b/packages/core/src/components/NotchedBox/index.tsx
@@ -72,7 +72,7 @@ export default withStyles(({ ui, color, unit }) => {
       width: notchSide,
       height: notchSide,
       position: 'absolute',
-      backgroundColor: color.core.neutral[0],
+      backgroundColor: color.accent.bg,
       transform: `translate(${offset}px, ${offset}px) rotate(-45deg)`,
     },
 
@@ -94,7 +94,7 @@ export default withStyles(({ ui, color, unit }) => {
     content: {
       padding: NOTCH_SPACING * unit,
       position: 'relative',
-      backgroundColor: color.core.neutral[0],
+      backgroundColor: color.accent.bg,
       borderRadius,
     },
   };


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Currently, the default color is a light grey. For better contrast and theme consistency, updating to `color.accent.bg`.

## Testing

- story

## Screenshots

<img width="754" alt="Storybook 2019-10-11 13-19-21" src="https://user-images.githubusercontent.com/306275/66682456-077e2580-ec2a-11e9-8034-c698fbed083f.png">

<img width="644" alt="Screen Shot 2019-10-11 at 1 17 09 PM" src="https://user-images.githubusercontent.com/306275/66682474-106ef700-ec2a-11e9-861c-16726dc3a9e5.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
