### PR TITLE
new(FormField): Support small and large sizes.

### DIFF
--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -10,7 +10,7 @@ import Suffix from './Suffix';
 import { styleSheet } from './styles';
 
 export type Props = {
-  /** Decrease label font size and spacing. */
+  /** @deprecated Decrease label font size and spacing. */
   compact?: boolean;
   /** @ignore Decrease bottom margin of the field. (Internal use only) */
   compactSpacing?: boolean;
@@ -32,12 +32,16 @@ export type Props = {
   label: NonNullable<React.ReactNode>;
   /** Small description to display under the label. */
   labelDescription?: React.ReactNode;
+  /** Increase label font size and spacing. */
+  large?: boolean;
   /** Remove bottom margin from field. */
   noSpacing?: boolean;
   /** Mark the field as optional. */
   optional?: boolean;
   /** Content to display before the input field. */
   prefix?: React.ReactNode;
+  /** Decrease label font size and spacing. */
+  small?: boolean;
   /** Content to display after the input field. */
   suffix?: React.ReactNode;
 };
@@ -75,6 +79,7 @@ export default function FormField({
   invalid,
   label,
   labelDescription,
+  large,
   noSpacing,
   optional,
   renderBeforeLabel,
@@ -82,6 +87,7 @@ export default function FormField({
   renderLargeLabel,
   stretchLabel,
   prefix,
+  small,
   suffix,
   topAlign,
 }: PrivateProps) {
@@ -109,7 +115,7 @@ export default function FormField({
     <section
       className={cx(
         styles.field,
-        (compact || compactSpacing) && !noSpacing && styles.field_compactSpacing,
+        (compact || compactSpacing || small) && !noSpacing && styles.field_compactSpacing,
         noSpacing && styles.field_noSpacing,
       )}
     >
@@ -125,7 +131,13 @@ export default function FormField({
             (inline || renderBeforeLabel) && styles.label_noSpacing,
           )}
         >
-          <StatusText danger={invalid} muted={disabled} small={compact} bold={!renderLargeLabel}>
+          <StatusText
+            danger={invalid}
+            muted={disabled}
+            small={compact || small}
+            large={large}
+            bold={!renderLargeLabel}
+          >
             {label}
 
             {optional && !hideOptionalLabel && (

--- a/packages/core/src/components/FormField/partitionFieldProps.ts
+++ b/packages/core/src/components/FormField/partitionFieldProps.ts
@@ -3,13 +3,15 @@ import { Props as FormFieldProps } from '.';
 export type MaybeChildren = { children?: unknown };
 
 export type ExplicitProps = {
-  value: string;
   compact: boolean;
   disabled: boolean;
   hasPrefix: boolean;
   hasSuffix: boolean;
   invalid: boolean;
+  large: boolean;
   optional: boolean;
+  small: boolean;
+  value: string;
 };
 
 export default function partitionFieldProps<Props extends MaybeChildren = {}>(
@@ -35,9 +37,11 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
     invalid = false,
     label,
     labelDescription = '',
+    large = false,
     noSpacing = false,
     optional = false,
     prefix = null,
+    small = false,
     suffix = null,
     ...inputProps
   } = props;
@@ -56,9 +60,11 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
       invalid,
       label,
       labelDescription,
+      large,
       noSpacing,
       optional,
       prefix,
+      small,
       suffix,
     },
     // @ts-ignore Hard to type
@@ -70,7 +76,9 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
       hasPrefix: !!prefix,
       hasSuffix: !!suffix,
       invalid,
+      large,
       optional,
+      small,
     },
   };
 }

--- a/packages/core/src/components/FormField/story.tsx
+++ b/packages/core/src/components/FormField/story.tsx
@@ -169,3 +169,21 @@ export function supportsInline() {
 supportsInline.story = {
   name: 'Supports inline.',
 };
+
+export function smallAndLargeSizes() {
+  return (
+    <>
+      <Input small name="size-small" label="Small" onChange={action('onChange')} />
+
+      <Select name="size-normal" label="Medium (normal)" onChange={action('onChange')}>
+        <option value="">Option</option>
+      </Select>
+
+      <TextArea large name="size-large" label="Large" onChange={action('onChange')} />
+    </>
+  );
+}
+
+smallAndLargeSizes.story = {
+  name: 'Small and large sizes.',
+};


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This updates the `FormField` to properly support small and large (which was missing).

## Motivation and Context

During the `compact` -> `small` transition, the form field labels were not migrated, which is causing normal sized (15px) labels to be used for small inputs.

## Testing

Storybook.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
