### PR TITLE
fix(Storybook): Change webpack tsconfig path of Storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const glob = require('fast-glob');
 const webpack = require('webpack');
 const getChangelogFromGitHistory = require('./helpers/getChangelogFromGitHistory');
-const tsConfig = require('../tsconfig.options.json');
+const tsConfig = require('../tsconfig.json');
 
 module.exports = async ({ config }) => {
   const babelConfig = config.module.rules[0];


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
The tsconfig file path of storybook is not matching the file generated by nimbus, which make `storybook:build` fail.

## Motivation and Context
Can not build storybook with the wrong tsconfig file path.

## Testing

Tested in localhost by running `storybook:build`.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
