### PR TITLE
update(Tooltip): Reduce offscreen pattern layer size and render a11y content in Portal

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -156,7 +156,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
       const { current } = this.containerRef;
 
       /* istanbul ignore if: refs are hard */
-      if (current) {
+      if (current && this.mounted) {
         this.setState({ targetRect: current.getBoundingClientRect() });
       }
     });

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -6,6 +6,7 @@ import NotchedBox, { NOTCH_SIZE, NOTCH_SPACING } from '../NotchedBox';
 import Text from '../Text';
 import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import { styleSheet } from './styles';
+import Portal from '../Portal';
 
 const EMPTY_TARGET_RECT: ClientRect = {
   bottom: 0,
@@ -76,7 +77,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
   mounted: boolean = false;
 
-  rafHandle?: number;
+  rafHandle: number = 0;
 
   static getDerivedStateFromProps({ disabled }: Props) {
     if (disabled) {
@@ -105,7 +106,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
   componentWillUnmount() {
     this.mounted = false;
-    cancelAnimationFrame(this.rafHandle as number);
+    cancelAnimationFrame(this.rafHandle);
   }
 
   updateTooltipHeight() {
@@ -150,12 +151,15 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   };
 
   private handleEnter = () => {
-    const { current } = this.containerRef;
+    /* istanbul ignore next: refs are hard */
+    this.rafHandle = requestAnimationFrame(() => {
+      const { current } = this.containerRef;
 
-    /* istanbul ignore if: refs are hard */
-    if (current) {
-      this.setState({ targetRect: current.getBoundingClientRect() });
-    }
+      /* istanbul ignore if: refs are hard */
+      if (current) {
+        this.setState({ targetRect: current.getBoundingClientRect() });
+      }
+    });
 
     if (!this.props.disabled && !this.state.open) {
       this.setState({ open: true });
@@ -213,9 +217,12 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
           {children}
         </div>
 
-        <div id={labelID} className={cx(styles.offscreen)}>
-          {content}
-        </div>
+        {/* render off-screen element in a separate layer */}
+        <Portal>
+          <div id={labelID} className={cx(styles.offscreen)}>
+            {content}
+          </div>
+        </Portal>
 
         <Overlay noBackground open={open} onClose={this.handleClose}>
           <div

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -95,7 +95,7 @@ export default function buildTheme(
       },
       offscreen: {
         position: 'absolute',
-        right: '105vw',
+        left: '-5vw',
         width: 1,
         height: 1,
         overflow: 'hidden',

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -95,7 +95,7 @@ export default function buildTheme(
       },
       offscreen: {
         position: 'absolute',
-        left: -9999,
+        right: '105vw',
         width: 1,
         height: 1,
         overflow: 'hidden',

--- a/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
@@ -17,12 +17,14 @@ exports[`<Tooltip /> can underline 1`] = `
       hello world
     </a>
   </div>
-  <div
-    className="offscreen"
-    id="uuid-test-mock"
-  >
-    test
-  </div>
+  <Portal>
+    <div
+      className="offscreen"
+      id="uuid-test-mock"
+    >
+      test
+    </div>
+  </Portal>
   <Overlay
     noBackground={true}
     onClose={[Function]}
@@ -67,12 +69,14 @@ exports[`<Tooltip /> disabled does not underline 1`] = `
       hello world
     </a>
   </div>
-  <div
-    className="offscreen"
-    id="uuid-test-mock"
-  >
-    test
-  </div>
+  <Portal>
+    <div
+      className="offscreen"
+      id="uuid-test-mock"
+    >
+      test
+    </div>
+  </Portal>
   <Overlay
     noBackground={true}
     onClose={[Function]}
@@ -117,12 +121,14 @@ exports[`<Tooltip /> disabled does not up when hovered 1`] = `
       hello world
     </a>
   </div>
-  <div
-    className="offscreen"
-    id="uuid-test-mock"
-  >
-    test
-  </div>
+  <Portal>
+    <div
+      className="offscreen"
+      id="uuid-test-mock"
+    >
+      test
+    </div>
+  </Portal>
   <Overlay
     noBackground={true}
     onClose={[Function]}
@@ -167,12 +173,14 @@ exports[`<Tooltip /> once open supports changing content 1`] = `
       hello world
     </a>
   </div>
-  <div
-    className="offscreen"
-    id="uuid-test-mock"
-  >
-    whatever
-  </div>
+  <Portal>
+    <div
+      className="offscreen"
+      id="uuid-test-mock"
+    >
+      whatever
+    </div>
+  </Portal>
   <Overlay
     noBackground={true}
     onClose={[Function]}
@@ -218,12 +226,14 @@ exports[`<Tooltip /> opens up when hovered 1`] = `
       hello world
     </a>
   </div>
-  <div
-    className="offscreen"
-    id="uuid-test-mock"
-  >
-    test
-  </div>
+  <Portal>
+    <div
+      className="offscreen"
+      id="uuid-test-mock"
+    >
+      test
+    </div>
+  </Portal>
   <Overlay
     noBackground={true}
     onClose={[Function]}


### PR DESCRIPTION
to: @milesj @stefhatcher @lencioni @etr2460

## Motivation and Context

We've been trying to do some perf optimization in a data-rich app, and noticed that the `left: -9999` style from `pattern.offset` used by `Tooltip` creates a very large layer which can become expensive for transitions and memory usage.

![image](https://user-images.githubusercontent.com/4496521/70297959-d8f17680-17a4-11ea-9821-cec8593871c5.png)

## Description

This PR makes a couple updates to help fix this
- update `pattern.offset` to be `left: -5vw` instead of `-9999px` to reduce its size
- render the persistent offscreen `a11y` tooltip content inside a `<Portal />` so that no matter its size it doesn't affect the flow of the content `<Tooltip />` wraps / is applied to 
- updates a `ref.getBoundingClientRect()` call to be within a `requestAnimationFrame` callback because it for [forces layout/reflow](https://gist.github.com/paulirish/5d52fb081b3570c81e3a#box-metrics) (one call in `Tooltip` was in a `raf` callback, but the other wasn't)

## Testing
- [x] functional 
  - [x] tooltips still function and are correctly positioned
  - [x] `a11y` content is still rendered (now in portal) 
- [x] CI
- [ ] perf
  - I **wasn't** actually able to re-produce the large `Tooltip` layer size in storybook examples unless I set `left: 9999` (instead of `-9999`), but there are no large layers with the portal + `pattern.offscreen` changes. I'm not sure if there is a storybook style that is preventing this 🤔 
  - In storybook it was also tough to test the impact of the new `requestAnimationFrame` on mouseover. I tried profiling but didn't see a significant difference even when rendering ~50 tooltips. If you have any thoughts let me know!

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
