### PR TITLE
new(MenuToggle): Add muted menu option.

### DIFF
--- a/packages/core/src/components/MenuToggle/index.tsx
+++ b/packages/core/src/components/MenuToggle/index.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { childrenOfType } from 'airbnb-prop-types';
 import iconComponent from '../../prop-types/iconComponent';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
-import Button from '../Button';
+import BaseButton from '../Button';
+import MutedButton from '../MutedButton';
 import IconButton from '../IconButton';
 import ExpandableIcon from '../ExpandableIcon';
 import Dropdown, { Props as DropdownProps } from '../Dropdown';
@@ -27,6 +28,8 @@ export type Props = {
   large?: boolean;
   /** Props to pass to the `Menu` component. */
   menuProps?: Partial<MenuProps>;
+  /** Use muted button instead of primary button. */
+  muted?: boolean;
   /** Callback fired when the menu popover is closed. */
   onHide?: () => void;
   /** Callback fired when the menu popover is opened. */
@@ -131,6 +134,7 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
       inverted,
       large,
       menuProps,
+      muted,
       small,
       styles,
       toggleIcon,
@@ -144,6 +148,8 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
     } else if (small) {
       iconSize = '1em';
     }
+
+    const Button = muted ? MutedButton : BaseButton;
 
     return (
       <div ref={this.ref} className={cx(styles.container)}>

--- a/packages/core/src/components/MenuToggle/story.tsx
+++ b/packages/core/src/components/MenuToggle/story.tsx
@@ -145,3 +145,27 @@ export function withDisabled() {
 withDisabled.story = {
   name: 'With disabled.',
 };
+
+export function aBasicMutedMenuWithMenuItems() {
+  return (
+    <MenuToggle muted accessibilityLabel="Actions" toggleLabel="Actions" zIndex={10}>
+      {children}
+    </MenuToggle>
+  );
+}
+
+aBasicMutedMenuWithMenuItems.story = {
+  name: 'With muted.',
+};
+
+export function aBasicMutedInvertedMenuWithMenuItems() {
+  return (
+    <MenuToggle muted inverted accessibilityLabel="Actions" toggleLabel="Actions" zIndex={10}>
+      {children}
+    </MenuToggle>
+  );
+}
+
+aBasicMutedInvertedMenuWithMenuItems.story = {
+  name: 'With muted and inverted.',
+};

--- a/packages/core/test/components/MenuToggle.test.tsx
+++ b/packages/core/test/components/MenuToggle.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallowWithStyles } from '@airbnb/lunar-test-utils';
 import Button from '../../src/components/Button';
+import MutedButton from '../../src/components/MutedButton';
 import IconButton from '../../src/components/IconButton';
 import Dropdown from '../../src/components/Dropdown';
 import MenuToggle from '../../src/components/MenuToggle';
@@ -196,5 +197,15 @@ describe('<MenuToggle />', () => {
     );
 
     expect(wrapper.find(Button).prop('disabled')).toBe(true);
+  });
+
+  it('renders a muted button', () => {
+    const wrapper = shallowWithStyles(
+      <MenuToggle muted accessibilityLabel="Foo" toggleLabel="Foo">
+        <Item>Child</Item>
+      </MenuToggle>,
+    );
+
+    expect(wrapper.find(MutedButton)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

adds `muted` to change the button to a secondary, muted button.

## Motivation and Context

seeing it pop up in a few designs.

## Testing

storybook

## Screenshots


<img width="570" alt="Core : MenuToggle - A Basic Muted Menu With Menu Items ⋅ Storybook 2019-11-05 13-09-11" src="https://user-images.githubusercontent.com/306275/68246427-9a15a880-ffcd-11e9-9dff-63bb322a4400.png">

<img width="570" alt="Core : MenuToggle - A Basic Muted Inverted Menu With Menu Items ⋅ Storybook 2019-11-05 13-08-50" src="https://user-images.githubusercontent.com/306275/68246428-9a15a880-ffcd-11e9-8203-5fce78af3fbb.png">



## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
