### PR TITLE
new: Add document manager for easier mutation updates.

### DIFF
--- a/packages/apollo/src/DocumentManager.ts
+++ b/packages/apollo/src/DocumentManager.ts
@@ -1,0 +1,24 @@
+import { DocumentNode } from 'graphql';
+
+interface QueryCache<T> {
+  query: DocumentNode;
+  variables?: T;
+}
+
+export default class DocumentManager {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private queries: Map<string, QueryCache<any>> = new Map();
+
+  readQuery<T>(key: string): QueryCache<T> | null {
+    return this.queries.get(key) || null;
+  }
+
+  saveQuery<T>(key: string, query: DocumentNode, variables?: T): this {
+    this.queries.set(key, {
+      query,
+      variables,
+    });
+
+    return this;
+  }
+}

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -7,6 +7,7 @@ import { HttpLink } from 'apollo-link-http';
 import Mutation from './components/Mutation';
 import Query from './components/Query';
 import Provider from './components/Provider';
+import DocumentManager from './DocumentManager';
 // @ts-ignore
 import pkg from '../package.json';
 
@@ -28,6 +29,8 @@ class Apollo {
   };
 
   protected client?: ApolloClient<{}>;
+
+  protected documents = new DocumentManager();
 
   initialize(settings?: Settings) {
     this.settings = {
@@ -71,6 +74,10 @@ class Apollo {
     }
 
     return this.client!;
+  }
+
+  getDocumentManager() {
+    return this.documents;
   }
 }
 

