### PR TITLE
fix(MessageItem): Fix wrapping when author is loading.

### DIFF
--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -153,22 +153,56 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
     return avatar;
   }
 
+  getTitle() {
+    const {
+      cx,
+      disableTitleTranslation,
+      loadingAuthor,
+      title,
+      titleClickDescription,
+      onClickTitle,
+      styles,
+    } = this.props;
+
+    if (loadingAuthor) {
+      return <Shimmer width={150} height={14} />;
+    }
+
+    const formatedTitle = disableTitleTranslation ? (
+      <span className="notranslate">{title}</span>
+    ) : (
+      title
+    );
+
+    if (onClickTitle) {
+      return (
+        <button
+          className={cx(styles.resetButton)}
+          type="button"
+          title={titleClickDescription || title}
+          onClick={onClickTitle}
+          onMouseUp={removeFocusOnMouseUp}
+        >
+          <Text bold>{formatedTitle}</Text>
+        </button>
+      );
+    }
+
+    return <Text bold>{formatedTitle}</Text>;
+  }
+
   render() {
     const {
       cx,
       children,
-      disableTitleTranslation,
       email,
       formattedTimestamp,
       horizontalSpacing,
       important,
       info,
-      onClickTitle,
       sending,
       source,
       styles,
-      title,
-      titleClickDescription,
       titleTag,
       verticalSpacing,
       warning,
@@ -181,12 +215,6 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
           { context: 'Timestamp and source within a message bubble', key: 'lunar.message.source' },
         )
       : formattedTimestamp;
-
-    const formatedTitle = disableTitleTranslation ? (
-      <span className="notranslate">{title}</span>
-    ) : (
-      title
-    );
 
     return (
       <div
@@ -207,19 +235,7 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
             <Spacing bottom={0.5}>
               <div className={cx(styles.title)}>
                 <Spacing inline bottom={0.5} right={1}>
-                  {onClickTitle ? (
-                    <button
-                      className={cx(styles.resetButton)}
-                      type="button"
-                      title={titleClickDescription || title}
-                      onClick={onClickTitle}
-                      onMouseUp={removeFocusOnMouseUp}
-                    >
-                      <Text bold>{formatedTitle}</Text>
-                    </button>
-                  ) : (
-                    <Text bold>{formatedTitle}</Text>
-                  )}
+                  {this.getTitle()}
                 </Spacing>
 
                 {titleTag && (

--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -182,18 +182,6 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
         )
       : formattedTimestamp;
 
-    const striped = !!(important || info || warning);
-
-    const containerStyles = cx(
-      styles.container,
-      horizontalSpacing && styles.container_horizontalSpacing,
-      verticalSpacing && styles.container_verticalSpacing,
-      striped && styles.container_withStripe,
-      important && styles.container_important,
-      info && styles.container_info,
-      warning && styles.container_warning,
-    );
-
     const formatedTitle = disableTitleTranslation ? (
       <span className="notranslate">{title}</span>
     ) : (
@@ -201,7 +189,17 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
     );
 
     return (
-      <div className={containerStyles}>
+      <div
+        className={cx(
+          styles.container,
+          horizontalSpacing && styles.container_horizontalSpacing,
+          verticalSpacing && styles.container_verticalSpacing,
+          !!(important || info || warning) && styles.container_withStripe,
+          important && styles.container_important,
+          info && styles.container_info,
+          warning && styles.container_warning,
+        )}
+      >
         <div className={cx(styles.grid)}>
           <div className={cx(styles.relative)}>{this.getAvatar()}</div>
 

--- a/packages/core/src/components/MessageItem/index.tsx
+++ b/packages/core/src/components/MessageItem/index.tsx
@@ -82,89 +82,21 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
     warning: false,
   };
 
-  render() {
+  getAvatar() {
     const {
       cx,
-      children,
-      disableTitleTranslation,
-      email,
-      formattedTimestamp,
-      horizontalSpacing,
       icon,
       imageBadgeSrc,
       imageDescription,
       imageSrc,
-      important,
-      info,
       loadingAuthor,
-      onClickImage,
-      onClickTitle,
-      sending,
-      source,
-      styles,
       title,
-      titleClickDescription,
-      titleTag,
-      verticalSpacing,
-      warning,
+      onClickImage,
+      styles,
     } = this.props;
 
-    const timestamp = source
-      ? T.phrase(
-          '%{time} via %{source}',
-          { time: formattedTimestamp, source },
-          { context: 'Timestamp and source within a message bubble', key: 'lunar.message.source' },
-        )
-      : formattedTimestamp;
-
-    const striped = !!(important || info || warning);
-
-    const containerStyles = cx(
-      styles.container,
-      horizontalSpacing && styles.container_horizontalSpacing,
-      verticalSpacing && styles.container_verticalSpacing,
-      striped && styles.container_withStripe,
-      important && styles.container_important,
-      info && styles.container_info,
-      warning && styles.container_warning,
-    );
-
-    const formatedTitle = disableTitleTranslation ? (
-      <span className="notranslate">{title}</span>
-    ) : (
-      title
-    );
-
     if (loadingAuthor) {
-      return (
-        <div className={containerStyles}>
-          <div className={cx(styles.grid)}>
-            <div>
-              <Shimmer width={32} height={32} radius="50%" />
-            </div>
-
-            <div>
-              <Spacing bottom={0.5}>
-                <div className={cx(styles.title)}>
-                  <Spacing inline bottom={0.5} right={1}>
-                    <Shimmer width={175} height={14} />
-                  </Spacing>
-
-                  <Text small muted>
-                    {timestamp}
-                  </Text>
-                </div>
-
-                {email && <Shimmer height={12} width={225} />}
-              </Spacing>
-
-              {children}
-            </div>
-          </div>
-
-          {sending && <div className={cx(styles.sendingOverlay)} />}
-        </div>
-      );
+      return <Shimmer width={32} height={32} radius="50%" />;
     }
 
     let profilePhoto = null;
@@ -204,24 +136,74 @@ export class MessageItem extends React.Component<Props & WithStylesProps> {
       profilePhoto
     );
 
+    if (onClickImage) {
+      return (
+        <button
+          className={cx(styles.resetButton)}
+          type="button"
+          title={imageDescription || title}
+          onClick={onClickImage}
+          onMouseUp={removeFocusOnMouseUp}
+        >
+          {avatar}
+        </button>
+      );
+    }
+
+    return avatar;
+  }
+
+  render() {
+    const {
+      cx,
+      children,
+      disableTitleTranslation,
+      email,
+      formattedTimestamp,
+      horizontalSpacing,
+      important,
+      info,
+      onClickTitle,
+      sending,
+      source,
+      styles,
+      title,
+      titleClickDescription,
+      titleTag,
+      verticalSpacing,
+      warning,
+    } = this.props;
+
+    const timestamp = source
+      ? T.phrase(
+          '%{time} via %{source}',
+          { time: formattedTimestamp, source },
+          { context: 'Timestamp and source within a message bubble', key: 'lunar.message.source' },
+        )
+      : formattedTimestamp;
+
+    const striped = !!(important || info || warning);
+
+    const containerStyles = cx(
+      styles.container,
+      horizontalSpacing && styles.container_horizontalSpacing,
+      verticalSpacing && styles.container_verticalSpacing,
+      striped && styles.container_withStripe,
+      important && styles.container_important,
+      info && styles.container_info,
+      warning && styles.container_warning,
+    );
+
+    const formatedTitle = disableTitleTranslation ? (
+      <span className="notranslate">{title}</span>
+    ) : (
+      title
+    );
+
     return (
       <div className={containerStyles}>
         <div className={cx(styles.grid)}>
-          <div className={cx(styles.relative)}>
-            {onClickImage ? (
-              <button
-                className={cx(styles.resetButton)}
-                type="button"
-                title={imageDescription || title}
-                onClick={onClickImage}
-                onMouseUp={removeFocusOnMouseUp}
-              >
-                {avatar}
-              </button>
-            ) : (
-              avatar
-            )}
-          </div>
+          <div className={cx(styles.relative)}>{this.getAvatar()}</div>
 
           <div>
             <Spacing bottom={0.5}>

--- a/packages/core/test/components/MessageItem.test.tsx
+++ b/packages/core/test/components/MessageItem.test.tsx
@@ -32,7 +32,7 @@ describe('<MessageItem>', () => {
       </MessageItem>,
     );
 
-    expect(wrapper.find(Shimmer)).toHaveLength(1);
+    expect(wrapper.find(Shimmer)).toHaveLength(2);
   });
 
   it('renders a sending overlay when message is sending', () => {

--- a/packages/core/test/components/MessageItem.test.tsx
+++ b/packages/core/test/components/MessageItem.test.tsx
@@ -32,7 +32,7 @@ describe('<MessageItem>', () => {
       </MessageItem>,
     );
 
-    expect(wrapper.find(Shimmer)).toHaveLength(2);
+    expect(wrapper.find(Shimmer)).toHaveLength(1);
   });
 
   it('renders a sending overlay when message is sending', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

bug fix and small cleanup

## Motivation and Context

seeing an issue where when `loadingAuthor` is true, the content isn't wrapping the same as when loading is complete. with a small refactor, the layout and wrapping is the same regardless of author loading or not.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

bug:
<img width="399" alt="beforewrap" src="https://user-images.githubusercontent.com/306275/67724167-628a7900-f99b-11e9-8f1a-7a9b98d8a96d.png">

after:
<img width="399" alt="afterwrap" src="https://user-images.githubusercontent.com/306275/67724315-eb091980-f99b-11e9-844c-7f58fa41d52a.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
