### PR TITLE
new(DataTable): Expose `overscanRowCount` prop

### DIFF
--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -57,6 +57,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     instantEdit: true,
     keys: [],
     minimumDynamicRowHeight: undefined,
+    overscanRowCount: 2,
     renderers: {},
     rowHeight: 'regular',
     selectable: false,
@@ -452,21 +453,22 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
   render() {
     const {
       autoHeight,
+      cx,
       data,
       dynamicRowHeight,
       expandable,
       filterData,
+      height,
+      overscanRowCount,
       propagateRef,
       rowHeight,
       selectable,
-      styles,
       selectedRowsFirst,
+      sortByCacheKey,
+      styles,
       tableHeaderHeight,
-      cx,
       showAllRows,
       width,
-      height,
-      sortByCacheKey,
     } = this.props;
 
     const { expandedRows, sortBy, sortDirection, editMode, selectedRows } = this.state;
@@ -513,7 +515,9 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
             headerRowRenderer={ColumnLabels(this.props)}
             rowHeight={dynamicRowHeight ? this.cache.rowHeight : HEIGHT_TO_PX[rowHeight!]}
             rowStyle={this.getRowStyle(expandedData)}
-            overscanRowCount={dynamicRowHeight && showAllRows ? expandedData.length : 2}
+            overscanRowCount={
+              dynamicRowHeight && showAllRows ? expandedData.length : overscanRowCount!
+            }
             onRowClick={this.handleRowClick}
           >
             {expandable && renderExpandableColumn(cx, styles, expandedRows, this.expandRow)}

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -89,7 +89,7 @@ export interface DataTableProps {
   /**
    * Specify number of additional rows react-virtualized renders in the direction the user is scrolling.
    * The higher the value, the more work react-virtualized needs to do in reaction to each scroll event.
-   * Not respected when
+   * Not respected when both dynamicRowHeight and showAllRows are true.
    */
   overscanRowCount?: number;
   /** Propagated as the 'ref' prop to the underlying react-virtualized Table instance. */

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -58,6 +58,8 @@ export interface DataTableProps {
   columnMetadata?: ColumnMetadata;
   /** Array of data rows. */
   data?: ParentRow[];
+  /** Ref to the underlying DataTable instance. */
+  dataTableRef?: DataTableRef;
   /** If dynamicRowHeight is enabled, this sets the default value for measured row height. */
   defaultDynamicRowHeight?: number;
   /** Default callback on all edits. */
@@ -84,8 +86,12 @@ export interface DataTableProps {
   keys?: string[];
   /** If dynamicRowHeight is enabled, this sets the minimum value for measured row height. */
   minimumDynamicRowHeight?: number;
-  /** Ref to the underlying DataTable instance. */
-  dataTableRef?: DataTableRef;
+  /**
+   * Specify number of additional rows react-virtualized renders in the direction the user is scrolling.
+   * The higher the value, the more work react-virtualized needs to do in reaction to each scroll event.
+   * Not respected when
+   */
+  overscanRowCount?: number;
   /** Propagated as the 'ref' prop to the underlying react-virtualized Table instance. */
   propagateRef?: TableRef;
   /** Custom renderers mapped to column keys. */
@@ -105,8 +111,8 @@ export interface DataTableProps {
   /**
    * If true, will set Table height to accomodate showing _all_ rows.
    * This effectively _disables_ virtualized row rendering and may have detrimental
-+  * performance implications for rendering many rows.
-   * */
+   * performance implications for rendering many rows.
+   */
   showAllRows?: boolean;
   /** If enabled, renders a border between each column. */
   showColumnDividers?: boolean;

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -813,4 +813,16 @@ describe('<DataTable />', () => {
 
     expect(ref.current).not.toBeNull();
   });
+
+  it.only('Passes the specified overscanRowCount to the underlying Table', () => {
+    const count = 14;
+    const wrapper = shallowWithStyles(<DataTable data={data} overscanRowCount={count} />);
+    const table = wrapper
+      .find(StyledDataTable)
+      .dive() // withStyles
+      .dive() // DataTable
+      .find(Table);
+
+    expect(table.prop('overscanRowCount')).toBe(count);
+  });
 });

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -814,7 +814,7 @@ describe('<DataTable />', () => {
     expect(ref.current).not.toBeNull();
   });
 
-  it.only('Passes the specified overscanRowCount to the underlying Table', () => {
+  it('Passes the specified overscanRowCount to the underlying Table', () => {
     const count = 14;
     const wrapper = shallowWithStyles(<DataTable data={data} overscanRowCount={count} />);
     const table = wrapper


### PR DESCRIPTION
to: @milesj @stefhatcher @conglei @schillerk 

## Description

This simply exposes the `react-virtualized` `overscanRowCount` prop in the `DataTable` component.

## Motivation and Context

We have a case where we'd like to change the `overscanRowCount` prop for performance optimization, but currently this prop is not exposed.

## Testing

- [x] CI
  - [x] new jest unit test

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
