### PR TITLE
fix(DataTable): Clear CellMeasureCache on sort change

### DIFF
--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -143,6 +143,10 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     const { dynamicRowHeight, data, filterData, width, height, sortByCacheKey } = this.props;
     const { sortBy, sortDirection, selectedRows } = this.state;
     const dimensionsChanged = width !== prevProps.width || height !== prevProps.height;
+    const sortChanged =
+      sortBy !== prevState.sortBy ||
+      sortDirection !== prevState.sortDirection ||
+      sortByCacheKey !== prevProps.sortByCacheKey;
     const sortedData: IndexedParentRow[] = this.getData(
       data!,
       sortBy,
@@ -152,7 +156,6 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     );
     const filteredData = filterData!(sortedData);
     const oldFilteredData = prevProps.filterData!(sortedData);
-
     const filteredDataChanged =
       filteredData.length > 0 &&
       (filteredData.length !== oldFilteredData.length ||
@@ -161,7 +164,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
             x.metadata.originalIndex !== oldFilteredData[i].metadata.originalIndex,
         ));
 
-    if (dynamicRowHeight && (filteredDataChanged || dimensionsChanged)) {
+    if (dynamicRowHeight && (filteredDataChanged || dimensionsChanged || sortChanged)) {
       // We need to make sure the cache is cleared before React tries to re-render.
       setTimeout(() => {
         this.cache.clearAll();

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -575,9 +575,12 @@ const dynamicSortKeyData = [
     metadata: {
       children: [
         {
+          // this tests dynamic rows
           data: {
-            banana: '🍌🍌🍌🍌🍌🍌🍌🍌',
-            grape: '🍇🍇🍇🍇🍇🍇🍇🍇',
+            banana:
+              '🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌🍌',
+            grape:
+              '🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇🍇',
           },
         },
       ],
@@ -608,6 +611,8 @@ export function ATableWithDynamicSortKey() {
         showAllRows
         showColumnDividers
         showRowDividers
+        dynamicRowHeight
+        minimumDynamicRowHeight={64}
         data={dynamicSortKeyData}
         keys={['mix', 'banana', 'grape']}
         renderers={{

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -40,7 +40,10 @@ export type HeaderButton = {
 
 export type DefaultDataTableProps = keyof DataTableProps;
 
-export type SortByValueAccessor<T extends GenericRow> = (row: T, columnKey: string) => unknown;
+export type SortByValueAccessor<T extends GenericRow = GenericRow> = (
+  row: T,
+  columnKey: string,
+) => unknown;
 
 export interface DataTableProps {
   /** If enabled height will be inferred from parent. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -40,7 +40,7 @@ export type HeaderButton = {
 
 export type DefaultDataTableProps = keyof DataTableProps;
 
-export type SortByValueAccessor<T = GenericRow> = (rowData: T, columnKey: string) => unknown;
+export type SortByValueAccessor<T extends GenericRow> = (row: T, columnKey: string) => unknown;
 
 export interface DataTableProps {
   /** If enabled height will be inferred from parent. */


### PR DESCRIPTION
to: @milesj @stefhatcher 
cc: @schillerk 

## Motivation and Context

This PR fixes another issue with dynamic row height + sorting 😭 The cell measure cache should be invalidated on sort change when `dynamicRowHeight` is used, otherwise you can end up with invalid row heights (see images below).

## Description

This just adds an additional check in `componentDidUpdate` to clear the cache if sorts were changed, and updates the story to demonstrate that it works.

## Testing

- [x] CI
- [x] functional in storybook (see screenshots)

## Screenshots

**Before**
(note the extra large row on top + clipped expanded row on bottom when the sort key is changed)
![dynamic-sort-key-row-size--before](https://user-images.githubusercontent.com/4496521/68251913-fcc07180-ffd8-11e9-84e3-8c06a4b2eef5.gif)

**After**
![dynamic-sort-key-row-size--after](https://user-images.githubusercontent.com/4496521/68251919-ff22cb80-ffd8-11e9-9e16-8b48d9edd510.gif)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
