### PR TITLE
fix(Dropdown): Omit styles from props before passing into cx

### DIFF
--- a/packages/core/src/components/Dropdown/index.tsx
+++ b/packages/core/src/components/Dropdown/index.tsx
@@ -87,6 +87,7 @@ class Dropdown extends React.PureComponent<Props & WithStylesProps> {
       zIndex,
       visible,
       onClickOutside,
+      styles, // do not pass the withStyles prop in
       ...props
     } = this.props;
     const style: Block = {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

withStyles passes in styles, and we do not omit it before passing props into the cx function.  For some reason this breaks dropdown on styleguide, because of some weirdness around them editing function prototypes.  

## Motivation and Context

Styleguide has some library that adds something weird to function prototypes, that cause circular reference to themselves, and the prefix function in aphrodite breaks on a circular reference.  Fixing this is the easiest way to fix that.  And it is a bug we are passing it in anyways.

## Testing

CI

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
