### PR TITLE
style(DataTable): Adjust expanded row spacing.

### DIFF
--- a/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderSelectableColumn.tsx
@@ -4,19 +4,13 @@ import T from '../../Translate';
 import CheckBox from '../../CheckBox';
 import Spacing from '../../Spacing';
 import { ExpandedRow, SelectedRows, VirtualRow } from '../types';
-import {
-  SELECTION_OPTIONS,
-  SELECTABLE_COLUMN_WIDTH,
-  SELECTABLE_COLUMN_WIDTH_EXPANDABLE,
-} from '../constants';
+import { SELECTION_OPTIONS, SELECTABLE_COLUMN_WIDTH } from '../constants';
 
 export default function renderSelectableColumn(
   selectedRows: SelectedRows,
   handleSelection: (rowData: ExpandedRow) => () => void,
   expandable?: boolean,
 ) {
-  const width = expandable ? SELECTABLE_COLUMN_WIDTH_EXPANDABLE : SELECTABLE_COLUMN_WIDTH;
-
   const selectableCellRenderer = (row: VirtualRow) => {
     const { metadata } = row.rowData;
     const { originalIndex, parentOriginalIndex, isChild } = metadata;
@@ -37,11 +31,11 @@ export default function renderSelectableColumn(
       Object.prototype.hasOwnProperty.call(selectedRows, originalIndex) &&
       selectedRows[originalIndex].status === SELECTION_OPTIONS.HAS_ACTIVE_CHILD;
 
-    const indentSize = expandable ? 2.5 : 2;
-    const spacing = isChild || !expandable ? indentSize : 0;
+    const indentSize = expandable ? 3.5 : 2;
+    const spacing = isChild || !expandable ? indentSize : 0.5;
 
     return (
-      <Spacing all={0.5} left={spacing}>
+      <Spacing vertical={0.5} right={0.5} left={spacing}>
         <CheckBox
           hideLabel
           label={T.phrase(
@@ -60,5 +54,11 @@ export default function renderSelectableColumn(
     );
   };
 
-  return <Column dataKey="selected" cellRenderer={selectableCellRenderer} width={width} />;
+  return (
+    <Column
+      dataKey="selected"
+      cellRenderer={selectableCellRenderer}
+      width={SELECTABLE_COLUMN_WIDTH}
+    />
+  );
 }

--- a/packages/core/src/components/DataTable/constants.tsx
+++ b/packages/core/src/components/DataTable/constants.tsx
@@ -34,4 +34,3 @@ export const DEFAULT_WIDTH_PROPERTIES: WidthProperties = {
 export const EXPANDABLE_COLUMN_WIDTH = 50;
 
 export const SELECTABLE_COLUMN_WIDTH = 50;
-export const SELECTABLE_COLUMN_WIDTH_EXPANDABLE = 39;

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -380,7 +380,6 @@ aTableWithSelectableAndExandableRowsThatDisplaysSelectedRowsFirst.story = {
 export function aTableWithFilteredData() {
   return (
     <DataTable
-      expandable
       selectable
       tableHeaderLabel="My Engineer Table"
       data={getData()}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
In https://github.com/airbnb/lunar/commit/ed2b890250774c808d304afa760c8e3576b09775#diff-f4d5288f4170d90e1c9824f8504fd651

I messed up spacing for expanded rows by adding `all`. This is a quick fix to re-enable additional left margin.

<img width="741" alt="Screen Shot 2019-10-22 at 9 55 44 PM" src="https://user-images.githubusercontent.com/8676510/67359469-16ad7f00-f518-11e9-937c-38e58be78b3b.png">
<img width="880" alt="Screen Shot 2019-10-22 at 10 03 16 PM" src="https://user-images.githubusercontent.com/8676510/67359470-18774280-f518-11e9-9ead-9fab3c605726.png">


<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
