### PR TITLE
new(Accordion): Enable multiple items to be open at once.

### DIFF
--- a/packages/core/src/components/Accordion/Item.tsx
+++ b/packages/core/src/components/Accordion/Item.tsx
@@ -11,8 +11,8 @@ export type Props = {
   children?: React.ReactNode;
   /** Whether the accordion item is expanded or not. */
   expanded?: boolean;
-  /** Unique id of the accordion item. */
-  id: string;
+  /** @ignore Unique id of the accordion item, passed in from parent. */
+  id?: string;
   /** Index amongst a collection of accordion items. */
   index?: number;
   /** Removes horizontal padding from the item and top padding from the item body. */

--- a/packages/core/src/components/Accordion/index.tsx
+++ b/packages/core/src/components/Accordion/index.tsx
@@ -14,32 +14,32 @@ export type Props = {
   /** Index of accordion expanded by default. Provide `-1` to collapse all initially. */
   defaultIndex?: number;
   /** Enable multiple items to be open at once. */
-  enableMultiple?: boolean;
+  expandMultiple?: boolean;
 };
 
 /** A controller for multiple accordion items. */
-export default function Accordion({ bordered, children, defaultIndex = 0, enableMultiple }: Props) {
+export default function Accordion({ bordered, children, defaultIndex = 0, expandMultiple }: Props) {
   const [id] = useState(uuid());
   const [styles, cx] = useStyles(styleSheet);
-  const [active, setActive] = useState(
+  const [expanded, setExpanded] = useState(
     new Set<number>([defaultIndex]),
   );
 
   useEffect(() => {
-    setActive(new Set([defaultIndex]));
+    setExpanded(new Set([defaultIndex]));
   }, [defaultIndex]);
 
   const handleClick = (index: number) => {
-    if (enableMultiple) {
-      if (active.has(index)) {
-        active.delete(index);
+    if (expandMultiple) {
+      if (expanded.has(index)) {
+        expanded.delete(index);
       } else {
-        active.add(index);
+        expanded.add(index);
       }
 
-      setActive(new Set(active));
+      setExpanded(new Set(expanded));
     } else {
-      setActive(new Set([active.has(index) ? -1 : index]));
+      setExpanded(new Set([expanded.has(index) ? -1 : index]));
     }
   };
 
@@ -52,7 +52,7 @@ export default function Accordion({ bordered, children, defaultIndex = 0, enable
 
         return React.cloneElement(child as React.ReactElement<AccordionItemProps>, {
           bordered,
-          expanded: active.has(i),
+          expanded: expanded.has(i),
           id: `${id}-${i}`,
           index: i,
           onClick: handleClick,

--- a/packages/core/src/components/Accordion/index.tsx
+++ b/packages/core/src/components/Accordion/index.tsx
@@ -19,37 +19,27 @@ export type Props = {
 
 /** A controller for multiple accordion items. */
 export default function Accordion({ bordered, children, defaultIndex = 0, enableMultiple }: Props) {
-  const [styles, cx] = useStyles(styleSheet);
   const [id] = useState(uuid());
-  const [activeIndex, setActiveIndex] = useState(defaultIndex);
-  const [openIndexes, setOpenIndexes] = useState(new Set<number>());
+  const [styles, cx] = useStyles(styleSheet);
+  const [active, setActive] = useState(
+    new Set<number>([defaultIndex]),
+  );
 
   useEffect(() => {
-    if (enableMultiple) {
-      if (openIndexes.has(defaultIndex)) {
-        openIndexes.delete(defaultIndex);
-      } else {
-        openIndexes.add(defaultIndex);
-      }
-
-      setOpenIndexes(new Set(openIndexes));
-    } else {
-      setActiveIndex(defaultIndex);
-    }
-  }, [defaultIndex, enableMultiple]);
+    setActive(new Set([defaultIndex]));
+  }, [defaultIndex]);
 
   const handleClick = (index: number) => {
     if (enableMultiple) {
-      if (openIndexes.has(index)) {
-        openIndexes.delete(index);
+      if (active.has(index)) {
+        active.delete(index);
       } else {
-        openIndexes.add(index);
+        active.add(index);
       }
 
-      setOpenIndexes(new Set(openIndexes));
+      setActive(new Set(active));
     } else {
-      // close the active one if its been clicked again
-      setActiveIndex(activeIndex === index ? -1 : index);
+      setActive(new Set([active.has(index) ? -1 : index]));
     }
   };
 
@@ -62,7 +52,7 @@ export default function Accordion({ bordered, children, defaultIndex = 0, enable
 
         return React.cloneElement(child as React.ReactElement<AccordionItemProps>, {
           bordered,
-          expanded: enableMultiple ? openIndexes.has(i) : activeIndex === i,
+          expanded: active.has(i),
           id: `${id}-${i}`,
           index: i,
           onClick: handleClick,

--- a/packages/core/src/components/Accordion/index.tsx
+++ b/packages/core/src/components/Accordion/index.tsx
@@ -19,7 +19,7 @@ export type Props = {
 
 /** A controller for multiple accordion items. */
 export default function Accordion({ bordered, children, defaultIndex = 0, expandMultiple }: Props) {
-  const [id] = useState(uuid());
+  const [id] = useState(() => uuid());
   const [styles, cx] = useStyles(styleSheet);
   const [expanded, setExpanded] = useState(
     new Set<number>([defaultIndex]),

--- a/packages/core/src/components/Accordion/story.tsx
+++ b/packages/core/src/components/Accordion/story.tsx
@@ -77,9 +77,9 @@ singleItemInitiallyClosed.story = {
   name: 'Single item initially closed.',
 };
 
-export function withEnableMultiple() {
+export function withexpandMultiple() {
   return (
-    <Accordion bordered enableMultiple defaultIndex={0}>
+    <Accordion bordered expandMultiple>
       <Item title="Item 1">
         <Text>
           <LoremIpsum />
@@ -101,7 +101,7 @@ export function withEnableMultiple() {
   );
 }
 
-withEnableMultiple.story = {
+withexpandMultiple.story = {
   name: 'Enable multiple items to be open at once.',
 };
 

--- a/packages/core/src/components/Accordion/story.tsx
+++ b/packages/core/src/components/Accordion/story.tsx
@@ -13,19 +13,19 @@ export default {
 export function multipleItemsWithBorders() {
   return (
     <Accordion bordered>
-      <Item title="Item 1" id="one">
+      <Item title="Item 1">
         <Text>
           <LoremIpsum />
         </Text>
       </Item>
 
-      <Item title="Item 2" id="two">
+      <Item title="Item 2">
         <Text>
           <LoremIpsum />
         </Text>
       </Item>
 
-      <Item title="Item 3" id="three">
+      <Item title="Item 3">
         <Text>
           <LoremIpsum />
         </Text>
@@ -38,22 +38,6 @@ multipleItemsWithBorders.story = {
   name: 'Multiple items with borders.',
 };
 
-export function singleItemInitiallyClosed() {
-  return (
-    <Accordion defaultIndex={-1}>
-      <Item title="Item 1" id="one">
-        <Text>
-          <LoremIpsum />
-        </Text>
-      </Item>
-    </Accordion>
-  );
-}
-
-singleItemInitiallyClosed.story = {
-  name: 'Single item initially closed.',
-};
-
 export function customTitleComponent() {
   return (
     <Accordion bordered>
@@ -64,7 +48,6 @@ export function customTitleComponent() {
             <small>Subtitle</small>
           </header>
         }
-        id="one"
       >
         <Text>
           <LoremIpsum />
@@ -78,16 +61,60 @@ customTitleComponent.story = {
   name: 'Custom title component.',
 };
 
-export function withNoSpacing() {
+export function singleItemInitiallyClosed() {
   return (
-    <Accordion bordered>
-      <Item noSpacing title="Item 1" id="one">
+    <Accordion defaultIndex={-1}>
+      <Item title="Item 1">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+    </Accordion>
+  );
+}
+
+singleItemInitiallyClosed.story = {
+  name: 'Single item initially closed.',
+};
+
+export function withEnableMultiple() {
+  return (
+    <Accordion bordered enableMultiple defaultIndex={1}>
+      <Item title="Item 1">
         <Text>
           <LoremIpsum />
         </Text>
       </Item>
 
-      <Item noSpacing title="Item 2" id="two">
+      <Item title="Item 2">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+
+      <Item title="Item 3">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+    </Accordion>
+  );
+}
+
+withEnableMultiple.story = {
+  name: 'Enable multiple items to be open at once.',
+};
+
+export function withNoSpacing() {
+  return (
+    <Accordion bordered>
+      <Item noSpacing title="Item 1">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Item>
+
+      <Item noSpacing title="Item 2">
         <Text>
           <LoremIpsum />
         </Text>
@@ -97,5 +124,5 @@ export function withNoSpacing() {
 }
 
 withNoSpacing.story = {
-  name: 'With no spacing.',
+  name: 'With no horizontal spacing.',
 };

--- a/packages/core/src/components/Accordion/story.tsx
+++ b/packages/core/src/components/Accordion/story.tsx
@@ -79,7 +79,7 @@ singleItemInitiallyClosed.story = {
 
 export function withEnableMultiple() {
   return (
-    <Accordion bordered enableMultiple defaultIndex={1}>
+    <Accordion bordered enableMultiple defaultIndex={0}>
       <Item title="Item 1">
         <Text>
           <LoremIpsum />

--- a/packages/core/test/components/Accordion.test.tsx
+++ b/packages/core/test/components/Accordion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallowWithStyles } from '@airbnb/lunar-test-utils';
+import { shallow, mount } from 'enzyme';
 import Accordion from '../../src/components/Accordion';
 import AccordionItem, { Props as AccordionItemProps } from '../../src/components/Accordion/Item';
 import proxyComponent from '../../src/utils/proxyComponent';
@@ -11,20 +11,20 @@ describe('<Accordion />', () => {
     ));
 
     expect(() =>
-      shallowWithStyles(
+      shallow(
         <Accordion>
-          <ProxiedAccordionItem id="0" title="Label" />
+          <ProxiedAccordionItem title="Label" />
         </Accordion>,
       ),
     ).not.toThrow();
   });
 
   it('renders expected number of accordion items', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion defaultIndex={1}>
-        <AccordionItem id="0" title="One" />
-        <AccordionItem id="1" title="Two" />
-        <AccordionItem id="2" title="Three" />
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
@@ -32,46 +32,33 @@ describe('<Accordion />', () => {
   });
 
   it('renders bordered', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion bordered>
-        <AccordionItem id="0" title="Label" />
+        <AccordionItem title="Label" />
       </Accordion>,
     );
-
-    // id is generated with uuid, need to manually set it for snapshots to match
-    wrapper.setState({
-      id: 0,
-    });
 
     expect(wrapper.prop('className')).toMatch('container_bordered');
   });
 
   it('has accessibility role set', () => {
-    const wrapper = shallowWithStyles(
-      <Accordion defaultIndex={3}>
-        <AccordionItem id="0" title="Label" />
+    const wrapper = shallow(
+      <Accordion defaultIndex={2}>
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
     expect(wrapper.prop('role')).toBe('tablist');
   });
 
-  it('sets index state using `defaultIndex`', () => {
-    const wrapper = shallowWithStyles(
-      <Accordion defaultIndex={3}>
-        <AccordionItem id="0" title="Label" />
-      </Accordion>,
-    );
-
-    expect(wrapper.state('index')).toBe(3);
-  });
-
   it('sets expanded state to accordion item by index', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion defaultIndex={1}>
-        <AccordionItem id="0" title="One" />
-        <AccordionItem id="1" title="Two" />
-        <AccordionItem id="2" title="Three" />
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
@@ -98,11 +85,11 @@ describe('<Accordion />', () => {
   });
 
   it('adds indices to items', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion>
-        <AccordionItem id="0" title="One" />
-        <AccordionItem id="1" title="Two" />
-        <AccordionItem id="2" title="Three" />
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
@@ -129,11 +116,11 @@ describe('<Accordion />', () => {
   });
 
   it('sets expanded state to false for all items if defaultIndex is negative', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion defaultIndex={-1}>
-        <AccordionItem id="0" title="One" />
-        <AccordionItem id="1" title="Two" />
-        <AccordionItem id="2" title="Three" />
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
@@ -160,64 +147,135 @@ describe('<Accordion />', () => {
   });
 
   it('handles falsey items', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion>
-        {false && <AccordionItem id="0" title="One" />}
-        {null && <AccordionItem id="0" title="Two" />}
-        <AccordionItem id="0" title="Three" />
+        {false && <AccordionItem title="One" />}
+        {null && <AccordionItem title="Two" />}
+        <AccordionItem title="Three" />
       </Accordion>,
     );
 
     expect(wrapper.find(AccordionItem)).toHaveLength(1);
   });
 
-  it('updates state index when `defaultIndex` changes', () => {
-    const wrapper = shallowWithStyles(
-      <Accordion defaultIndex={3}>
-        <AccordionItem id="0" title="Label" />
-      </Accordion>,
-    );
-
-    expect(wrapper.state('index')).toBe(3);
-
-    wrapper.setProps({
-      defaultIndex: 1,
-    });
-
-    expect(wrapper.state('index')).toBe(1);
-  });
-
   it('updates index when `handleClick` is triggered', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion defaultIndex={3}>
-        <AccordionItem id="0" title="Label" />
+        <AccordionItem title="Label" />
       </Accordion>,
     );
 
-    expect(wrapper.state('index')).toBe(3);
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(false);
 
     wrapper
       .find(AccordionItem)
       .at(0)
       .prop('onClick')!(0);
 
-    expect(wrapper.state('index')).toBe(0);
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(true);
   });
 
   it('updates index to -1 when current index is clicked', () => {
-    const wrapper = shallowWithStyles(
+    const wrapper = shallow(
       <Accordion defaultIndex={0}>
-        <AccordionItem id="0" title="Label" />
+        <AccordionItem title="Label" />
       </Accordion>,
     );
 
-    expect(wrapper.state('index')).toBe(0);
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(true);
 
     wrapper
       .find(AccordionItem)
       .at(0)
       .prop('onClick')!(0);
 
-    expect(wrapper.state('index')).toBe(-1);
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(false);
+  });
+
+  it('enables multiple items to be open when clicked', () => {
+    const wrapper = shallow(
+      <Accordion enableMultiple>
+        <AccordionItem title="One" />
+        <AccordionItem title="Two" />
+        <AccordionItem title="Three" />
+      </Accordion>,
+    );
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(false);
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(1)
+        .prop('expanded'),
+    ).toBe(false);
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(2)
+        .prop('expanded'),
+    ).toBe(false);
+
+    wrapper
+      .find(AccordionItem)
+      .at(0)
+      .prop('onClick')!(0);
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(0)
+        .prop('expanded'),
+    ).toBe(true);
+
+    wrapper
+      .find(AccordionItem)
+      .at(1)
+      .prop('onClick')!(1);
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(1)
+        .prop('expanded'),
+    ).toBe(true);
+
+    wrapper
+      .find(AccordionItem)
+      .at(2)
+      .prop('onClick')!(2);
+
+    expect(
+      wrapper
+        .find(AccordionItem)
+        .at(2)
+        .prop('expanded'),
+    ).toBe(true);
   });
 });

--- a/packages/core/test/components/Accordion.test.tsx
+++ b/packages/core/test/components/Accordion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import Accordion from '../../src/components/Accordion';
 import AccordionItem, { Props as AccordionItemProps } from '../../src/components/Accordion/Item';
 import proxyComponent from '../../src/utils/proxyComponent';

--- a/packages/core/test/components/Accordion.test.tsx
+++ b/packages/core/test/components/Accordion.test.tsx
@@ -214,7 +214,7 @@ describe('<Accordion />', () => {
 
   it('enables multiple items to be open when clicked', () => {
     const wrapper = shallow(
-      <Accordion enableMultiple>
+      <Accordion enableMultiple defaultIndex={-1}>
         <AccordionItem title="One" />
         <AccordionItem title="Two" />
         <AccordionItem title="Three" />

--- a/packages/core/test/components/Accordion.test.tsx
+++ b/packages/core/test/components/Accordion.test.tsx
@@ -214,7 +214,7 @@ describe('<Accordion />', () => {
 
   it('enables multiple items to be open when clicked', () => {
     const wrapper = shallow(
-      <Accordion enableMultiple defaultIndex={-1}>
+      <Accordion expandMultiple defaultIndex={-1}>
         <AccordionItem title="One" />
         <AccordionItem title="Two" />
         <AccordionItem title="Three" />


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

add an option to break the default ux of an accordion - allow multiple to be open/toggled, instead of only one open at a time.

## Motivation and Context

people want it and keep designing for it

## Testing

storybook
tests

## Screenshots

<img width="1277" alt="Screen Shot 2019-11-20 at 2 14 58 PM" src="https://user-images.githubusercontent.com/306275/69286448-1d2b2700-0ba8-11ea-800d-1958b2c86323.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
