### PR TITLE
style(Accordion, AccordionItem): Remove accordion background color.

### DIFF
--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -42,7 +42,7 @@ export class AccordionItem extends React.Component<Props & WithStylesProps> {
     const { cx, bordered, children, expanded, id, noSpacing, styles, theme, title } = this.props;
 
     return (
-      <div className={cx(styles.item, bordered && styles.item_bordered)}>
+      <div className={cx(bordered && styles.item_bordered)}>
         <button
           className={cx(styles.title, noSpacing && styles.title_noSpacing)}
           aria-controls={`accordion-body-${id}`}
@@ -89,10 +89,6 @@ export default withStyles(
 
     body_expanded: {
       display: 'block',
-    },
-
-    item: {
-      background: color.accent.bg,
     },
 
     item_bordered: {

--- a/packages/core/src/components/Accordion/index.tsx
+++ b/packages/core/src/components/Accordion/index.tsx
@@ -71,7 +71,6 @@ export class Accordion extends React.Component<Props & WithStylesProps, State> {
 
 export default withStyles(({ color }) => ({
   container: {
-    background: color.accent.bg,
     borderBottom: '1px solid transparent',
     borderTop: '1px solid transparent',
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Remove background of `Accordion` and `AccordionItem`. This makes the background transparent.

## Motivation and Context

Want to be able to specify background color for accordions.

## Testing

Manual testing in style guide. No visual changes were found or expected.

## Screenshots

No change. Should be verified via happo as well.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
