### PR TITLE
new(List): Add `middleAlign` support for `horizontal`.

### DIFF
--- a/packages/core/src/components/List/index.tsx
+++ b/packages/core/src/components/List/index.tsx
@@ -12,13 +12,15 @@ export type Props = {
   gutter?: boolean;
   /** Horizontal list. */
   horizontal?: boolean;
+  /** Align contents in the middle vertically, to be used with `horizontal`. */
+  middleAlign?: boolean;
   /** Renders an `<ol></ol>`. */
   ordered?: boolean;
   /** Wrap horizontal list. */
   wrap?: boolean;
 };
 
-export default function List({ children, gutter, horizontal, ordered, wrap }: Props) {
+export default function List({ children, gutter, horizontal, middleAlign, ordered, wrap }: Props) {
   const Tag = ordered ? 'ol' : 'ul';
   const [styles, cx] = useStyles(styleSheet);
 
@@ -30,6 +32,7 @@ export default function List({ children, gutter, horizontal, ordered, wrap }: Pr
         horizontal && styles.list_horizontal,
         horizontal && gutter && styles.list_gutter_horizontal,
         horizontal && wrap && styles.list_horizontal_wrap,
+        middleAlign && styles.list_middleAlign,
       )}
     >
       {React.Children.map(children, child => {

--- a/packages/core/src/components/List/story.tsx
+++ b/packages/core/src/components/List/story.tsx
@@ -119,7 +119,37 @@ export function listWithHorizontalAndGutter() {
 }
 
 listWithHorizontalAndGutter.story = {
-  name: 'List  with `horizontal` and `gutter`.',
+  name: 'List with `horizontal` and `gutter`.',
+};
+
+export function listWithHorizontalMiddleAlignAndGutter() {
+  return (
+    <List gutter horizontal middleAlign>
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+
+      <Item>
+        <Text>
+          <LoremIpsum short />
+          <br />
+          <LoremIpsum short />
+        </Text>
+      </Item>
+
+      <Item>
+        <Text>
+          <LoremIpsum short />
+        </Text>
+      </Item>
+    </List>
+  );
+}
+
+listWithHorizontalMiddleAlignAndGutter.story = {
+  name: 'List with `horizontal`, `middleAlign`, and `gutter`.',
 };
 
 export function listWithHorizontalAndWrap() {

--- a/packages/core/src/components/List/styles.ts
+++ b/packages/core/src/components/List/styles.ts
@@ -10,7 +10,7 @@ export const styleSheet: StyleSheet = ({ unit }) => ({
   list_gutter: {
     '@selectors': {
       '> li': {
-        marginBottom: unit / 2,
+        marginBottom: unit,
       },
 
       '> li:last-child': {
@@ -23,7 +23,7 @@ export const styleSheet: StyleSheet = ({ unit }) => ({
     '@selectors': {
       '> li': {
         marginBottom: 0,
-        marginRight: unit,
+        marginRight: unit * 2,
       },
 
       '> li:last-child': {

--- a/packages/core/src/components/List/styles.ts
+++ b/packages/core/src/components/List/styles.ts
@@ -36,6 +36,10 @@ export const styleSheet: StyleSheet = ({ unit }) => ({
     display: 'flex',
   },
 
+  list_middleAlign: {
+    alignItems: 'center',
+  },
+
   list_horizontal_wrap: {
     flexWrap: 'wrap',
   },

--- a/packages/core/test/components/List.test.tsx
+++ b/packages/core/test/components/List.test.tsx
@@ -90,4 +90,14 @@ describe('<List />', () => {
 
     expect(wrapper.prop('className')).toContain('list_horizontal');
   });
+
+  it('renders a list with middleAlign', () => {
+    const wrapper = shallow(
+      <List middleAlign>
+        <Item>Item 1</Item>
+      </List>,
+    );
+
+    expect(wrapper.prop('className')).toContain('list_middleAlign');
+  });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

vertically center horizontal list items

## Motivation and Context

sometimes height vary!

## Testing

local storybook
new story

## Screenshots

<img width="1278" alt="Screen Shot 2019-11-14 at 1 49 58 PM" src="https://user-images.githubusercontent.com/306275/68899057-abedfe80-06e5-11ea-983b-f84ce1b7b53d.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
