### PR TITLE
fix(AdaptiveGrid): Hide/filter out empty grid items.

### DIFF
--- a/packages/core/src/components/AdaptiveGrid/index.tsx
+++ b/packages/core/src/components/AdaptiveGrid/index.tsx
@@ -25,14 +25,16 @@ class AdaptiveGrid extends React.PureComponent<Props> {
     const { breakpoints, children, cx, defaultItemsPerRow, noGutter, styles } = this.props;
 
     const childElements =
-      children &&
+      !!children &&
       React.Children.map(children, (child: React.ReactNode, idx: number) =>
         child ? (
           // These items are generic and don't have a guaranteed id or any unique property
           // eslint-disable-next-line react/no-array-index-key
-          <div key={idx}>{child}</div>
+          <div key={idx} className={cx(styles.item)}>
+            {child}
+          </div>
         ) : null,
-      );
+      ).filter(Boolean);
 
     const breakpointStyles: { [key: string]: { [key: string]: string } } = {};
     const breakpointKeys = Object.keys(breakpoints!);
@@ -71,5 +73,10 @@ export default withStyles(({ unit }) => ({
   },
   container_noGutter: {
     gridGap: 0,
+  },
+  item: {
+    ':empty': {
+      display: 'none',
+    },
   },
 }))(AdaptiveGrid);

--- a/packages/core/src/components/AdaptiveGrid/story.tsx
+++ b/packages/core/src/components/AdaptiveGrid/story.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import AdaptiveGrid from '.';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 
-function gridItem(short: boolean = true): React.ReactNode {
+function GridItem({ empty, short = true }: { empty?: boolean; short?: boolean }) {
+  if (empty) {
+    return null;
+  }
+
   return (
     <div style={{ height: '100%', border: '1px solid black', padding: '16px' }}>
       <LoremIpsum short={short} />
@@ -20,65 +24,83 @@ export default {
 export function aGridWith3ItemsPerRow() {
   return (
     <AdaptiveGrid defaultItemsPerRow={3}>
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
     </AdaptiveGrid>
   );
 }
 
 aGridWith3ItemsPerRow.story = {
-  name: 'A grid with 3 items per row',
+  name: 'A grid with 3 items per row.',
 };
 
 export function aGridWith432ItemsPerRowDependingOnWidth() {
   return (
     <AdaptiveGrid defaultItemsPerRow={2} breakpoints={{ 950: 4, 800: 3 }}>
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem(false)}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem(false)}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem short={false} />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem short={false} />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
     </AdaptiveGrid>
   );
 }
 
 aGridWith432ItemsPerRowDependingOnWidth.story = {
-  name: 'A grid with 4/3/2 items per row depending on width',
+  name: 'A grid with 4/3/2 items per row depending on width.',
 };
 
 export function aGridWith4ItemsPerRowAndNoPadding() {
   return (
     <AdaptiveGrid noGutter defaultItemsPerRow={4}>
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
-      {gridItem()}
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
+      <GridItem />
     </AdaptiveGrid>
   );
 }
 
 aGridWith4ItemsPerRowAndNoPadding.story = {
-  name: 'A grid with 4 items per row and no padding',
+  name: 'A grid with 4 items per row and no padding.',
+};
+
+export function filtersOutNullResults() {
+  return (
+    <AdaptiveGrid defaultItemsPerRow={3}>
+      <GridItem />
+      <GridItem empty />
+      <GridItem />
+      <GridItem empty />
+      <GridItem />
+      <GridItem empty />
+      <GridItem />
+    </AdaptiveGrid>
+  );
+}
+
+filtersOutNullResults.story = {
+  name: 'Filters out null results.',
 };


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @schillerk 

## Description

Grid items that rendered null (for whatever reason) would render an empty block. This PR adds some logic to filter them out.

## Motivation and Context

Cause it looks broken.

## Testing

Storybook. This isn't testable since it's a CSS visual change.

## Screenshots

Before:
<img width="1200" alt="Screen Shot 2019-11-11 at 10 20 14 AM" src="https://user-images.githubusercontent.com/143744/68610636-147e7680-046d-11ea-92f2-d58f3a35aa6d.png">

After:
<img width="1201" alt="Screen Shot 2019-11-11 at 10 20 03 AM" src="https://user-images.githubusercontent.com/143744/68610651-1a745780-046d-11ea-9a8b-46b4e345f9dc.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
