### PR TITLE
fix(DataTable): Enable rightAlign functionality in columnMetadata.

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -59,6 +59,7 @@ export default function ColumnLabels({
 
     const rightAlignmentStyle: React.CSSProperties = {
       justifyContent: 'flex-end',
+      width: '100%',
     };
 
     const newColumns = columns.map((col, idx) => {

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -177,7 +177,22 @@ export default {
 };
 
 export function aStandardTable() {
-  return <DataTable data={getData()} keys={['name', 'jobTitle', 'tenureDays']} />;
+  return (
+    <DataTable
+      data={getData()}
+      keys={['name', 'jobTitle', 'tenureDays']}
+      renderers={{
+        tenureDays: ({ row }: RendererProps<CustomShape>) => (
+          <div style={{ float: 'right', marginRight: -8 }}>{row.rowData.data.tenureDays}</div>
+        ),
+      }}
+      columnMetadata={{
+        tenureDays: {
+          rightAlign: 1,
+        },
+      }}
+    />
+  );
 }
 
 aStandardTable.story = {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
This functionality is required by several apps, but totally broken right now and very difficult to hack around since `columnToLabel` only gives you access to the header content, but not the arrows.


Before
<img width="1190" alt="Screen Shot 2019-10-24 at 2 20 34 AM" src="https://user-images.githubusercontent.com/8676510/67473156-0b854c80-f607-11e9-8ee8-0bce7236ebb6.png">

After
<img width="1180" alt="Screen Shot 2019-10-24 at 2 33 54 AM" src="https://user-images.githubusercontent.com/8676510/67473151-09bb8900-f607-11e9-9efc-6e52a150d711.png">



<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
