### PR TITLE
new(Layout): Add custom `minHeight` support.

### DIFF
--- a/packages/layouts/src/components/Layout/index.tsx
+++ b/packages/layouts/src/components/Layout/index.tsx
@@ -7,6 +7,8 @@ export type Props = {
   children: NonNullable<React.ReactNode>;
   /** Expand main content to full width of viewport. */
   fluid?: boolean;
+  /** Min height of the main content. */
+  minHeight?: number | string;
   /** Remove background color from main content. */
   noBackground?: boolean;
   /** Remove padding from main content. */
@@ -26,13 +28,14 @@ export default function Layout({
   before,
   children,
   fluid,
+  minHeight,
   noBackground,
   noPadding,
 }: Props & AsideProps) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
-    <div className={cx(styles.layout)}>
+    <div className={cx(styles.layout, { minHeight })}>
       {before}
 
       <main

--- a/packages/layouts/src/components/Layout/index.tsx
+++ b/packages/layouts/src/components/Layout/index.tsx
@@ -35,7 +35,7 @@ export default function Layout({
   const [styles, cx] = useStyles(styleSheet);
 
   return (
-    <div className={cx(styles.layout, { minHeight })}>
+    <div className={cx(styles.layout, { minHeight: minHeight || '100vh' })}>
       {before}
 
       <main

--- a/packages/layouts/src/components/Layout/story.tsx
+++ b/packages/layouts/src/components/Layout/story.tsx
@@ -22,6 +22,18 @@ standardLayout.story = {
   name: 'Standard layout.',
 };
 
+export function withAFixedHeight() {
+  return (
+    <Layout minHeight={300}>
+      <LoremIpsum />
+    </Layout>
+  );
+}
+
+withAFixedHeight.story = {
+  name: 'With a custom min-height.',
+};
+
 export function withLeftAsideAndNoMainPadding() {
   return (
     <Layout

--- a/packages/layouts/src/components/Layout/styles.ts
+++ b/packages/layouts/src/components/Layout/styles.ts
@@ -4,7 +4,6 @@ const styleSheet: StyleSheet = ({ breakpoints, color, unit }) => ({
   layout: {
     display: 'flex',
     width: '100%',
-    minHeight: '100vh',
     justifyContent: 'space-between',
   },
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

be able to adjust the min-height

## Motivation and Context

sometimes, there's a top bar above the layout. need to adjust the min-height on layout to be something different besides `100vh`.

## Testing

storybook

## Screenshots

<img width="1280" alt="Screen Shot 2019-11-18 at 2 37 56 PM" src="https://user-images.githubusercontent.com/306275/69100056-2afa7400-0a11-11ea-969a-470ff628ec55.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