--- a/packages/apollo/src/updaters/addToList.ts
+++ b/packages/apollo/src/updaters/addToList.ts
@@ -2,11 +2,12 @@ import { DocumentNode } from 'graphql';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { MutationUpdaterFn } from 'apollo-client';
+import { DataProxy } from 'apollo-cache';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
 export default function addToList<Result = {}>(
-  docOrQuery: DocumentNode,
+  docOrQuery: DocumentNode | DataProxy.Query<{}>,
   listPath: string,
   mutationPath: string,
 ): MutationUpdaterFn {

--- a/packages/apollo/src/updaters/addToList.ts
+++ b/packages/apollo/src/updaters/addToList.ts
@@ -6,15 +6,15 @@ import { DataProxy } from 'apollo-cache';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
-export default function addToList<Result = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<{}>,
+export default function addToList(
+  docOrQuery: string | DocumentNode | DataProxy.Query<{}>,
   listPath: string,
   mutationPath: string,
 ): MutationUpdaterFn {
   const query = prepareQuery(docOrQuery);
 
-  return (cache, result) => {
-    const queryResult = cache.readQuery<Result>(query);
+  return (cache, mutationResult) => {
+    const queryResult = cache.readQuery<object>(query);
     const nextResult = { ...queryResult };
     const list = get(queryResult, listPath);
 
@@ -26,7 +26,7 @@ export default function addToList<Result = {}>(
       }
     }
 
-    const data = get(result.data, mutationPath);
+    const data = get(mutationResult.data, mutationPath);
 
     if (typeof data === 'undefined') {
       if (__DEV__) {

--- a/packages/apollo/src/updaters/addToList.ts
+++ b/packages/apollo/src/updaters/addToList.ts
@@ -1,19 +1,18 @@
 import { DocumentNode } from 'graphql';
 import get from 'lodash/get';
 import set from 'lodash/set';
-import { DataProxy } from 'apollo-cache';
-import { MutationFetchResult } from 'react-apollo';
+import { MutationUpdaterFn } from 'apollo-client';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
-export default function addToList<Result, Vars = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<Vars>,
+export default function addToList<Result = {}>(
+  docOrQuery: DocumentNode,
   listPath: string,
   mutationPath: string,
-) {
-  const query = prepareQuery<Vars>(docOrQuery);
+): MutationUpdaterFn {
+  const query = prepareQuery(docOrQuery);
 
-  return (cache: DataProxy, mutationResult: MutationFetchResult<Result>) => {
+  return (cache, result) => {
     const queryResult = cache.readQuery<Result>(query);
     const nextResult = { ...queryResult };
     const list = get(queryResult, listPath);
@@ -26,7 +25,7 @@ export default function addToList<Result, Vars = {}>(
       }
     }
 
-    const data = get(mutationResult.data, mutationPath);
+    const data = get(result.data, mutationPath);
 
     if (typeof data === 'undefined') {
       if (__DEV__) {

--- a/packages/apollo/src/updaters/removeFromList.ts
+++ b/packages/apollo/src/updaters/removeFromList.ts
@@ -6,16 +6,16 @@ import { DataProxy } from 'apollo-cache';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
-export default function removeFromList<Result = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<{}>,
+export default function removeFromList(
+  docOrQuery: string | DocumentNode | DataProxy.Query<{}>,
   listPath: string,
   id: string | number,
   idName: string = 'id',
-): MutationUpdaterFn<Result> {
+): MutationUpdaterFn {
   const query = prepareQuery(docOrQuery);
 
   return cache => {
-    const queryResult = cache.readQuery<{}>(query);
+    const queryResult = cache.readQuery<object>(query);
     const nextResult = { ...queryResult };
     const list = get(queryResult, listPath);
 

--- a/packages/apollo/src/updaters/removeFromList.ts
+++ b/packages/apollo/src/updaters/removeFromList.ts
@@ -2,11 +2,12 @@ import { DocumentNode } from 'graphql';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { MutationUpdaterFn } from 'apollo-client';
+import { DataProxy } from 'apollo-cache';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
 export default function removeFromList<Result = {}>(
-  docOrQuery: DocumentNode,
+  docOrQuery: DocumentNode | DataProxy.Query<{}>,
   listPath: string,
   id: string | number,
   idName: string = 'id',

--- a/packages/apollo/src/updaters/removeFromList.ts
+++ b/packages/apollo/src/updaters/removeFromList.ts
@@ -1,20 +1,20 @@
 import { DocumentNode } from 'graphql';
 import get from 'lodash/get';
 import set from 'lodash/set';
-import { DataProxy } from 'apollo-cache';
+import { MutationUpdaterFn } from 'apollo-client';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
-export default function removeFromList<Result, Vars = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<Vars>,
+export default function removeFromList<Result = {}>(
+  docOrQuery: DocumentNode,
   listPath: string,
   id: string | number,
   idName: string = 'id',
-) {
-  const query = prepareQuery<Vars>(docOrQuery);
+): MutationUpdaterFn<Result> {
+  const query = prepareQuery(docOrQuery);
 
-  return (cache: DataProxy) => {
-    const queryResult = cache.readQuery<Result>(query);
+  return cache => {
+    const queryResult = cache.readQuery<{}>(query);
     const nextResult = { ...queryResult };
     const list = get(queryResult, listPath);
 

--- a/packages/apollo/src/utils/prepareQuery.ts
+++ b/packages/apollo/src/utils/prepareQuery.ts
@@ -1,10 +1,19 @@
 import { DocumentNode } from 'graphql';
 import { DataProxy } from 'apollo-cache';
+import Apollo from '..';
 
 export default function prepareQuery<Vars = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<Vars>,
+  docOrQuery: string | DocumentNode | DataProxy.Query<Vars>,
 ): DataProxy.Query<Vars> {
   const query = docOrQuery;
+
+  if (typeof query === 'string') {
+    const cache = Apollo.getDocumentManager().readQuery<Vars>(query);
+
+    if (cache) {
+      return cache;
+    }
+  }
 
   if ((query as DocumentNode).kind) {
     return { query } as DataProxy.Query<Vars>;

--- a/packages/apollo/test/DocumentManager.test.ts
+++ b/packages/apollo/test/DocumentManager.test.ts
@@ -1,0 +1,31 @@
+import gql from 'graphql-tag';
+import DocumentManager from '../src/DocumentManager';
+
+describe('DocumentManager', () => {
+  let manager: DocumentManager;
+
+  beforeEach(() => {
+    manager = new DocumentManager();
+  });
+
+  it('can save and read a query', () => {
+    const query = gql`
+      query {
+        foo {
+          id
+        }
+      }
+    `;
+
+    manager.saveQuery('unique-key', query, { id: 123 });
+
+    expect(manager.readQuery('unique-key')).toEqual({
+      query,
+      variables: { id: 123 },
+    });
+  });
+
+  it('returns null for unknown key', () => {
+    expect(manager.readQuery('unique-key')).toBeNull();
+  });
+});

--- a/packages/apollo/test/updaters/removeFromList.test.ts
+++ b/packages/apollo/test/updaters/removeFromList.test.ts
@@ -51,19 +51,19 @@ describe('removeFromList()', () => {
         `,
         'things',
         3,
-      )(cache);
+      )(cache, {});
     }).toThrowErrorMatchingSnapshot();
   });
 
   it('errors if property name is not an array', () => {
     expect(() => {
       // Should be `something.things`
-      removeFromList(QUERY, 'something.name', 3)(cache);
+      removeFromList(QUERY, 'something.name', 3)(cache, {});
     }).toThrowErrorMatchingSnapshot();
   });
 
   it('removes item from list based on ID', () => {
-    removeFromList(QUERY, 'something.things', 3)(cache);
+    removeFromList(QUERY, 'something.things', 3)(cache, {});
 
     expect(cache.readQuery({ query: QUERY })).toEqual({
       something: {

--- a/packages/apollo/test/utils/prepareQuery.test.ts
+++ b/packages/apollo/test/utils/prepareQuery.test.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import prepareQuery from '../../src/utils/prepareQuery';
+import Apollo from '../../src';
 
 describe('prepareQuery()', () => {
   const query = gql`
@@ -9,6 +10,12 @@ describe('prepareQuery()', () => {
       }
     }
   `;
+
+  it('returns a gql document from the manager cache', () => {
+    Apollo.getDocumentManager().saveQuery('foo-bar', query);
+
+    expect(prepareQuery('foo-bar')).toEqual({ query });
+  });
 
   it('returns a gql document wrapped', () => {
     expect(prepareQuery(query)).toEqual({ query });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- Standardizes our updater types.
- Adds a document manager for making updates easier to use.

## Motivation and Context

Mutations support an [update option](https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-after-a-mutation), which allows the internal cache to be modified. We make use of this with the `addToList` and `removeFromList` updaters in Lunar.

However, for this to work correctly, a query + *exact* variables need to be used, otherwise the query cannot be found in the cache. This can be extremely complicated to achieve, especially if the query and mutation occur in completely different parts of the tree. To mitigate this, the document manager can be used to cache queries by a unique key, in which the updater can use.

```ts
update: addToList('some-query-on-another-page', 'data.list', 'saveData'),
```

## Testing

Unit tests.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
