### PR TITLE
update(Table): Add `noWrap` prop.

### DIFF
--- a/packages/core/src/components/Table/index.tsx
+++ b/packages/core/src/components/Table/index.tsx
@@ -20,6 +20,8 @@ export type Props = {
   loading?: boolean;
   /** Applies verticalAlign: middle to child cells. */
   middleAlign?: boolean;
+  /** Disable responsive wrapper. */
+  noWrap?: boolean;
   /** Alternate row background color. */
   striped?: boolean;
   /** A unique name for tracking purposes. */
@@ -39,6 +41,7 @@ export class Table extends React.Component<Props & WithStylesProps> {
     horizontal: false,
     loading: false,
     middleAlign: false,
+    noWrap: false,
     striped: false,
     transparent: false,
     vertical: false,
@@ -54,6 +57,7 @@ export class Table extends React.Component<Props & WithStylesProps> {
       horizontal,
       loading,
       middleAlign,
+      noWrap,
       striped,
       styles,
       transparent,
@@ -61,7 +65,7 @@ export class Table extends React.Component<Props & WithStylesProps> {
     } = this.props;
 
     return (
-      <div className={cx(styles.responsive_wrapper)}>
+      <div className={cx(!noWrap && styles.responsive_wrapper)}>
         <table
           className={cx(
             styles.table,

--- a/packages/core/src/components/Table/story.tsx
+++ b/packages/core/src/components/Table/story.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Text from '../Text';
+import MenuToggle from '../MenuToggle';
+import { Item as MenuItem } from '../Menu';
 import Table, { Cell, Row } from '.';
 
 export default {
@@ -283,4 +285,59 @@ export function cellsWithCenteredContent() {
 
 cellsWithCenteredContent.story = {
   name: 'Cells with centered content.',
+};
+
+export function withoutResponsiveWrapper() {
+  return (
+    <Text>
+      <Table noWrap>
+        <thead>
+          <tr>
+            <th>One</th>
+            <th>Two</th>
+            <th>Three</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Title 1</td>
+            <td>Lorem ipsum dolor sit amet.</td>
+            <td>
+              <MenuToggle closeOnClick accessibilityLabel="Menu" toggleLabel="Actions">
+                <MenuItem>
+                  <Text>Item</Text>
+                </MenuItem>
+              </MenuToggle>
+            </td>
+          </tr>
+          <tr>
+            <td>Title 2</td>
+            <td>Lorem ipsum dolor sit amet.</td>
+            <td>
+              <MenuToggle closeOnClick accessibilityLabel="Menu" toggleLabel="Actions">
+                <MenuItem>
+                  <Text>Item</Text>
+                </MenuItem>
+              </MenuToggle>
+            </td>
+          </tr>
+          <tr>
+            <td>Title 3</td>
+            <td>Lorem ipsum dolor sit amet.</td>
+            <td>
+              <MenuToggle closeOnClick accessibilityLabel="Menu" toggleLabel="Actions">
+                <MenuItem>
+                  <Text>Item</Text>
+                </MenuItem>
+              </MenuToggle>
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+    </Text>
+  );
+}
+
+withoutResponsiveWrapper.story = {
+  name: 'Display a table without responsive wrapper (noWrap).',
 };

--- a/packages/core/test/components/Table.test.tsx
+++ b/packages/core/test/components/Table.test.tsx
@@ -62,4 +62,10 @@ describe('<Table />', () => {
 
     expect(wrapper.find('table').prop('className')).toMatch('content_middle_align');
   });
+
+  it('renders bordered', () => {
+    const wrapper = unwrap(<Table noWrap>Bordered</Table>);
+
+    expect(wrapper.find('div').prop('className')).toMatch('responsive_wrapper');
+  });
 });

--- a/packages/core/test/components/Table.test.tsx
+++ b/packages/core/test/components/Table.test.tsx
@@ -70,7 +70,7 @@ describe('<Table />', () => {
       expect(wrapper.find('div').prop('className')).toMatch('responsive_wrapper');
     });
 
-    it('renders wrapper', () => {
+    it('renders without wrapper', () => {
       const wrapper = unwrap(<Table noWrap>No Wrap</Table>);
 
       expect(wrapper.find('div').prop('className')).not.toMatch('responsive_wrapper');

--- a/packages/core/test/components/Table.test.tsx
+++ b/packages/core/test/components/Table.test.tsx
@@ -65,7 +65,7 @@ describe('<Table />', () => {
 
   describe('responsive wrapper', () => {
     it('renders wrapper', () => {
-      const wrapper = unwrap(<Table> Wrap</Table>);
+      const wrapper = unwrap(<Table>Wrap</Table>);
 
       expect(wrapper.find('div').prop('className')).toMatch('responsive_wrapper');
     });

--- a/packages/core/test/components/Table.test.tsx
+++ b/packages/core/test/components/Table.test.tsx
@@ -63,9 +63,17 @@ describe('<Table />', () => {
     expect(wrapper.find('table').prop('className')).toMatch('content_middle_align');
   });
 
-  it('renders bordered', () => {
-    const wrapper = unwrap(<Table noWrap>Bordered</Table>);
+  describe('responsive wrapper', () => {
+    it('renders wrapper', () => {
+      const wrapper = unwrap(<Table> Wrap</Table>);
 
-    expect(wrapper.find('div').prop('className')).toMatch('responsive_wrapper');
+      expect(wrapper.find('div').prop('className')).toMatch('responsive_wrapper');
+    });
+
+    it('renders wrapper', () => {
+      const wrapper = unwrap(<Table noWrap>No Wrap</Table>);
+
+      expect(wrapper.find('div').prop('className')).not.toMatch('responsive_wrapper');
+    });
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Add a flag to disable the responsive wrapper div's overflow rules.

## Motivation and Context

When I was rendering menus in my table, I was seeing overflow and clipping when these styles were enabled.

## Testing

Added a unit test that assets against rendered classnames.

## Screenshots

[See Slack thread]

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
