### PR TITLE
update(DataTable): Flip expanded row caret direction.

### DIFF
--- a/packages/core/src/components/ExpandableIcon/index.tsx
+++ b/packages/core/src/components/ExpandableIcon/index.tsx
@@ -17,8 +17,6 @@ export default function ExpandableIcon({ expanded, size }: Props) {
   const context = useContext(DirectionContext);
 
   return expanded ? (
-    <IconChevronDown decorative size={size} />
-  ) : (
     <DirectionalIcon
       decorative
       direction={Core.isRTL(context) ? 'left' : 'right'}
@@ -26,5 +24,7 @@ export default function ExpandableIcon({ expanded, size }: Props) {
       right={IconChevronRight}
       size={size}
     />
+  ) : (
+    <IconChevronDown decorative size={size} />
   );
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Previously carets faced right by default and down when rows are expanded. Eli tells me this is actually flipped and should be the opposite.

Here's the new orientation:
<img width="739" alt="Screen Shot 2019-10-22 at 10 11 25 PM" src="https://user-images.githubusercontent.com/8676510/67359741-fc27d580-f518-11e9-96c6-04fafaf250fe.png">
<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
