### PR TITLE
new(DataTable): Add `sortByValue` accessor + `sortByCacheKey`

### DIFF
--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -120,8 +120,9 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortBy: string,
       sortDirection: SortDirectionType,
       selectedRows: SelectedRows,
+      maybeSortKey?: string,
     ): IndexedParentRow[] => {
-      const { selectedRowsFirst } = this.props;
+      const { selectedRowsFirst, sortByValue } = this.props;
       const indexedData = indexData(data);
       const sortedData = sortData(
         indexedData,
@@ -130,6 +131,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
         selectedRowsFirst!,
         sortBy,
         sortDirection,
+        sortByValue,
       );
 
       return sortedData;
@@ -138,10 +140,16 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   );
 
   componentDidUpdate(prevProps: DataTableProps, prevState: State) {
-    const { dynamicRowHeight, data, filterData, width, height } = this.props;
+    const { dynamicRowHeight, data, filterData, width, height, sortByCacheKey } = this.props;
     const { sortBy, sortDirection, selectedRows } = this.state;
     const dimensionsChanged = width !== prevProps.width || height !== prevProps.height;
-    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection, selectedRows);
+    const sortedData: IndexedParentRow[] = this.getData(
+      data!,
+      sortBy,
+      sortDirection,
+      selectedRows,
+      sortByCacheKey,
+    );
     const filteredData = filterData!(sortedData);
     const oldFilteredData = prevProps.filterData!(sortedData);
 
@@ -308,7 +316,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   };
 
   private handleChildSelection = (row: ExpandedRow) => {
-    const { data, selectCallback } = this.props;
+    const { data, selectCallback, sortByCacheKey } = this.props;
     const {
       selectedRows,
       sortBy,
@@ -319,7 +327,13 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortDirection: SortDirectionType;
     } = this.state;
 
-    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection, selectedRows);
+    const sortedData: IndexedParentRow[] = this.getData(
+      data!,
+      sortBy,
+      sortDirection,
+      selectedRows,
+      sortByCacheKey,
+    );
 
     const { parentOriginalIndex, parentIndex, originalIndex } = row.metadata;
 
@@ -449,11 +463,18 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       showAllRows,
       width,
       height,
+      sortByCacheKey,
     } = this.props;
 
     const { expandedRows, sortBy, sortDirection, editMode, selectedRows } = this.state;
 
-    const sortedData: IndexedParentRow[] = this.getData(data!, sortBy, sortDirection, selectedRows);
+    const sortedData: IndexedParentRow[] = this.getData(
+      data!,
+      sortBy,
+      sortDirection,
+      selectedRows,
+      sortByCacheKey,
+    );
 
     const filteredData = filterData!(sortedData);
 

--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -120,7 +120,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       sortBy: string,
       sortDirection: SortDirectionType,
       selectedRows: SelectedRows,
-      maybeSortKey?: string,
+      sortByCacheKey?: string, // used only in the memoize cache key below
     ): IndexedParentRow[] => {
       const { selectedRowsFirst, sortByValue } = this.props;
       const indexedData = indexData(data);

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -599,8 +599,8 @@ export function ATableWithDynamicSortKey() {
             setSortByKey(key as 'banana' | 'grape');
           }}
         >
-          <Tab key="banana" label="banana 🍌" />
           <Tab key="grape" label="grape 🍇" />
+          <Tab key="banana" label="banana 🍌" />
         </Tabs>
       </Spacing>
       <DataTable

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -13,8 +13,10 @@ import Button from '../Button';
 import Input from '../Input';
 import Row from '../Row';
 import Spacing from '../Spacing';
+import Text from '../Text';
 import { RendererProps, SelectedRows, IndexedParentRow } from './types';
 import { DataTable as StyledDataTable } from './DataTable';
