### PR TITLE
update(CardContent): Allow full size content in before and after for Card Content

### DIFF
--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -6,6 +6,7 @@ import Image from '../Image';
 import Row from '../Row';
 import Spacing from '../Spacing';
 import { styleSheetContent as styleSheet } from './styles';
+import ButtonOrLink from '../private/ButtonOrLink';
 
 function getSideImageWidth({ large, small }: { large?: boolean; small?: boolean }): number {
   if (small) {
@@ -107,9 +108,9 @@ function CardContent({
 
     if (onAfterImageClick) {
       afterContent = (
-        <button name="AfterContent" className={cx(styles.side_button)} onClick={onAfterImageClick}>
+        <ButtonOrLink className={cx(styles.sideButton)} onClick={onAfterImageClick}>
           {afterContent}
-        </button>
+        </ButtonOrLink>
       );
     }
   }
@@ -141,13 +142,9 @@ function CardContent({
 
     if (onBeforeImageClick) {
       beforeContent = (
-        <button
-          name="BeforeContent"
-          className={cx(styles.side_button)}
-          onClick={onBeforeImageClick}
-        >
+        <ButtonOrLink className={cx(styles.sideButton)} onClick={onBeforeImageClick}>
           {beforeContent}
-        </button>
+        </ButtonOrLink>
       );
     }
   }

--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -46,6 +46,10 @@ export type Props = {
   topImageSrc?: string;
   /** To use with text truncation; overflow is hidden. */
   truncated?: boolean;
+  /** If provided, makes the after image clickable, firing this callback. */
+  onAfterImageClick?: () => void;
+  /** If provided, makes the before image clickable, firing this callback. */
+  onBeforeImageClick?: () => void;
   /** If provided, makes the entire content clickable, firing this callback. */
   onClick?: () => void;
 };
@@ -66,6 +70,8 @@ function CardContent({
   small,
   topImageSrc,
   truncated,
+  onAfterImageClick,
+  onBeforeImageClick,
 }: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
@@ -98,6 +104,14 @@ function CardContent({
         src={afterImageSrc}
       />
     );
+
+    if (onAfterImageClick) {
+      afterContent = (
+        <button name="AfterContent" className={cx(styles.side_button)} onClick={onAfterImageClick}>
+          {afterContent}
+        </button>
+      );
+    }
   }
 
   let beforeContent = before ? (
@@ -124,6 +138,18 @@ function CardContent({
         src={beforeImageSrc}
       />
     );
+
+    if (onBeforeImageClick) {
+      beforeContent = (
+        <button
+          name="BeforeContent"
+          className={cx(styles.side_button)}
+          onClick={onBeforeImageClick}
+        >
+          {beforeContent}
+        </button>
+      );
+    }
   }
 
   return (

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -336,7 +336,7 @@ cardAsAButtonWithMiddleAlignment.story = {
 export function asClickableBeforeImage() {
   return (
     <Card>
-      <Content large afterImageSrc={moon} onAfterImageClick={action('onClick before')}>
+      <Content large beforeImageSrc={moon} onBeforeImageClick={action('onClick before')}>
         <Text>
           <LoremIpsum />
         </Text>

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -332,3 +332,35 @@ export function cardAsAButtonWithMiddleAlignment() {
 cardAsAButtonWithMiddleAlignment.story = {
   name: 'Card as a button with middle alignment.',
 };
+
+export function asClickableBeforeImage() {
+  return (
+    <Card>
+      <Content large afterImageSrc={moon} onAfterImageClick={action('onClick before')}>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  );
+}
+
+asClickableBeforeImage.story = {
+  name: 'A card with a clickable before image',
+};
+
+export function asClickableAfterImage() {
+  return (
+    <Card>
+      <Content large afterImageSrc={moon} onAfterImageClick={action('onClick after')}>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  );
+}
+
+asClickableAfterImage.story = {
+  name: 'A card with a clickable after image.',
+};

--- a/packages/core/src/components/Card/styles.ts
+++ b/packages/core/src/components/Card/styles.ts
@@ -44,9 +44,15 @@ export const styleSheetContent: StyleSheet = ({ color, pattern, ui, unit }) => (
     paddingBottom: unit * 3,
   },
 
-  side_button: {
+  sideButton: {
     ...pattern.resetButton,
     height: '100%',
+    '@selectors': {
+      '> span': {
+        height: '100%',
+        display: 'block',
+      },
+    },
   },
 
   side_compact: {

--- a/packages/core/src/components/Card/styles.ts
+++ b/packages/core/src/components/Card/styles.ts
@@ -44,6 +44,11 @@ export const styleSheetContent: StyleSheet = ({ color, pattern, ui, unit }) => (
     paddingBottom: unit * 3,
   },
 
+  side_button: {
+    ...pattern.resetButton,
+    height: '100%',
+  },
+
   side_compact: {
     paddingTop: unit * 1.5,
     paddingBottom: unit * 1.5,

--- a/packages/core/test/components/Card/Content.test.tsx
+++ b/packages/core/test/components/Card/Content.test.tsx
@@ -54,6 +54,36 @@ describe('<Card />', () => {
     );
   });
 
+  it('renders before content as clickable', () => {
+    const imageUrl = 'LeftFoo.jpg';
+    const handleClick = jest.fn();
+    const wrapper = shallow(
+      <Content beforeImageSrc={imageUrl} onBeforeImageClick={handleClick}>
+        Sup
+      </Content>,
+    );
+
+    shallow(wrapper.find(Row).prop('before') as React.ReactElement)
+      .find('button')
+      .simulate('click');
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('renders after content as clickable', () => {
+    const imageUrl = 'RightFoo.jpg';
+    const handleClick = jest.fn();
+    const wrapper = shallow(
+      <Content afterImageSrc={imageUrl} onAfterImageClick={handleClick}>
+        Sup
+      </Content>,
+    );
+
+    shallow(wrapper.find(Row).prop('after') as React.ReactElement)
+      .find('button')
+      .simulate('click');
+    expect(handleClick).toHaveBeenCalled();
+  });
+
   it('renders before and after content', () => {
     const after = '~~After~~';
     const before = '~*Before*~';


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Adding full size props for before/after to remove automatic spacing in the content.

## Motivation and Context

There's been some churn in using before/after card content, first with us needing a new size for the content, and now us needing to make the image a link.  Making the content a bit more flexible so we can customize it as needed.
## Testing

Checking in storybook.

## Screenshots

![image](https://user-images.githubusercontent.com/18182784/68968571-c41e5600-0797-11ea-85b9-0b5476834056.png)
![image](https://user-images.githubusercontent.com/18182784/68968584-cb456400-0797-11ea-94c6-93ebc0e71cd6.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
