### PR TITLE
fix(Alert): Add word-break support for titles.

### DIFF
--- a/packages/core/src/components/Alert/index.tsx
+++ b/packages/core/src/components/Alert/index.tsx
@@ -157,6 +157,7 @@ export default withStyles(
       backgroundColor: color.accent.bg,
       overflow: 'hidden',
       padding: unit * 3,
+      wordBreak: 'break-word',
 
       ':before': {
         content: '" "',


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Seeing an issue with Alert nested in various flex and block level displays, mixed with a long character titles, the Alert is overflowing outside of its container. Adding `word-break: break-word` helps the title to wrap better in these cases.

## Motivation and Context

bug

## Testing

locally with storybook

## Screenshots

before:
<img width="416" alt="before" src="https://user-images.githubusercontent.com/306275/67722463-62d44580-f996-11e9-837e-66892d9c37ff.png">

after:
<img width="416" alt="after" src="https://user-images.githubusercontent.com/306275/67722464-62d44580-f996-11e9-9205-4016899980c4.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
