### PR TITLE
new(ButtonGroup): Add `endAlign` support.

### DIFF
--- a/packages/core/src/components/ButtonGroup/index.tsx
+++ b/packages/core/src/components/ButtonGroup/index.tsx
@@ -5,16 +5,24 @@ import { styleSheet } from './styles';
 export type Props = {
   /** List of components to group. */
   children: NonNullable<React.ReactNode>;
+  /** Horizontally align the buttons to the end (flex-end). */
+  endAlign?: boolean;
   /** Stack the buttons vertically. */
   stacked?: boolean;
 };
 
 /** Horizontally align `Button`s with a consistent gutter between each. */
-export default function ButtonGroup({ children, stacked }: Props) {
+export default function ButtonGroup({ children, endAlign, stacked }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
-    <div className={cx(styles.buttonGroup, stacked && styles.buttonGroup_stacked)}>
+    <div
+      className={cx(
+        styles.buttonGroup,
+        endAlign && styles.buttonGroup_endAlign,
+        stacked && styles.buttonGroup_stacked,
+      )}
+    >
       {React.Children.map(children, child =>
         child ? (
           <div className={cx(stacked ? styles.cell_stacked : styles.cell)}>{child}</div>

--- a/packages/core/src/components/ButtonGroup/story.tsx
+++ b/packages/core/src/components/ButtonGroup/story.tsx
@@ -24,6 +24,19 @@ groupAnArbitraryNumberOfComponents.story = {
   name: 'Group an arbitrary number of components.',
 };
 
+export function endAlignButtons() {
+  return (
+    <ButtonGroup endAlign>
+      <Button inverted>Previous</Button>
+      <Button>Next</Button>
+    </ButtonGroup>
+  );
+}
+
+endAlignButtons.story = {
+  name: 'Align buttons to the end.',
+};
+
 export function stackButtonsVertically() {
   return (
     <div style={{ width: 300 }}>

--- a/packages/core/src/components/ButtonGroup/styles.ts
+++ b/packages/core/src/components/ButtonGroup/styles.ts
@@ -11,6 +11,10 @@ const styleSheet: StyleSheet = ({ unit }) => ({
     alignItems: 'stretch',
   },
 
+  buttonGroup_endAlign: {
+    justifyContent: 'flex-end',
+  },
+
   cell: {
     marginRight: unit,
 

--- a/packages/core/src/components/Table/styles.ts
+++ b/packages/core/src/components/Table/styles.ts
@@ -10,6 +10,17 @@ function createCell(styles: StyleBlock) {
   };
 }
 
+function createRow(hex: string) {
+  return {
+    // Overrides table specificity
+    '@selectors': {
+      ':nth-child(n) > td': {
+        backgroundColor: hex,
+      },
+    },
+  };
+}
+
 export const styleSheet: StyleSheet = ({ color, ui, unit }) => ({
   table: {
     width: '100%',
@@ -134,17 +145,6 @@ export const styleSheetCell: StyleSheet = () => ({
 });
 
 export const styleSheetRow: StyleSheet = ({ color }) => {
-  function createRow(hex: string) {
-    return {
-      // Overrides table specificity
-      '@selectors': {
-        ':nth-child(n) > td': {
-          backgroundColor: hex,
-        },
-      },
-    };
-  }
-
   return {
     row_danger: createRow(color.core.danger[0]),
     row_info: createRow(color.core.primary[0]),

--- a/packages/core/test/components/ButtonGroup.test.tsx
+++ b/packages/core/test/components/ButtonGroup.test.tsx
@@ -16,6 +16,19 @@ describe('<ButtonGroup />', () => {
     expect(wrapper.find(Button)).toHaveLength(3);
   });
 
+  it('renders buttons to the end', () => {
+    const wrapper = shallow(
+      <ButtonGroup endAlign>
+        <Button>One</Button>
+        <Button>Two</Button>
+        <Button>Three</Button>
+      </ButtonGroup>,
+    );
+
+    expect(wrapper.prop('className')).toMatch('buttonGroup_endAlign');
+    expect(wrapper.find(Button)).toHaveLength(3);
+  });
+
   it('renders buttons stacked', () => {
     const wrapper = shallow(
       <ButtonGroup stacked>


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

new `endAlign` prop to move buttons to `flex-end` / right side.

## Motivation and Context

sometimes, we want buttons aligned to the end! especially in modals and workflows.

## Testing

local storybook
tests

## Screenshots

<img width="1279" alt="Screen Shot 2019-11-14 at 11 18 06 AM" src="https://user-images.githubusercontent.com/306275/68888884-a3d79400-06d0-11ea-831a-218b3fb25d19.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
