### PR TITLE
fix: Fix proofreader crashing by memoizing form input.

### DIFF
--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -148,4 +148,5 @@ FormInput.propTypes = {
   small: sizingProp,
 };
 
-export default FormInput;
+// Proofreader crashes in non-latin languages unless this component is memoized
+export default React.memo(FormInput);


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Before:
<img width="324" alt="Screen Shot 2019-12-12 at 3 41 36 PM" src="https://user-images.githubusercontent.com/143744/70757851-f1f2ae00-1cf5-11ea-8be0-a0b6a3cfab79.png">

After:
<img width="380" alt="Screen Shot 2019-12-12 at 3 41 22 PM" src="https://user-images.githubusercontent.com/143744/70757857-f74ff880-1cf5-11ea-81b2-6870c03a2783.png">


## Motivation and Context

It was broken.

## Testing

Storybook.

## Screenshots

Above.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