+import Tabs, { Tab } from '../Tabs';
 
 type CustomShape = {
   name: string;
@@ -545,3 +547,82 @@ export function aComplexTableWithAllFeaturesEnabled() {
 aComplexTableWithAllFeaturesEnabled.story = {
   name: 'A complex table with all features enabled.',
 };
+
+const dynamicSortKeyData = [
+  {
+    data: {
+      banana: '🍌',
+      grape: '🍇🍇🍇🍇',
+    },
+  },
+  {
+    data: {
+      banana: '🍌🍌',
+      grape: '🍇🍇🍇',
+    },
+  },
+  {
+    data: {
+      banana: '🍌🍌🍌',
+      grape: '🍇🍇',
+    },
+  },
+  {
+    data: {
+      banana: '🍌🍌🍌🍌',
+      grape: '🍇',
+    },
+    metadata: {
+      children: [
+        {
+          data: {
+            banana: '🍌🍌🍌🍌🍌🍌🍌🍌',
+            grape: '🍇🍇🍇🍇🍇🍇🍇🍇',
+          },
+        },
+      ],
+    },
+  },
+];
+
+export function ATableWithDynamicSortKey() {
+  const [sortByKey, setSortByKey] = React.useState<'banana' | 'grape'>('grape');
+
+  return (
+    <>
+      <Text small>Select a sort key for the mixed column</Text>
+      <Spacing vertical={0.5}>
+        <Tabs
+          secondary
+          defaultKey={sortByKey}
+          onChange={key => {
+            setSortByKey(key as 'banana' | 'grape');
+          }}
+        >
+          <Tab key="banana" label="banana 🍌" />
+          <Tab key="grape" label="grape 🍇" />
+        </Tabs>
+      </Spacing>
+      <DataTable
+        expandable
+        showAllRows
+        showColumnDividers
+        showRowDividers
+        data={dynamicSortKeyData}
+        keys={['mix', 'banana', 'grape']}
+        renderers={{
+          banana: ({ row: { rowData } }) => <>{rowData.data.banana}</>,
+          grape: ({ row: { rowData } }) => <>{rowData.data.grape}</>,
+          mix: ({ row: { rowData } }) => <>{`${rowData.data.grape}${rowData.data.banana}`}</>,
+        }}
+        columnToLabel={{
+          mix: `Mix: Sorting on selection: "${sortByKey} ${sortByKey === 'banana' ? '🍌' : '🍇'}"`,
+          banana: 'Sort by 🍌',
+          grape: 'Sort by 🍇',
+        }}
+        sortByValue={({ data: d }, key) => d[key === 'mix' ? sortByKey : key]}
+        sortByCacheKey={sortByKey}
+      />
+    </>
+  );
+}

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -40,6 +40,8 @@ export type HeaderButton = {
 
 export type DefaultDataTableProps = keyof DataTableProps;
 
+export type SortByValueAccessor<T = GenericRow> = (rowData: T, columnKey: string) => unknown;
+
 export interface DataTableProps {
   /** If enabled height will be inferred from parent. */
   autoHeight?: boolean;
@@ -111,6 +113,10 @@ export interface DataTableProps {
   sortOverride?: boolean;
   /** sortBy value if override is enabled. */
   sortByOverride?: string;
+  /** Key used as part of the sort cache key, can be used to force re-sorting without a full sortOverride. */
+  sortByCacheKey?: string;
+  /** Given rowData and a column key, returns the value used for sorting rows. Defaults to rowData.data[columnKey]. */
+  sortByValue?: SortByValueAccessor;
   /** sortDirection value if override is enabled. */
   sortDirectionOverride?: SortDirectionType;
   /** sortCallback if override is enabled. */

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -502,6 +502,65 @@ describe('<DataTable /> renders and sorts data', () => {
 
     expect(text).toBe('Product Percy');
   });
+
+  it('should use the output of sortByValue for sorting', () => {
+    const sortByLowHigh = jest.fn(({ data: d }, key) => d[key]);
+    const sortByHighLow = jest.fn(({ data: d }, key) => -d[key]);
+
+    const table = mountWithStyles(
+      <DataTable
+        {...simpleProps}
+        sortOverride
+        expandable={false} // affects cell index
+        selectable={false}
+        sortByOverride="cats"
+        sortDirectionOverride="ASC"
+        sortByCacheKey={0}
+        keys={['cats']}
+        sortByValue={sortByLowHigh}
+      />,
+    );
+
+    expect(
+      getCell(table, 1, 1)
+        .find(Text)
+        .text(),
+    ).toBe('1');
+
+    table.setProps({ sortByValue: sortByHighLow, sortByCacheKey: 1 });
+
+    expect(
+      getCell(table, 1, 1)
+        .find(Text)
+        .text(),
+    ).toBe('3');
+  });
+
+  it('should re-sort upon sortCacheKey change', () => {
+    const sortByValue = jest.fn(() => 1);
+    const table = mountWithStyles(
+      <DataTable
+        {...simpleProps}
+        expandable={false} // affects cell index
+        selectable={false}
+        keys={['cats']}
+        sortByCacheKey={0}
+        sortByValue={sortByValue}
+      />,
+    );
+
+    const nameHeader = table.find('.ReactVirtualized__Table__headerColumn').first();
+    nameHeader.simulate('click');
+
+    const callCount = sortByValue.mock.calls.length;
+    expect(callCount).toBeGreaterThan(0);
+
+    table.setProps({ sortByCacheKey: 0 });
+    expect(sortByValue.mock.calls).toHaveLength(callCount);
+
+    table.setProps({ sortByCacheKey: 1 });
+    expect(sortByValue.mock.calls.length).toBeGreaterThan(callCount);
+  });
 });
 
 describe('<DataTable /> renders column labels', () => {

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -515,7 +515,7 @@ describe('<DataTable /> renders and sorts data', () => {
         selectable={false}
         sortByOverride="cats"
         sortDirectionOverride="ASC"
-        sortByCacheKey={0}
+        sortByCacheKey="a"
         keys={['cats']}
         sortByValue={sortByLowHigh}
       />,
@@ -527,7 +527,7 @@ describe('<DataTable /> renders and sorts data', () => {
         .text(),
     ).toBe('1');
 
-    table.setProps({ sortByValue: sortByHighLow, sortByCacheKey: 1 });
+    table.setProps({ sortByValue: sortByHighLow, sortByCacheKey: 'b' });
 
     expect(
       getCell(table, 1, 1)
@@ -541,10 +541,10 @@ describe('<DataTable /> renders and sorts data', () => {
     const table = mountWithStyles(
       <DataTable
         {...simpleProps}
-        expandable={false} // affects cell index
+        expandable={false}
         selectable={false}
         keys={['cats']}
-        sortByCacheKey={0}
+        sortByCacheKey="a"
         sortByValue={sortByValue}
       />,
     );
@@ -555,10 +555,11 @@ describe('<DataTable /> renders and sorts data', () => {
     const callCount = sortByValue.mock.calls.length;
     expect(callCount).toBeGreaterThan(0);
 
-    table.setProps({ sortByCacheKey: 0 });
+    // setting the same cache key should do nothing
+    table.setProps({ sortByCacheKey: 'a' });
     expect(sortByValue.mock.calls).toHaveLength(callCount);
 
-    table.setProps({ sortByCacheKey: 1 });
+    table.setProps({ sortByCacheKey: 'b' });
     expect(sortByValue.mock.calls.length).toBeGreaterThan(callCount);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher
cc: @schillerk 

## Motivation and Context

tl;dr **`DataTable` sorting + expanded rows are incompatible** in some cases

Currently `sortBy` values are static in `DataTable`, meaning that you cannot dynamically change the value used to determine the sort order of a cell. We have use cases where the value of a cell changes dynamically (without a `data` update), which should result in a new sort order.

The current options for updating the sort are either 
a) pass new `data` to the table with the column value 
b) handle sort in the parent with `sortOverride`, which also requires new `data`. 

The primary issue we've encountered with new `data` is that is clears expanded + selected rows (this is even more problematic when `dynamicRowHeight` is used). This (again) makes sorting + expanded rows incompatible.

## Description
This PR adds two props to `DataTable` to address the above limitation:
- `sortByValue: (rowData: T, columnKey: string) => unknown` is a new function that returns the value used for sorting rows, it defaults to the previous behavior of `rowData.data[columnKey]`
- `sortByCacheKey` Key used as part of the sorted data cache key, which can be used to force re-sorting without a full `sortOverride` (and the required new `data`).

It also adds a new story to demonstrate.

## Testing

- [x] CI
  - [x] new unit tests (WIP)

- [x] Functional new storybook example
  - [x] `sortByValue` determines sort order
  - [x] `sortByCacheKey` changes 
  - [x] `expandedRow` state is maintained across sorts

## Screenshots

New storybook example
![dynamic-sort-key](https://user-images.githubusercontent.com/4496521/67731874-d7b77780-f9b6-11e9-94eb-3b4187fe182d.gif)


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
