### PR TITLE
new(Link): Add `micro` sizing.

### DIFF
--- a/packages/core/src/components/Link/index.tsx
+++ b/packages/core/src/components/Link/index.tsx
@@ -5,7 +5,7 @@ import ButtonOrLink, { Props as ButtonOrLinkProps } from '../private/ButtonOrLin
 import Text from '../Text';
 import { styleSheet } from './styles';
 
-const sizingProp = mutuallyExclusiveTrueProps('small', 'large');
+const sizingProp = mutuallyExclusiveTrueProps('micro', 'small', 'large');
 const stateProp = mutuallyExclusiveTrueProps('disabled', 'muted', 'inverted');
 
 export type Props = ButtonOrLinkProps & {
@@ -17,6 +17,8 @@ export type Props = ButtonOrLinkProps & {
   inverted?: boolean;
   /** Increase font size to large. */
   large?: boolean;
+  /** Decrease font size to micro. */
+  micro?: boolean;
   /** Mark the link as muted. */
   muted?: boolean;
   /** Decrease font size to small. */
@@ -42,6 +44,7 @@ export class Link extends React.Component<Props & WithStylesProps> {
     disabled: false,
     inverted: false,
     large: false,
+    micro: false,
     muted: false,
     small: false,
   };
@@ -55,6 +58,7 @@ export class Link extends React.Component<Props & WithStylesProps> {
       disabled,
       inverted,
       large,
+      micro,
       muted,
       small,
       bold,
@@ -63,7 +67,14 @@ export class Link extends React.Component<Props & WithStylesProps> {
     } = this.props;
 
     return (
-      <Text inline={!block} baseline={baseline} small={small} large={large} bold={bold}>
+      <Text
+        inline={!block}
+        baseline={baseline}
+        micro={micro}
+        small={small}
+        large={large}
+        bold={bold}
+      >
         <ButtonOrLink
           {...restProps}
           disabled={disabled}

--- a/packages/core/src/components/Link/story.tsx
+++ b/packages/core/src/components/Link/story.tsx
@@ -27,9 +27,12 @@ aButtonLink.story = {
   name: 'A button link.',
 };
 
-export function withDifferentSizingSmallRegularDefaultAndLarge() {
+export function withDifferentSizingMicroSmallRegularDefaultAndLarge() {
   return (
     <>
+      <Link micro href="https://github.com/airbnb/lunar">
+        Link
+      </Link>{' '}
       <Link small href="https://github.com/airbnb/lunar">
         Link
       </Link>{' '}
@@ -41,7 +44,7 @@ export function withDifferentSizingSmallRegularDefaultAndLarge() {
   );
 }
 
-withDifferentSizingSmallRegularDefaultAndLarge.story = {
+withDifferentSizingMicroSmallRegularDefaultAndLarge.story = {
   name: 'With different sizing: small, regular (default), and large.',
 };
 

--- a/packages/core/test/components/Link.test.tsx
+++ b/packages/core/test/components/Link.test.tsx
@@ -24,6 +24,16 @@ describe('<Link />', () => {
     }).toThrow();
   });
 
+  it('renders micro (passes to `Text`)', () => {
+    const wrapper = shallowWithStyles(
+      <Link micro href="/">
+        Micro
+      </Link>,
+    );
+
+    expect(wrapper.prop('micro')).toBe(true);
+  });
+
   it('renders small (passes to `Text`)', () => {
     const wrapper = shallowWithStyles(
       <Link small href="/">


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Added support for passing `micro` to the `Link` component

## Motivation and Context
Required to stay in line with design spec in Torch

## Testing
Locally in Storybook

## Screenshots

![image](https://user-images.githubusercontent.com/17676991/69113176-1cbf4e80-0a37-11ea-86d8-1a0fe7885452.png)


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
