### PR TITLE
update(Tab): Set background color to clear

### DIFF
--- a/packages/core/src/components/Tabs/styles.ts
+++ b/packages/core/src/components/Tabs/styles.ts
@@ -22,6 +22,7 @@ export const styleSheet: StyleSheet = ({ color, ui, unit }) => ({
 
 export const styleSheetTab: StyleSheet = ({ color, font, pattern, unit, ui, transition }) => ({
   tab: {
+    backgroundColor: color.clear,
     borderBottom: ui.borderThick,
     marginRight: unit * 4,
     marginBottom: -2,


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Tabs component background color transparent

## Motivation and Context
Tabs background is white. When component background is not white, tab looks off because the background colors don't match. To resolve this, make background tab color transparent. 

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
<img width="329" alt="Screen Shot 2019-11-14 at 4 07 33 PM" src="https://user-images.githubusercontent.com/24639248/68907378-6557ce80-06fc-11ea-84f7-41059cfbe955.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
