### PR TITLE
update: Refactor form components to use hooks

### DIFF
--- a/.storybook/addons/props/About.js
+++ b/.storybook/addons/props/About.js
@@ -38,16 +38,16 @@ export default class About extends React.Component {
   render() {
     const { changelog, name, metadata, storyPath } = this.props;
 
-    if (!metadata) {
+    if (!metadata || Object.keys(metadata).length === 0) {
       return <Placeholder>No component information found for {name}.</Placeholder>;
     }
 
-    const { description } = metadata.docgenInfo;
+    const info = metadata.docgenInfo || { description: '', props: {} };
     const requiredProps = [];
     const optionalProps = [];
     const alphaSort = (a, b) => a.name.localeCompare(b.name);
 
-    Object.values(metadata.docgenInfo.props).forEach(prop => {
+    Object.values(info.props).forEach(prop => {
       if (prop.description.includes('@ignore')) {
         return;
       }
@@ -69,9 +69,9 @@ export default class About extends React.Component {
           importPath={getImportPath(metadata.path, metadata.name)}
         />
 
-        {description && (
+        {info.description && (
           <Description>
-            <Markdown>{description}</Markdown>
+            <Markdown>{info.description}</Markdown>
           </Description>
         )}
 

--- a/packages/core/src/components/DatePickerInput/Input/index.tsx
+++ b/packages/core/src/components/DatePickerInput/Input/index.tsx
@@ -68,6 +68,12 @@ export default class PrivatePickerInput extends DayPickerInput {
     this.updateState(new Date(), this.props.formatDate(new Date()), this.hideAfterDayClick);
   };
 
+  private handleClickOutside = ({ target }: MouseEvent) => {
+    if (target !== this.input) {
+      this.hideDayPicker();
+    }
+  };
+
   renderOverlay = () => {
     const { dayPickerProps = {}, dropdownProps = {} } = this.props;
     const { selectedDays, value } = this.state;
@@ -86,12 +92,14 @@ export default class PrivatePickerInput extends DayPickerInput {
 
     return (
       <Dropdown
+        visible
         top="100%"
         tabIndex={0}
         zIndex={100}
         {...dropdownProps}
         onFocus={this.handleOverlayFocus}
         onBlur={this.handleOverlayBlur}
+        onClickOutside={this.handleClickOutside}
       >
         <DatePicker
           {...dayPickerProps}

--- a/packages/core/src/components/DatePickerInput/index.tsx
+++ b/packages/core/src/components/DatePickerInput/index.tsx
@@ -121,7 +121,7 @@ export default class DatePickerInput extends React.Component<Props, State> {
     return (
       <FormField {...fieldProps} id={id}>
         <PrivatePickerInput
-          keepFocus
+          keepFocus={false}
           value={restProps.value}
           dayPickerProps={pickerProps}
           dropdownProps={dropdownProps}

--- a/packages/core/src/components/DatePickerInput/story.tsx
+++ b/packages/core/src/components/DatePickerInput/story.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-expressions */
+
 import React from 'react';
 import Spacing from '../Spacing';
 import DatePickerInput from '.';
@@ -11,10 +13,17 @@ class DatePickerInputDemo extends React.Component<{}, State> {
     to: null,
   };
 
-  ref = React.createRef<HTMLInputElement>();
+  fromRef = React.createRef<HTMLInputElement>();
+
+  toRef = React.createRef<HTMLInputElement>();
 
   handleDayClick = () => {
-    window.setTimeout(() => this.ref.current && this.ref.current.focus(), 0);
+    this.toRef.current?.focus();
+    this.toRef.current?.click();
+
+    window.setTimeout(() => {
+      this.fromRef.current?.blur();
+    }, 5);
   };
 
   handleFromChange = (value: string, from: Date | null) => {
@@ -36,6 +45,7 @@ class DatePickerInputDemo extends React.Component<{}, State> {
             hideLabel
             label="From"
             name="from-date"
+            propagateRef={this.fromRef}
             placeholder="Start date"
             value={from || undefined}
             datePickerProps={{
@@ -55,7 +65,7 @@ class DatePickerInputDemo extends React.Component<{}, State> {
             hideLabel
             label="To"
             name="to-date"
-            propagateRef={this.ref}
+            propagateRef={this.toRef}
             placeholder="End date"
             value={to || undefined}
             datePickerProps={{

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -74,6 +74,8 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
   currentTooltipRef: HTMLDivElement | null = null;
 
+  mounted: boolean = false;
+
   rafHandle?: number;
 
   static getDerivedStateFromProps({ disabled }: Props) {
@@ -87,6 +89,8 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   }
 
   componentDidMount() {
+    this.mounted = true;
+
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({
       targetRect: document.body.getBoundingClientRect(),
@@ -100,6 +104,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   }
 
   componentWillUnmount() {
+    this.mounted = false;
     cancelAnimationFrame(this.rafHandle as number);
   }
 
@@ -108,7 +113,10 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     /* istanbul ignore next: refs are hard */
     this.rafHandle = requestAnimationFrame(() => {
       const el = this.currentTooltipRef;
-      this.setState({ tooltipHeight: el ? el.offsetHeight : 0 });
+
+      if (this.mounted) {
+        this.setState({ tooltipHeight: el ? el.offsetHeight : 0 });
+      }
     });
   }
 

--- a/packages/forms/src/components/Autocomplete.story.tsx
+++ b/packages/forms/src/components/Autocomplete.story.tsx
@@ -30,6 +30,8 @@ export function connectedToTheParentForm() {
         label="Label"
         accessibilityLabel="Autocomplete"
         validator={() => {}}
+        onChange={action('onChange')}
+        onSelectItem={action('onSelectItem')}
         onLoadItems={value =>
           Promise.resolve(items.filter(item => item.name.toLowerCase().match(value.toLowerCase())))
         }

--- a/packages/forms/src/components/CheckBox.story.tsx
+++ b/packages/forms/src/components/CheckBox.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <CheckBox name="field" label="Label" validator={() => {}} />
+      <CheckBox name="field" label="Label" validator={() => {}} onChange={action('onChange')} />
     </Form>
   );
 }

--- a/packages/forms/src/components/CheckBoxController.story.tsx
+++ b/packages/forms/src/components/CheckBoxController.story.tsx
@@ -18,7 +18,12 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <CheckBoxController name="field" label="Label" validator={() => {}}>
+      <CheckBoxController
+        name="field"
+        label="Label"
+        validator={() => {}}
+        onChange={action('onChange')}
+      >
         {CheckBox => (
           <div>
             <CheckBox label="❤️ Red" value="red" />

--- a/packages/forms/src/components/DateTimeSelect.story.tsx
+++ b/packages/forms/src/components/DateTimeSelect.story.tsx
@@ -25,6 +25,7 @@ export function connectedToTheParentForm() {
         label="Label"
         validator={() => {}}
         defaultValue={fixedDate.toISOString()}
+        onChange={action('onChange')}
       />
     </Form>
   );

--- a/packages/forms/src/components/FileInput.story.tsx
+++ b/packages/forms/src/components/FileInput.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <FileInput name="field" label="Label" validator={() => {}} />
+      <FileInput name="field" label="Label" validator={() => {}} onChange={action('onChange')} />
     </Form>
   );
 }

--- a/packages/forms/src/components/Form/Autocomplete.tsx
+++ b/packages/forms/src/components/Form/Autocomplete.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import BaseAutocomplete, { Props } from '@airbnb/lunar/lib/components/Autocomplete';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import BaseAutocomplete, { Props, Item } from '@airbnb/lunar/lib/components/Autocomplete';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `Autocomplete` automatically connected to the parent `Form`. */
-export function FormAutocomplete(props: Props & ConnectToFormProps<string>) {
-  return <BaseAutocomplete {...props} />;
-}
+export default function FormAutocomplete<T extends Item = Item>(
+  props: Props<T> & FieldProps<string>,
+) {
+  const fieldProps = useFormField<string, Props<T>>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormAutocomplete);
+  return <BaseAutocomplete<T> {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/Autocomplete.tsx
+++ b/packages/forms/src/components/Form/Autocomplete.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseAutocomplete, { Props, Item } from '@airbnb/lunar/lib/components/Autocomplete';
+import Autocomplete, { Props, Item } from '@airbnb/lunar/lib/components/Autocomplete';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -12,5 +12,5 @@ export default function FormAutocomplete<T extends Item = Item>(
     parse: toString,
   });
 
-  return <BaseAutocomplete<T> {...fieldProps} />;
+  return <Autocomplete<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Autocomplete.tsx
+++ b/packages/forms/src/components/Form/Autocomplete.tsx
@@ -5,9 +5,9 @@ import { toString } from '../../helpers';
 
 /** `Autocomplete` automatically connected to the parent `Form`. */
 export default function FormAutocomplete<T extends Item = Item>(
-  props: Props<T> & FieldProps<string>,
+  props: FieldProps<string, Props<T>>,
 ) {
-  const fieldProps = useFormField<string, Props<T>>(props, {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/CheckBox.tsx
+++ b/packages/forms/src/components/Form/CheckBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseCheckBox, { Props } from '@airbnb/lunar/lib/components/CheckBox';
+import CheckBox, { Props } from '@airbnb/lunar/lib/components/CheckBox';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
@@ -11,5 +11,5 @@ export default function FormCheckBox(props: FieldProps<boolean, Props>) {
     valueProp: 'checked',
   });
 
-  return <BaseCheckBox {...fieldProps} />;
+  return <CheckBox {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/CheckBox.tsx
+++ b/packages/forms/src/components/Form/CheckBox.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `CheckBox` automatically connected to the parent `Form`.  */
-export default function FormCheckBox(props: Props & FieldProps<boolean>) {
-  const fieldProps = useFormField<boolean, Props>(props, {
+export default function FormCheckBox(props: FieldProps<boolean, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: false,
     parse: toBool,
     valueProp: 'checked',

--- a/packages/forms/src/components/Form/CheckBox.tsx
+++ b/packages/forms/src/components/Form/CheckBox.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import BaseCheckBox, { Props } from '@airbnb/lunar/lib/components/CheckBox';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `CheckBox` automatically connected to the parent `Form`.  */
-export function FormCheckBox(props: Props & ConnectToFormProps<boolean>) {
-  return <BaseCheckBox {...props} />;
-}
+export default function FormCheckBox(props: Props & FieldProps<boolean>) {
+  const fieldProps = useFormField<boolean, Props>(props, {
+    initialValue: false,
+    parse: toBool,
+    valueProp: 'checked',
+  });
 
-export default connectToForm<boolean>({
-  initialValue: false,
-  parse: toBool,
-  valueProp: 'checked',
-})(FormCheckBox);
+  return <BaseCheckBox {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/CheckBoxController.tsx
+++ b/packages/forms/src/components/Form/CheckBoxController.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `CheckBoxController` automatically connected to the parent `Form`.  */
-export default function FormCheckBoxController(props: Props & FieldProps<string[]>) {
-  const fieldProps = useFormField<string[], Props>(props, {
+export default function FormCheckBoxController(props: FieldProps<string[], Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: [],
     multiple: true,
     parse: toString,

--- a/packages/forms/src/components/Form/CheckBoxController.tsx
+++ b/packages/forms/src/components/Form/CheckBoxController.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import BaseCheckBoxController, { Props } from '@airbnb/lunar/lib/components/CheckBoxController';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `CheckBoxController` automatically connected to the parent `Form`.  */
-export function FormCheckBoxController(props: Props & ConnectToFormProps<string[]>) {
-  return <BaseCheckBoxController {...props} />;
-}
+export default function FormCheckBoxController(props: Props & FieldProps<string[]>) {
+  const fieldProps = useFormField<string[], Props>(props, {
+    initialValue: [],
+    multiple: true,
+    parse: toString,
+  });
 
-export default connectToForm<string[]>({
-  initialValue: [],
-  multiple: true,
-  parse: toString,
-})(FormCheckBoxController);
+  return <BaseCheckBoxController {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/CheckBoxController.tsx
+++ b/packages/forms/src/components/Form/CheckBoxController.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseCheckBoxController, { Props } from '@airbnb/lunar/lib/components/CheckBoxController';
+import CheckBoxController, { Props } from '@airbnb/lunar/lib/components/CheckBoxController';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -11,5 +11,5 @@ export default function FormCheckBoxController(props: FieldProps<string[], Props
     parse: toString,
   });
 
-  return <BaseCheckBoxController {...fieldProps} />;
+  return <CheckBoxController {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -2,19 +2,21 @@ import React from 'react';
 import DatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
+function wrapHandler<T>(cb: (event: T) => void) {
+  return (event: T) => {
+    setTimeout(() => {
+      cb(event);
+    }, 0);
+  };
+}
+
 /** `DatePickerInput` automatically connected to the parent `Form`.  */
-export default function FormDatePickerInput(
-  // Blur and focus events provided by `final-form` break the picker
-  // overlay, so let's omit them for now, as it isn't an easy fix.
-  // Luckily, we can get away with this as it's mostly used for
-  // validation purposes, and dates are deterministic.
-  // onBlur,
-  // onFocus,
-  props: FieldProps<string | Date, Props>,
-) {
-  const fieldProps = useFormField(props, {
+export default function FormDatePickerInput(props: FieldProps<string | Date, Props>) {
+  const { onBlur, onFocus, ...fieldProps } = useFormField(props, {
     initialValue: '',
   });
 
-  return <DatePickerInput {...fieldProps} />;
+  return (
+    <DatePickerInput {...fieldProps} onBlur={wrapHandler(onBlur)} onFocus={wrapHandler(onFocus)} />
+  );
 }

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import DatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
+// The `react-day-picker` and `final-form` handlers collide a little bit,
+// so let's delay the forms to run after the picker.
 function wrapHandler<T>(cb: (event: T) => void) {
   return (event: T) => {
     setTimeout(() => {

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -3,16 +3,16 @@ import BaseDatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePic
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `DatePickerInput` automatically connected to the parent `Form`.  */
-export default function FormDatePickerInput({
+export default function FormDatePickerInput(
   // Blur and focus events provided by `final-form` break the picker
   // overlay, so let's omit them for now, as it isn't an easy fix.
   // Luckily, we can get away with this as it's mostly used for
   // validation purposes, and dates are deterministic.
   // onBlur,
   // onFocus,
-  ...props
-}: Props & FieldProps<string | Date>) {
-  const fieldProps = useFormField<string | Date, Props>(props, {
+  props: FieldProps<string | Date, Props>,
+) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
   });
 

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseDatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
+import DatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `DatePickerInput` automatically connected to the parent `Form`.  */
@@ -16,5 +16,5 @@ export default function FormDatePickerInput(
     initialValue: '',
   });
 
-  return <BaseDatePickerInput {...fieldProps} />;
+  return <DatePickerInput {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/DatePickerInput.tsx
+++ b/packages/forms/src/components/Form/DatePickerInput.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import BaseDatePickerInput, { Props } from '@airbnb/lunar/lib/components/DatePickerInput';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `DatePickerInput` automatically connected to the parent `Form`.  */
-export function FormDatePickerInput({
+export default function FormDatePickerInput({
   // Blur and focus events provided by `final-form` break the picker
   // overlay, so let's omit them for now, as it isn't an easy fix.
   // Luckily, we can get away with this as it's mostly used for
   // validation purposes, and dates are deterministic.
-  onBlur,
-  onFocus,
+  // onBlur,
+  // onFocus,
   ...props
-}: Props & ConnectToFormProps<string | Date>) {
-  return <BaseDatePickerInput {...props} />;
-}
+}: Props & FieldProps<string | Date>) {
+  const fieldProps = useFormField<string | Date, Props>(props, {
+    initialValue: '',
+  });
 
-export default connectToForm<string | Date>({
-  initialValue: '',
-})(FormDatePickerInput);
+  return <BaseDatePickerInput {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/DateTimeSelect.tsx
+++ b/packages/forms/src/components/Form/DateTimeSelect.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `DateTimeSelect` automatically connected to the parent `Form`.  */
-export default function FormDateTimeSelect(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormDateTimeSelect(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: new Date().toISOString(),
     parse: toString,
   });

--- a/packages/forms/src/components/Form/DateTimeSelect.tsx
+++ b/packages/forms/src/components/Form/DateTimeSelect.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import BaseDateTimeSelect, { Props } from '@airbnb/lunar/lib/components/DateTimeSelect';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `DateTimeSelect` automatically connected to the parent `Form`.  */
-export function FormDateTimeSelect(props: Props & ConnectToFormProps<string>) {
-  return <BaseDateTimeSelect {...props} />;
-}
+export default function FormDateTimeSelect(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: new Date().toISOString(),
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: new Date().toISOString(),
-  parse: toString,
-})(FormDateTimeSelect);
+  return <BaseDateTimeSelect {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/DateTimeSelect.tsx
+++ b/packages/forms/src/components/Form/DateTimeSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseDateTimeSelect, { Props } from '@airbnb/lunar/lib/components/DateTimeSelect';
+import DateTimeSelect, { Props } from '@airbnb/lunar/lib/components/DateTimeSelect';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -10,5 +10,5 @@ export default function FormDateTimeSelect(props: FieldProps<string, Props>) {
     parse: toString,
   });
 
-  return <BaseDateTimeSelect {...fieldProps} />;
+  return <DateTimeSelect {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseFileInput, { Props } from '@airbnb/lunar/lib/components/FileInput';
+import FileInput, { Props } from '@airbnb/lunar/lib/components/FileInput';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `FileInput` automatically connected to the parent `Form`.  */
@@ -9,5 +9,5 @@ export default function FormFileInput(props: FieldProps<File[], Props>) {
     ignoreValue: true,
   });
 
-  return <BaseFileInput {...fieldProps} />;
+  return <FileInput {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -3,8 +3,8 @@ import BaseFileInput, { Props } from '@airbnb/lunar/lib/components/FileInput';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `FileInput` automatically connected to the parent `Form`.  */
-export default function FormFileInput(props: Props & FieldProps<File[]>) {
-  const fieldProps = useFormField<File[], Props>(props, {
+export default function FormFileInput(props: FieldProps<File[], Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: [],
     ignoreValue: true,
   });

--- a/packages/forms/src/components/Form/FileInput.tsx
+++ b/packages/forms/src/components/Form/FileInput.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import BaseFileInput, { Props } from '@airbnb/lunar/lib/components/FileInput';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `FileInput` automatically connected to the parent `Form`.  */
-export function FormFileInput(props: Props & ConnectToFormProps<File[]>) {
-  return <BaseFileInput {...props} />;
-}
+export default function FormFileInput(props: Props & FieldProps<File[]>) {
+  const fieldProps = useFormField<File[], Props>(props, {
+    initialValue: [],
+    ignoreValue: true,
+  });
 
-export default connectToForm<File[]>({
-  initialValue: [],
-  ignoreValue: true,
-})(FormFileInput);
+  return <BaseFileInput {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/Input.tsx
+++ b/packages/forms/src/components/Form/Input.tsx
@@ -4,8 +4,8 @@ import { toString } from '../../helpers';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `Input` automatically connected to the parent `Form`.  */
-export default function FormInput(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormInput(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/Input.tsx
+++ b/packages/forms/src/components/Form/Input.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import BaseInput, { Props } from '@airbnb/lunar/lib/components/Input';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
 import { toString } from '../../helpers';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 
 /** `Input` automatically connected to the parent `Form`.  */
-export function FormInput(props: Props & ConnectToFormProps<string>) {
-  return <BaseInput {...props} />;
-}
+export default function FormInput(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormInput);
+  return <BaseInput {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/Input.tsx
+++ b/packages/forms/src/components/Form/Input.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseInput, { Props } from '@airbnb/lunar/lib/components/Input';
+import Input, { Props } from '@airbnb/lunar/lib/components/Input';
 import { toString } from '../../helpers';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 
@@ -10,5 +10,5 @@ export default function FormInput(props: FieldProps<string, Props>) {
     parse: toString,
   });
 
-  return <BaseInput {...fieldProps} />;
+  return <Input {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Multicomplete.tsx
+++ b/packages/forms/src/components/Form/Multicomplete.tsx
@@ -5,9 +5,9 @@ import { toString } from '../../helpers';
 
 /** `Multicomplete` automatically connected to the parent `Form`.  */
 export default function FormMulticomplete<T extends Item = Item>(
-  props: Props<T> & FieldProps<string[]>,
+  props: FieldProps<string[], Props<T>>,
 ) {
-  const fieldProps = useFormField<string[], Props<T>>(props, {
+  const fieldProps = useFormField(props, {
     initialValue: [],
     multiple: true,
     parse: toString,

--- a/packages/forms/src/components/Form/Multicomplete.tsx
+++ b/packages/forms/src/components/Form/Multicomplete.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseMulticomplete, { Props, Item } from '@airbnb/lunar/lib/components/Multicomplete';
+import Multicomplete, { Props, Item } from '@airbnb/lunar/lib/components/Multicomplete';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -13,5 +13,5 @@ export default function FormMulticomplete<T extends Item = Item>(
     parse: toString,
   });
 
-  return <BaseMulticomplete<T> {...fieldProps} />;
+  return <Multicomplete<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Multicomplete.tsx
+++ b/packages/forms/src/components/Form/Multicomplete.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import BaseMulticomplete, { Props } from '@airbnb/lunar/lib/components/Multicomplete';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import BaseMulticomplete, { Props, Item } from '@airbnb/lunar/lib/components/Multicomplete';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `Multicomplete` automatically connected to the parent `Form`.  */
-export function FormMulticomplete(props: Props & ConnectToFormProps<string[]>) {
-  return <BaseMulticomplete {...props} />;
-}
+export default function FormMulticomplete<T extends Item = Item>(
+  props: Props<T> & FieldProps<string[]>,
+) {
+  const fieldProps = useFormField<string[], Props<T>>(props, {
+    initialValue: [],
+    multiple: true,
+    parse: toString,
+  });
 
-export default connectToForm<string[]>({
-  initialValue: [],
-  multiple: true,
-  parse: toString,
-})(FormMulticomplete);
+  return <BaseMulticomplete<T> {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/RadioButtonController.tsx
+++ b/packages/forms/src/components/Form/RadioButtonController.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import BaseRadioButtonController, {
   Props,
 } from '@airbnb/lunar/lib/components/RadioButtonController';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `RadioButtonController` automatically connected to the parent `Form`.  */
-export function FormRadioButtonController(props: Props & ConnectToFormProps<string>) {
-  return <BaseRadioButtonController {...props} />;
-}
+export default function FormRadioButtonController(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormRadioButtonController);
+  return <BaseRadioButtonController {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/RadioButtonController.tsx
+++ b/packages/forms/src/components/Form/RadioButtonController.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import BaseRadioButtonController, {
-  Props,
-} from '@airbnb/lunar/lib/components/RadioButtonController';
+import RadioButtonController, { Props } from '@airbnb/lunar/lib/components/RadioButtonController';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -12,5 +10,5 @@ export default function FormRadioButtonController(props: FieldProps<string, Prop
     parse: toString,
   });
 
-  return <BaseRadioButtonController {...fieldProps} />;
+  return <RadioButtonController {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/RadioButtonController.tsx
+++ b/packages/forms/src/components/Form/RadioButtonController.tsx
@@ -6,8 +6,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `RadioButtonController` automatically connected to the parent `Form`.  */
-export default function FormRadioButtonController(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormRadioButtonController(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/Select.tsx
+++ b/packages/forms/src/components/Form/Select.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import BaseSelect, { Props } from '@airbnb/lunar/lib/components/Select';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `Select` automatically connected to the parent `Form`.  */
-export function FormSelect(props: Props & ConnectToFormProps<string>) {
-  return <BaseSelect {...props} />;
-}
+export default function FormSelect(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormSelect);
+  return <BaseSelect {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/Select.tsx
+++ b/packages/forms/src/components/Form/Select.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseSelect, { Props } from '@airbnb/lunar/lib/components/Select';
+import Select, { Props } from '@airbnb/lunar/lib/components/Select';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -10,5 +10,5 @@ export default function FormSelect(props: FieldProps<string, Props>) {
     parse: toString,
   });
 
-  return <BaseSelect {...fieldProps} />;
+  return <Select {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Select.tsx
+++ b/packages/forms/src/components/Form/Select.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `Select` automatically connected to the parent `Form`.  */
-export default function FormSelect(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormSelect(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/Switch.tsx
+++ b/packages/forms/src/components/Form/Switch.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import BaseSwitch, { Props } from '@airbnb/lunar/lib/components/Switch';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `Switch` automatically connected to the parent `Form`.  */
-export function FormSwitch(props: Props & ConnectToFormProps<boolean>) {
-  return <BaseSwitch {...props} />;
-}
+export default function FormSwitch(props: Props & FieldProps<boolean>) {
+  const fieldProps = useFormField<boolean, Props>(props, {
+    initialValue: false,
+    parse: toBool,
+    valueProp: 'checked',
+  });
 
-export default connectToForm<boolean>({
-  initialValue: false,
-  parse: toBool,
-  valueProp: 'checked',
-})(FormSwitch);
+  return <BaseSwitch {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/Switch.tsx
+++ b/packages/forms/src/components/Form/Switch.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `Switch` automatically connected to the parent `Form`.  */
-export default function FormSwitch(props: Props & FieldProps<boolean>) {
-  const fieldProps = useFormField<boolean, Props>(props, {
+export default function FormSwitch(props: FieldProps<boolean, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: false,
     parse: toBool,
     valueProp: 'checked',

--- a/packages/forms/src/components/Form/Switch.tsx
+++ b/packages/forms/src/components/Form/Switch.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseSwitch, { Props } from '@airbnb/lunar/lib/components/Switch';
+import Switch, { Props } from '@airbnb/lunar/lib/components/Switch';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
@@ -11,5 +11,5 @@ export default function FormSwitch(props: FieldProps<boolean, Props>) {
     valueProp: 'checked',
   });
 
-  return <BaseSwitch {...fieldProps} />;
+  return <Switch {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/TextArea.tsx
+++ b/packages/forms/src/components/Form/TextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseTextArea, { Props } from '@airbnb/lunar/lib/components/TextArea';
+import TextArea, { Props } from '@airbnb/lunar/lib/components/TextArea';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -10,5 +10,5 @@ export default function FormTextArea(props: FieldProps<string, Props>) {
     parse: toString,
   });
 
-  return <BaseTextArea {...fieldProps} />;
+  return <TextArea {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/TextArea.tsx
+++ b/packages/forms/src/components/Form/TextArea.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import BaseTextArea, { Props } from '@airbnb/lunar/lib/components/TextArea';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `TextArea` automatically connected to the parent `Form`.  */
-export function FormTextArea(props: Props & ConnectToFormProps<string>) {
-  return <BaseTextArea {...props} />;
-}
+export default function FormTextArea(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormTextArea);
+  return <BaseTextArea {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/TextArea.tsx
+++ b/packages/forms/src/components/Form/TextArea.tsx
@@ -4,8 +4,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `TextArea` automatically connected to the parent `Form`.  */
-export default function FormTextArea(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormTextArea(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/ToggleButtonController.tsx
+++ b/packages/forms/src/components/Form/ToggleButtonController.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import BaseToggleButtonController, {
   Props,
 } from '@airbnb/lunar/lib/components/ToggleButtonController';
-import connectToForm, { ConnectToFormProps } from '../../composers/connectToForm';
+import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `ToggleButtonController` automatically connected to the parent `Form`.  */
-export function FormToggleButtonController(props: Props & ConnectToFormProps<string>) {
-  return <BaseToggleButtonController {...props} />;
-}
+export default function FormToggleButtonController(props: Props & FieldProps<string>) {
+  const fieldProps = useFormField<string, Props>(props, {
+    initialValue: '',
+    parse: toString,
+  });
 
-export default connectToForm<string>({
-  initialValue: '',
-  parse: toString,
-})(FormToggleButtonController);
+  return <BaseToggleButtonController {...fieldProps} />;
+}

--- a/packages/forms/src/components/Form/ToggleButtonController.tsx
+++ b/packages/forms/src/components/Form/ToggleButtonController.tsx
@@ -6,8 +6,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `ToggleButtonController` automatically connected to the parent `Form`.  */
-export default function FormToggleButtonController(props: Props & FieldProps<string>) {
-  const fieldProps = useFormField<string, Props>(props, {
+export default function FormToggleButtonController(props: FieldProps<string, Props>) {
+  const fieldProps = useFormField(props, {
     initialValue: '',
     parse: toString,
   });

--- a/packages/forms/src/components/Form/ToggleButtonController.tsx
+++ b/packages/forms/src/components/Form/ToggleButtonController.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import BaseToggleButtonController, {
-  Props,
-} from '@airbnb/lunar/lib/components/ToggleButtonController';
+import ToggleButtonController, { Props } from '@airbnb/lunar/lib/components/ToggleButtonController';
 import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
@@ -12,5 +10,5 @@ export default function FormToggleButtonController(props: FieldProps<string, Pro
     parse: toString,
   });
 
-  return <BaseToggleButtonController {...fieldProps} />;
+  return <ToggleButtonController {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -356,15 +356,10 @@ export default class Form<Data extends object = {}> extends React.Component<
 
     field.data.config = config;
     // @ts-ignore
-    field.initial = value;
-    // @ts-ignore
     field.value = value;
     field.touched = config.validateDefaultValue || false;
-
-    /* eslint-disable no-param-reassign */
-    formState.initialValues = setIn(formState.initialValues!, name, value);
+    // eslint-disable-next-line no-param-reassign
     formState.values = setIn(formState.values, name, value);
-    /* eslint-enable no-param-reassign */
   }
 
   /**

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -356,10 +356,16 @@ export default class Form<Data extends object = {}> extends React.Component<
 
     field.data.config = config;
     // @ts-ignore
+    field.initial = value;
+    // @ts-ignore
     field.value = value;
     field.touched = config.validateDefaultValue || false;
-    // eslint-disable-next-line no-param-reassign
+
+    // These are needed for form "reset" to work correctly!
+    /* eslint-disable no-param-reassign */
+    formState.initialValues = setIn(formState.initialValues!, name, value);
     formState.values = setIn(formState.values, name, value);
+    /* eslint-enable no-param-reassign */
   }
 
   /**

--- a/packages/forms/src/components/FormActions/index.tsx
+++ b/packages/forms/src/components/FormActions/index.tsx
@@ -1,21 +1,13 @@
-import React, { useContext } from 'react';
-import { FormState } from 'final-form';
+import React from 'react';
 import BaseFormActions, { Props as BaseProps } from '@airbnb/lunar/lib/components/FormActions';
-import FormContext from '../FormContext';
+import useForm from '../../hooks/useForm';
 
 export type Props = Omit<BaseProps, 'disabled' | 'processing'>;
 
 /** `FormActions` automatically connected to the parent `Form`. */
 export default function FormActions(props: Props) {
-  const context = useContext(FormContext);
-  const baseProps: BaseProps = { ...props };
+  const form = useForm();
+  const { submitting, valid } = form.getState();
 
-  if (context) {
-    const { submitting, valid }: FormState<unknown> = context.getState();
-
-    baseProps.disabled = !valid;
-    baseProps.processing = submitting;
-  }
-
-  return <BaseFormActions {...baseProps} />;
+  return <BaseFormActions {...props} disabled={!valid} processing={submitting} />;
 }

--- a/packages/forms/src/components/Input.story.tsx
+++ b/packages/forms/src/components/Input.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <Input name="field" label="Label" validator={() => {}} />
+      <Input name="field" label="Label" validator={() => {}} onChange={action('onChange')} />
     </Form>
   );
 }

--- a/packages/forms/src/components/Multicomplete.story.tsx
+++ b/packages/forms/src/components/Multicomplete.story.tsx
@@ -30,6 +30,8 @@ export function connectedToTheParentForm() {
         label="Label"
         accessibilityLabel="Multicomplete"
         validator={() => {}}
+        onChange={action('onChange')}
+        onSelectItem={action('onSelectItem')}
         onLoadItems={value =>
           Promise.resolve(items.filter(item => item.name.toLowerCase().match(value.toLowerCase())))
         }

--- a/packages/forms/src/components/RadioButtonController.story.tsx
+++ b/packages/forms/src/components/RadioButtonController.story.tsx
@@ -18,7 +18,12 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <RadioButtonController name="field" label="Label" validator={() => {}}>
+      <RadioButtonController
+        name="field"
+        label="Label"
+        validator={() => {}}
+        onChange={action('onChange')}
+      >
         {RadioButton => (
           <div>
             <RadioButton label="❤️ Red" value="red" />

--- a/packages/forms/src/components/Select.story.tsx
+++ b/packages/forms/src/components/Select.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <Select name="field" label="Label" validator={() => {}}>
+      <Select name="field" label="Label" validator={() => {}} onChange={action('onChange')}>
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>
         <option value="baz">Baz</option>

--- a/packages/forms/src/components/Switch.story.tsx
+++ b/packages/forms/src/components/Switch.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <Switch name="field" label="Label" validator={() => {}} />
+      <Switch name="field" label="Label" validator={() => {}} onChange={action('onChange')} />
     </Form>
   );
 }

--- a/packages/forms/src/components/TextArea.story.tsx
+++ b/packages/forms/src/components/TextArea.story.tsx
@@ -18,7 +18,7 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <TextArea name="field" label="Label" validator={() => {}} />
+      <TextArea name="field" label="Label" validator={() => {}} onChange={action('onChange')} />
     </Form>
   );
 }

--- a/packages/forms/src/components/ToggleButtonController.story.tsx
+++ b/packages/forms/src/components/ToggleButtonController.story.tsx
@@ -19,7 +19,12 @@ export function connectedToTheParentForm() {
         return Promise.resolve();
       }}
     >
-      <ToggleButtonController name="field" label="Label" validator={() => {}}>
+      <ToggleButtonController
+        name="field"
+        label="Label"
+        validator={() => {}}
+        onChange={action('onChange')}
+      >
         {ControlledButton => (
           <ButtonGroup>
             <ControlledButton key="red" value="red">

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -8,7 +8,7 @@ import useFormField, {
   FieldProvidedProps,
 } from '../hooks/useFormField';
 
-if (__DEV__) {
+if (process.env.NODE_ENV === 'development') {
   // eslint-disable-next-line no-console
   console.warn(
     '`connectToForm` composer is deprecated. Please migrate to the `useFormField` hook.',

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -8,28 +8,27 @@ import useFormField, {
   FieldProvidedProps,
 } from '../hooks/useFormField';
 
-export type Options<T> = BaseOptions<T>;
-export type ConnectToFormProps<T> = FieldProvidedProps<T>;
-export type ConnectToFormWrapperProps<T> = FieldInternalProps<T>;
-
 if (__DEV__) {
+  // eslint-disable-next-line no-console
   console.warn(
     '`connectToForm` composer is deprecated. Please migrate to the `useFormField` hook.',
   );
 }
 
+export type Options<T> = BaseOptions<T>;
+export type ConnectToFormProps<T> = FieldProvidedProps<T>;
+export type ConnectToFormWrapperProps<T> = FieldInternalProps<T>;
+
 export default function connectToForm<T>(options: Options<T>) /* infer */ {
   return function connectToFormFactory<P>(
-    WrappedComponent: React.ComponentType<FieldProps<T, P>>,
-  ): React.ComponentType<FieldReturnProps<T, P>> {
+    WrappedComponent: React.ComponentType<FieldReturnProps<T, P>>,
+  ): React.ComponentType<FieldProps<T, P>> {
     function ConnectToForm(props: FieldProps<T, P>) {
       const fieldProps = useFormField<T, P>(props, options);
 
-      // @ts-ignore
       return <WrappedComponent {...fieldProps} />;
     }
 
-    // @ts-ignore
     return finishHOC('connectToForm', ConnectToForm, WrappedComponent);
   };
 }

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -1,263 +1,35 @@
-import React, { useContext } from 'react';
-import omit from 'lodash/omit';
-import { fieldSubscriptionItems, FieldState, Unsubscribe } from 'final-form';
+import React from 'react';
 import finishHOC from '@airbnb/lunar/lib/utils/finishHOC';
-import FormContext from '../components/FormContext';
-import { Context, Parse, Field, DefaultValue } from '../types';
+import useFormField, {
+  Options as BaseOptions,
+  FieldProps,
+  FieldReturnProps,
+  FieldInternalProps,
+  FieldProvidedProps,
+} from '../hooks/useFormField';
 
-// Keep in sync with props!
-export const PROP_NAMES = [
-  'defaultValue',
-  'form',
-  'isEqual',
-  'name',
-  'onBatchChange',
-  'onBlur',
-  'onChange',
-  'onFocus',
-  'onStateUpdate',
-  'parse',
-  'subscriptions',
-  'unregisterOnUnmount',
-  'validateDefaultValue',
-  'validateFields',
-  'validator',
-];
+export type Options<T> = BaseOptions<T>;
+export type ConnectToFormProps<T> = FieldProvidedProps<T>;
+export type ConnectToFormWrapperProps<T> = FieldInternalProps<T>;
 
-// Our composer provides implementations for a few critical props
-// in the wrapped component, so we need to remove them.
-// Otherwise they would collide with the underlying implementation.
-export type RemoveWrappedProps<P> = Omit<P, 'defaultValue' | 'onChange'>;
-
-export type Options<T> = {
-  ignoreValue?: boolean;
-  initialValue: T;
-  multiple?: boolean;
-  parse?: Parse<T>;
-  valueProp?: 'value' | 'checked';
-};
-
-export interface ConnectToFormProps<T> {
-  name: string;
-  invalid: boolean;
-  errorMessage: string;
-  field: FieldState<T>;
-  onBlur: (event: React.FocusEvent) => void;
-  onChange: (value: T, ...args: any[]) => void;
-  onFocus: (event: React.FocusEvent) => void;
-  value?: T;
-  checked?: boolean;
-}
-
-export interface ConnectToFormWrapperProps<T> extends Field<T> {
-  onBatchChange?: (value: T) => object | undefined;
-  onBlur?: (event: React.FocusEvent) => void;
-  onChange?: (value: T, ...args: any[]) => void;
-  onFocus?: (event: React.FocusEvent) => void;
-  onStateUpdate?: (state: FieldState<T>) => void;
-  unregisterOnUnmount?: boolean;
-}
-
-export interface ConnectToFormState<T> extends Required<FieldState<T>> {
-  name: string;
+if (__DEV__) {
+  console.warn(
+    '`connectToForm` composer is deprecated. Please migrate to the `useFormField` hook.',
+  );
 }
 
 export default function connectToForm<T>(options: Options<T>) /* infer */ {
-  const {
-    ignoreValue = false,
-    initialValue,
-    multiple = false,
-    parse,
-    valueProp = 'value',
-  } = options;
+  return function connectToFormFactory<P>(
+    WrappedComponent: React.ComponentType<FieldProps<T, P>>,
+  ): React.ComponentType<FieldReturnProps<T, P>> {
+    function ConnectToForm(props: FieldProps<T, P>) {
+      const fieldProps = useFormField<T, P>(props, options);
 
-  return function connectToFormFactory<Props extends object = {}>(
-    WrappedComponent: React.ComponentType<Props & ConnectToFormProps<T>>,
-  ): React.ComponentType<RemoveWrappedProps<Props> & ConnectToFormWrapperProps<T>> {
-    type OwnProps = RemoveWrappedProps<Props> & ConnectToFormWrapperProps<T>;
-
-    class ConnectToForm extends React.Component<
-      OwnProps & { form: Context },
-      ConnectToFormState<T>
-    > {
-      static defaultProps = {
-        defaultValue: initialValue,
-        parse,
-        subscriptions: fieldSubscriptionItems,
-        unregisterOnUnmount: false,
-        validateDefaultValue: false,
-        validateFields: [],
-      };
-
-      // https://github.com/final-form/final-form#fieldstate
-      // @ts-ignore Other non-critical fields get set on mount
-      state: ConnectToFormState<T> = {
-        blur() {},
-        error: '',
-        focus() {},
-        invalid: false,
-        touched: false,
-        name: this.props.name,
-        value: this.props.defaultValue!,
-      };
-
-      private mounted: boolean = false;
-
-      private unregister: Unsubscribe | null = null;
-
-      componentDidMount() {
-        this.mounted = true;
-
-        // Register the form after the mounted boolean above is set.
-        // Otherwise form data will be lost in `handleUpdate` when the
-        // component is unmounted and mounted again.
-        this.unregister = this.props.form.register(this.props, this.handleUpdate);
-      }
-
-      componentDidUpdate(prevProps: OwnProps & { form: Context }) {
-        // A name change is quite disruptive, so let's unregister and register again to be safe.
-        // If this is causing issues in userland, add a unique key prop to each field.
-        if (this.props.name !== prevProps.name && this.unregister) {
-          this.unregister();
-          this.unregister = this.props.form.register(this.props, this.handleUpdate);
-
-          return;
-        }
-
-        if (this.props.defaultValue !== prevProps.defaultValue) {
-          this.setState(
-            {
-              value: this.props.defaultValue!,
-            },
-            () => {
-              if (typeof this.props.defaultValue === 'string') {
-                this.props.form.change(this.props.name, this.props.defaultValue, {});
-              }
-            },
-          );
-        }
-      }
-
-      componentWillUnmount() {
-        this.mounted = false;
-
-        if (this.props.unregisterOnUnmount && this.unregister) {
-          this.unregister();
-        }
-      }
-
-      formatError(error: string | Error): string {
-        if (!error) {
-          return '';
-        }
-
-        return error instanceof Error ? error.message : String(error);
-      }
-
-      formatValue(defaultValue: DefaultValue<T>) {
-        const cast = this.props.parse as Parse<T> | undefined;
-        let value = defaultValue;
-
-        // Some fields dont use the value, so wont have a parser
-        if (!cast) {
-          return value;
-        }
-
-        if (multiple && !Array.isArray(value)) {
-          // @ts-ignore Some consumers use arrays, so handle it custom here
-          value = [value] as string[];
-        }
-
-        if (Array.isArray(value)) {
-          return value.map(cast);
-        }
-
-        // @ts-ignore Typing this is very difficult
-        return cast(value);
-      }
-
-      omitFormProps(props: Partial<OwnProps>): Props {
-        return omit(props, PROP_NAMES) as Props;
-      }
-
-      private handleBlur = (event: React.FocusEvent) => {
-        this.state.blur();
-
-        if (this.props.onBlur) {
-          this.props.onBlur(event);
-        }
-      };
-
-      private handleChange = (
-        checkedOrValue: T,
-        valueOrEvent: T | React.ChangeEvent<unknown>,
-        event?: React.ChangeEvent,
-      ) => {
-        this.props.form.change(
-          this.props.name,
-          checkedOrValue,
-          this.props.onBatchChange ? this.props.onBatchChange(checkedOrValue) : {},
-        );
-
-        if (this.props.onChange) {
-          this.props.onChange(checkedOrValue, valueOrEvent, event);
-        }
-      };
-
-      private handleFocus = (event: React.FocusEvent) => {
-        this.state.focus();
-
-        if (this.props.onFocus) {
-          this.props.onFocus(event);
-        }
-      };
-
-      // istanbul ignore next
-      private handleUpdate = (state: FieldState<T>) => {
-        if (!this.mounted) {
-          return;
-        }
-
-        this.setState(
-          prevState => ({
-            ...prevState,
-            ...state,
-          }),
-          () => {
-            if (this.props.onStateUpdate) {
-              this.props.onStateUpdate(state);
-            }
-          },
-        );
-      };
-
-      render() {
-        const { error, invalid, touched, name, value } = this.state;
-        const props: ConnectToFormProps<T> = {
-          name,
-          invalid: touched ? invalid : false,
-          errorMessage: touched ? this.formatError(error) : '',
-          field: this.state,
-          onBlur: this.handleBlur,
-          onChange: this.handleChange,
-          onFocus: this.handleFocus,
-        };
-
-        if (!ignoreValue) {
-          props[valueProp as 'value'] = this.formatValue(value) as T;
-        }
-
-        return <WrappedComponent {...this.omitFormProps(this.props)} {...props} />;
-      }
+      // @ts-ignore
+      return <WrappedComponent {...fieldProps} />;
     }
 
-    function ConnectToFormWrapper(props: OwnProps) {
-      const form = useContext(FormContext);
-
-      // @ts-ignore Props spreading
-      return form ? <ConnectToForm {...props} form={form} /> : null;
-    }
-
-    return finishHOC('connectToForm', ConnectToFormWrapper, WrappedComponent);
+    // @ts-ignore
+    return finishHOC('connectToForm', ConnectToForm, WrappedComponent);
   };
 }

--- a/packages/forms/src/hooks/useForm.tsx
+++ b/packages/forms/src/hooks/useForm.tsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import FormContext from '../components/FormContext';
+import { Context } from '../types';
+
+export default function useForm(): Context {
+  const form = useContext(FormContext);
+
+  if (!form && __DEV__) {
+    throw new Error('The `useForm` hook must be called within a `<Form />`.');
+  }
+
+  return form!;
+}

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -152,18 +152,21 @@ export default function useFormField<T, P>(
   }, [name]);
 
   // Change value in form if default value changes
-  useEffect(() => {
-    if (defaultValue) {
-      setField(prevField => ({
-        ...prevField,
-        value: defaultValue,
-      }));
+  useEffect(
+    () => {
+      if (defaultValue) {
+        setField(prevField => ({
+          ...prevField,
+          value: defaultValue,
+        }));
 
-      form.change(name, defaultValue);
-    }
+        form.change(name, defaultValue);
+      }
+    },
     // We only want to update value when default value changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultValue]);
+    Array.isArray(defaultValue) ? [...defaultValue] : [defaultValue],
+  );
 
   return {
     ...((restProps as unknown) as P),

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -151,23 +151,6 @@ export default function useFormField<T, P>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
 
-  // Change value in form if default value changes
-  useEffect(
-    () => {
-      if (defaultValue) {
-        setField(prevField => ({
-          ...prevField,
-          value: defaultValue,
-        }));
-
-        form.change(name, defaultValue);
-      }
-    },
-    // We only want to update value when default value changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    Array.isArray(defaultValue) ? [...defaultValue] : [defaultValue],
-  );
-
   return {
     ...((restProps as unknown) as P),
     errorMessage: field.touched ? formatError(field.error) : '',

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -70,7 +70,7 @@ export default function useFormField<T, P = {}>(
     parse: defaultParse,
     valueProp = 'value',
   }: Options<T>,
-): P & FieldProvidedProps<T> {
+): Omit<P, keyof FieldProps<T>> & FieldProvidedProps<T> {
   const {
     defaultValue = initialValue,
     isEqual,

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { FieldState, fieldSubscriptionItems, Unsubscribe } from 'final-form';
+import shallowEqual from 'shallowequal';
 import { Parse, Field, DefaultValue } from '../types';
 import useForm from './useForm';
 
@@ -104,6 +105,7 @@ export default function useFormField<T, P>(
     value: defaultValue!,
   });
   const fieldName = useRef(name);
+  const fieldDefaultValue = useRef(defaultValue);
   const unregister = useRef<Unsubscribe>();
 
   // Register field in parent form
@@ -150,6 +152,19 @@ export default function useFormField<T, P>(
     // We only want to register/unregister fields when the name changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
+
+  // Change value in form if default value changes
+  useEffect(
+    () => {
+      if (defaultValue && !shallowEqual(defaultValue, fieldDefaultValue.current)) {
+        form.change(name, defaultValue);
+        fieldDefaultValue.current = defaultValue;
+      }
+    },
+    // We only want to update the value when the default value changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    Array.isArray(defaultValue) ? [...defaultValue] : [defaultValue],
+  );
 
   return {
     ...((restProps as unknown) as P),

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useState } from 'react';
+import { FieldState, fieldSubscriptionItems } from 'final-form';
+import { Parse, Field, DefaultValue } from '../types';
+import useForm from './useForm';
+
+export type Options<T> = {
+  ignoreValue?: boolean;
+  initialValue: T;
+  multiple?: boolean;
+  parse?: Parse<T>;
+  valueProp?: 'value' | 'checked';
+};
+
+export interface FieldProps<T> extends Field<T> {
+  onBatchChange?: (value: T) => object | undefined;
+  onBlur?: (event: React.FocusEvent) => void;
+  onChange?: (value: T, ...args: any[]) => void;
+  onFocus?: (event: React.FocusEvent) => void;
+  onStateUpdate?: (state: FieldState<T>) => void;
+  unregisterOnUnmount?: boolean;
+}
+
+export interface FieldProvidedProps<T> {
+  name: string;
+  invalid: boolean;
+  errorMessage: string;
+  field: FieldState<T>;
+  onBlur: (event: React.FocusEvent) => void;
+  onChange: (value: T, ...args: any[]) => void;
+  onFocus: (event: React.FocusEvent) => void;
+  value?: T;
+  checked?: boolean;
+}
+
+function formatError(error: string | Error): string {
+  if (!error) {
+    return '';
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatValue<T>(defaultValue: DefaultValue<T>, multiple: boolean, cast?: Parse<T>) {
+  let value = defaultValue;
+
+  // Some fields dont use the value, so wont have a parser
+  if (!cast) {
+    return value;
+  }
+
+  if (multiple && !Array.isArray(value)) {
+    // @ts-ignore Some consumers use arrays, so handle it custom here
+    value = [value] as string[];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(cast);
+  }
+
+  // @ts-ignore Typing this is very difficult
+  return cast(value);
+}
+
+export default function useFormField<T, P = {}>(
+  props: P & FieldProps<T>,
+  {
+    ignoreValue = false,
+    initialValue,
+    multiple = false,
+    parse: defaultParse,
+    valueProp = 'value',
+  }: Options<T>,
+): P & FieldProvidedProps<T> {
+  const {
+    defaultValue = initialValue,
+    isEqual,
+    name,
+    onBatchChange,
+    onBlur,
+    onChange,
+    onFocus,
+    onStateUpdate,
+    parse = defaultParse,
+    subscriptions = fieldSubscriptionItems,
+    unregisterOnUnmount,
+    validateDefaultValue = false,
+    validateFields = [],
+    validator,
+    ...restProps
+  } = props;
+  const form = useForm();
+  const [field, setField] = useState<FieldState<T>>({
+    change() {},
+    blur() {},
+    error: '',
+    focus() {},
+    invalid: false,
+    touched: false,
+    name,
+    value: defaultValue!,
+  });
+
+  // Register field in parent form
+  useEffect(() => {
+    let mounted = true;
+
+    const unregister = form.register(
+      {
+        defaultValue,
+        isEqual,
+        name,
+        parse,
+        subscriptions: subscriptions as Field<T>['subscriptions'],
+        validateDefaultValue,
+        validateFields,
+        validator,
+      },
+      state => {
+        if (mounted) {
+          setField(prevField => ({
+            ...prevField,
+            ...state,
+          }));
+        }
+
+        if (onStateUpdate) {
+          onStateUpdate(state);
+        }
+      },
+    );
+
+    return () => {
+      mounted = false;
+
+      if (unregisterOnUnmount) {
+        unregister();
+      }
+    };
+  }, [name]);
+
+  // Handlers
+  const handleBlur = (event: React.FocusEvent) => {
+    field.blur();
+
+    if (onBlur) {
+      onBlur(event);
+    }
+  };
+
+  const handleChange = (
+    checkedOrValue: T,
+    valueOrEvent: T | React.ChangeEvent<unknown>,
+    event?: React.ChangeEvent,
+  ) => {
+    form.change(name, checkedOrValue, onBatchChange ? onBatchChange(checkedOrValue) : {});
+
+    if (onChange) {
+      onChange(checkedOrValue, valueOrEvent, event);
+    }
+  };
+
+  const handleFocus = (event: React.FocusEvent) => {
+    field.focus();
+
+    if (onFocus) {
+      onFocus(event);
+    }
+  };
+
+  // Return new props
+  const nextProps: FieldProvidedProps<T> = {
+    name,
+    invalid: field.touched ? field.invalid! : false,
+    errorMessage: field.touched ? formatError(field.error) : '',
+    field,
+    onBlur: handleBlur,
+    onChange: handleChange,
+    onFocus: handleFocus,
+  };
+
+  if (!ignoreValue) {
+    nextProps[valueProp as 'value'] = formatValue(field.value, multiple, parse) as T;
+  }
+
+  // @ts-ignore
+  return {
+    ...restProps,
+    ...nextProps,
+  };
+}

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -11,7 +11,9 @@ export type Options<T> = {
   valueProp?: 'value' | 'checked';
 };
 
-export interface FieldProps<T> extends Field<T> {
+export type FieldProps<T, P> = Omit<P, 'defaultValue' | 'onChange'> & FieldInternalProps<T>;
+
+export interface FieldInternalProps<T> extends Field<T> {
   onBatchChange?: (value: T) => object | undefined;
   onBlur?: (event: React.FocusEvent) => void;
   onChange?: (value: T, ...args: any[]) => void;
@@ -61,8 +63,8 @@ function formatValue<T>(defaultValue: DefaultValue<T>, multiple: boolean, cast?:
   return cast(value);
 }
 
-export default function useFormField<T, P = {}>(
-  props: P & FieldProps<T>,
+export default function useFormField<T, P>(
+  props: FieldProps<T, P>,
   {
     ignoreValue = false,
     initialValue,
@@ -70,7 +72,7 @@ export default function useFormField<T, P = {}>(
     parse: defaultParse,
     valueProp = 'value',
   }: Options<T>,
-): Omit<P, keyof FieldProps<T>> & FieldProvidedProps<T> {
+): Omit<P, keyof FieldInternalProps<T>> & FieldProvidedProps<T> {
   const {
     defaultValue = initialValue,
     isEqual,

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { FieldState, fieldSubscriptionItems } from 'final-form';
 import { Parse, Field, DefaultValue } from '../types';
 import useForm from './useForm';
@@ -93,6 +93,7 @@ export default function useFormField<T, P>(
     ...restProps
   } = props;
   const form = useForm();
+  const fieldName = useRef(name);
   const [field, setField] = useState<FieldState<T>>({
     change() {},
     blur() {},
@@ -107,8 +108,13 @@ export default function useFormField<T, P>(
   // Register field in parent form
   useEffect(() => {
     let mounted = true;
+    let unregister: () => void;
 
-    const unregister = form.register(
+    if (name !== fieldName.current && unregister) {
+      unregister();
+    }
+
+    unregister = form.register(
       {
         defaultValue,
         isEqual,
@@ -140,6 +146,8 @@ export default function useFormField<T, P>(
         unregister();
       }
     };
+    // We only want to register/unregister fields when the name changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
 
   // Handlers

--- a/packages/forms/src/hooks/useFormField.tsx
+++ b/packages/forms/src/hooks/useFormField.tsx
@@ -13,6 +13,8 @@ export type Options<T> = {
 
 export type FieldProps<T, P> = Omit<P, 'defaultValue' | 'onChange'> & FieldInternalProps<T>;
 
+export type FieldReturnProps<T, P> = Omit<P, keyof FieldInternalProps<T>> & FieldProvidedProps<T>;
+
 export interface FieldInternalProps<T> extends Field<T> {
   onBatchChange?: (value: T) => object | undefined;
   onBlur?: (event: React.FocusEvent) => void;
@@ -72,7 +74,7 @@ export default function useFormField<T, P>(
     parse: defaultParse,
     valueProp = 'value',
   }: Options<T>,
-): Omit<P, keyof FieldInternalProps<T>> & FieldProvidedProps<T> {
+): FieldReturnProps<T, P> {
   const {
     defaultValue = initialValue,
     isEqual,

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -14,7 +14,6 @@ import Select from './components/Form/Select';
 import Switch from './components/Form/Switch';
 import TextArea from './components/Form/TextArea';
 import ToggleButtonController from './components/Form/ToggleButtonController';
-import connectToForm from './composers/connectToForm';
 
 export * from './types';
 
@@ -32,7 +31,6 @@ export {
   Switch,
   TextArea,
   ToggleButtonController,
-  connectToForm,
   FormActions,
   FormContext,
 };

--- a/packages/forms/test/components/Form.test.tsx
+++ b/packages/forms/test/components/Form.test.tsx
@@ -537,7 +537,7 @@ describe('<Form />', () => {
         validator() {},
       };
       const fields = { foo: { data: {} } };
-      const formState = { initialValues: {}, values: {} };
+      const formState = { values: {} };
 
       // @ts-ignore
       instance.setFieldConfig(['foo', config], { fields, formState });
@@ -545,16 +545,12 @@ describe('<Form />', () => {
       expect(fields).toEqual({
         foo: {
           data: { config },
-          initial: '123',
           value: '123',
           touched: true,
         },
       });
 
       expect(formState).toEqual({
-        initialValues: {
-          foo: '123',
-        },
         values: {
           foo: '123',
         },

--- a/packages/forms/test/components/Form.test.tsx
+++ b/packages/forms/test/components/Form.test.tsx
@@ -537,7 +537,7 @@ describe('<Form />', () => {
         validator() {},
       };
       const fields = { foo: { data: {} } };
-      const formState = { values: {} };
+      const formState = { initialValues: {}, values: {} };
 
       // @ts-ignore
       instance.setFieldConfig(['foo', config], { fields, formState });
@@ -545,12 +545,16 @@ describe('<Form />', () => {
       expect(fields).toEqual({
         foo: {
           data: { config },
+          initial: '123',
           value: '123',
           touched: true,
         },
       });
 
       expect(formState).toEqual({
+        initialValues: {
+          foo: '123',
+        },
         values: {
           foo: '123',
         },

--- a/packages/forms/test/composers/connectToForm.test.tsx
+++ b/packages/forms/test/composers/connectToForm.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import connectToForm, {
-  PROP_NAMES,
   ConnectToFormWrapperProps,
   ConnectToFormProps,
 } from '../../src/composers/connectToForm';
@@ -74,16 +73,6 @@ describe('connectToForm()', () => {
     const wrapper = unwrap(<HocInitialValue name="foo" validator={() => {}} />);
 
     expect(wrapper.find(BaseField).prop('value')).toBe(123);
-  });
-
-  it('doesnt pass field props to wrapped component', () => {
-    const wrapper = unwrap(<Hoc {...props} />);
-
-    PROP_NAMES.forEach(name => {
-      if (name !== 'name' && name.slice(0, 2) !== 'on') {
-        expect(wrapper.find(BaseField).prop(name)).toBeUndefined();
-      }
-    });
   });
 
   describe('componentDidMount()', () => {

--- a/packages/forms/test/composers/connectToForm.test.tsx
+++ b/packages/forms/test/composers/connectToForm.test.tsx
@@ -29,11 +29,6 @@ describe('connectToForm()', () => {
     parse: toNumber,
   })(BaseField);
 
-  const HocInvalid = connectToForm<string>({
-    initialValue: '',
-    parse: toString,
-  })(BaseField);
-
   const props = {
     name: 'foo',
     defaultValue: 'baz',
@@ -75,187 +70,144 @@ describe('connectToForm()', () => {
     expect(wrapper.find(BaseField).prop('value')).toBe(123);
   });
 
-  describe('componentDidMount()', () => {
-    it('sets name and default value into state', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
+  it('sets name and value', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
 
-      expect(wrapper.find('ConnectToForm').state()).toEqual(
-        expect.objectContaining({
-          error: '',
-          invalid: false,
-          name: 'foo',
-          value: 'baz',
-        }),
-      );
-    });
-
-    it('registers field on mount', () => {
-      const spy = jest.fn();
-
-      unwrap(<Hoc {...props} unregisterOnUnmount validator={spy} />);
-
-      expect(form.register).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'foo',
-          defaultValue: 'baz',
-          unregisterOnUnmount: true,
-          validator: spy,
-        }),
-        expect.anything(),
-      );
-    });
+    expect(wrapper.find(BaseField).prop('name')).toBe('foo');
+    expect(wrapper.find(BaseField).prop('value')).toBe('baz');
   });
 
-  describe('componentDidUpdate()', () => {
-    it('re-registers field if name changes', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
+  it('registers field on mount', () => {
+    const spy = jest.fn();
 
-      wrapper.setProps({
-        name: 'bar',
-      });
+    unwrap(<Hoc {...props} unregisterOnUnmount validator={spy} />);
 
-      expect(form.unregister).toHaveBeenCalled();
-      expect(form.register).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'foo',
-          defaultValue: 'baz',
-        }),
-        expect.anything(),
-      );
-    });
-
-    it('updates state.value when defaultValue changes', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
-
-      wrapper.setProps({
-        defaultValue: 'bar',
-      });
-
-      expect(form.change).toHaveBeenCalledWith('foo', 'bar', {});
-    });
+    expect(form.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'foo',
+        defaultValue: 'baz',
+        validator: spy,
+      }),
+      expect.anything(),
+    );
   });
 
-  describe('componentWillUnmount()', () => {
-    it('unregisters field if `unregisterOnMount` is set', () => {
-      const wrapper = unwrap(<Hoc {...props} unregisterOnUnmount />);
+  it('re-registers field if name changes', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
 
-      wrapper.unmount();
-
-      expect(form.unregister).toHaveBeenCalled();
+    wrapper.setProps({
+      name: 'bar',
     });
 
-    it('doesnt unregister field if `unregisterOnMount` is not set', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
-
-      wrapper.unmount();
-
-      expect(form.unregister).not.toHaveBeenCalled();
-    });
+    expect(form.unregister).toHaveBeenCalled();
+    expect(form.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'foo',
+        defaultValue: 'baz',
+      }),
+      expect.anything(),
+    );
   });
 
-  describe('handleBlur()', () => {
-    it('calls `onBlur`', () => {
-      const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onBlur={spy} />);
-      const event = { type: 'blur' } as React.FocusEvent;
+  it('updates value when defaultValue changes', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
 
-      findField(wrapper).invoke('onBlur')(event);
-
-      expect(spy).toHaveBeenCalledWith(event);
+    wrapper.setProps({
+      defaultValue: 'bar',
     });
+
+    expect(form.change).toHaveBeenCalledWith('foo', 'bar');
   });
 
-  describe('handleChange()', () => {
-    it('calls context `change` and `onChange`', () => {
-      const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onChange={spy} />);
-      const event = { type: 'change' };
+  it('unregisters field if `unregisterOnMount` is set', () => {
+    const wrapper = unwrap(<Hoc {...props} unregisterOnUnmount />);
 
-      findField(wrapper).invoke('onChange')('new value', event);
+    wrapper.unmount();
 
-      expect(spy).toHaveBeenCalledWith('new value', event, undefined);
-      expect(form.change).toHaveBeenCalledWith('foo', 'new value', {});
-    });
-
-    it('can pass batch values using `onBatchChange`', () => {
-      const wrapper = unwrap(<Hoc {...props} onBatchChange={() => ({ bar: 'other value' })} />);
-      const event = { type: 'change' };
-
-      findField(wrapper).invoke('onChange')('new value', event);
-
-      expect(form.change).toHaveBeenCalledWith('foo', 'new value', { bar: 'other value' });
-    });
+    expect(form.unregister).toHaveBeenCalled();
   });
 
-  describe('handleFocus()', () => {
-    it('calls `onFocus`', () => {
-      const spy = jest.fn();
-      const wrapper = unwrap(<Hoc {...props} onFocus={spy} />);
-      const event = { type: 'focus' } as React.FocusEvent;
+  it('doesnt unregister field if `unregisterOnMount` is not set', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
 
-      findField(wrapper).invoke('onFocus')(event);
+    wrapper.unmount();
 
-      expect(spy).toHaveBeenCalledWith(event);
-    });
+    expect(form.unregister).not.toHaveBeenCalled();
   });
 
-  describe('render()', () => {
-    it('passes form and handler props down', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
+  it('calls `onBlur`', () => {
+    const spy = jest.fn();
+    const wrapper = unwrap(<Hoc {...props} onBlur={spy} />);
+    const event = { type: 'blur' } as React.FocusEvent;
 
-      expect(wrapper.find(BaseField).props()).toEqual(
-        expect.objectContaining({
-          errorMessage: '',
-          invalid: false,
-          name: 'foo',
-          value: 'baz',
-          onBlur: expect.any(Function),
-          onChange: expect.any(Function),
-          onFocus: expect.any(Function),
-        }),
-      );
-    });
+    findField(wrapper).invoke('onBlur')(event);
 
-    it('passes custom props down', () => {
-      const wrapper = unwrap(<Hoc {...props} aria-hidden="true" />);
+    expect(spy).toHaveBeenCalledWith(event);
+  });
 
-      expect(wrapper.find(BaseField).prop('aria-hidden')).toBe('true');
-    });
+  it('calls context `change` and `onChange`', () => {
+    const spy = jest.fn();
+    const wrapper = unwrap(<Hoc {...props} onChange={spy} />);
+    const event = { type: 'change' };
 
-    it('doesnt pass connect props down', () => {
-      const wrapper = unwrap(<Hoc {...props} />);
+    findField(wrapper).invoke('onChange')('new value', event);
 
-      expect(wrapper.find(BaseField).prop('unregisterOnMount')).toBeUndefined();
-      expect(wrapper.find(BaseField).prop('validator')).toBeUndefined();
-    });
+    expect(spy).toHaveBeenCalledWith('new value', event, undefined);
+    expect(form.change).toHaveBeenCalledWith('foo', 'new value', {});
+  });
 
-    it('can change value prop used', () => {
-      const wrapper = unwrap(<HocChecked {...props} defaultValue />);
+  it('can pass batch values using `onBatchChange`', () => {
+    const wrapper = unwrap(<Hoc {...props} onBatchChange={() => ({ bar: 'other value' })} />);
+    const event = { type: 'change' };
 
-      expect(wrapper.find(BaseField).prop('value')).toBeUndefined();
-      expect(wrapper.find(BaseField).prop('checked')).toBe(true);
-    });
+    findField(wrapper).invoke('onChange')('new value', event);
 
-    it('passes down error messages and invalid state', () => {
-      const wrapper = unwrap(
-        <HocInvalid
-          {...props}
-          validator={() => {
-            throw new Error('Oops');
-          }}
-        />,
-      );
+    expect(form.change).toHaveBeenCalledWith('foo', 'new value', { bar: 'other value' });
+  });
 
-      wrapper.find('ConnectToForm').setState({
-        error: new Error('Oops'),
-        invalid: true,
-        touched: true,
-      });
+  it('calls `onFocus`', () => {
+    const spy = jest.fn();
+    const wrapper = unwrap(<Hoc {...props} onFocus={spy} />);
+    const event = { type: 'focus' } as React.FocusEvent;
 
-      wrapper.update();
+    findField(wrapper).invoke('onFocus')(event);
 
-      expect(wrapper.find(BaseField).prop('invalid')).toBe(true);
-      expect(wrapper.find(BaseField).prop('errorMessage')).toBe('Oops');
-    });
+    expect(spy).toHaveBeenCalledWith(event);
+  });
+
+  it('passes form and handler props down', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
+
+    expect(wrapper.find(BaseField).props()).toEqual(
+      expect.objectContaining({
+        errorMessage: '',
+        invalid: false,
+        name: 'foo',
+        value: 'baz',
+        onBlur: expect.any(Function),
+        onChange: expect.any(Function),
+        onFocus: expect.any(Function),
+      }),
+    );
+  });
+
+  it('passes custom props down', () => {
+    const wrapper = unwrap(<Hoc {...props} aria-hidden="true" />);
+
+    expect(wrapper.find(BaseField).prop('aria-hidden')).toBe('true');
+  });
+
+  it('doesnt pass connect props down', () => {
+    const wrapper = unwrap(<Hoc {...props} />);
+
+    expect(wrapper.find(BaseField).prop('unregisterOnMount')).toBeUndefined();
+    expect(wrapper.find(BaseField).prop('validator')).toBeUndefined();
+  });
+
+  it('can change value prop used', () => {
+    const wrapper = unwrap(<HocChecked {...props} defaultValue />);
+
+    expect(wrapper.find(BaseField).prop('value')).toBeUndefined();
+    expect(wrapper.find(BaseField).prop('checked')).toBe(true);
   });
 });

--- a/packages/forms/test/index.test.ts
+++ b/packages/forms/test/index.test.ts
@@ -20,7 +20,6 @@ describe('forms', () => {
       'Switch',
       'TextArea',
       'ToggleButtonController',
-      'connectToForm',
     ]);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Rewrites all form components to use the new `useFormField` hook instead of the `connectToForm` HOC.

## Motivation and Context

- Hooks are easier to use than HOCs.
- Hooks type better.
- Hooks are easily testable.
- Slightly reduces filesize.
- Generics can now be passed properly (Auto/multicomplete were broken before).

## Testing

Storybook.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
