### PR TITLE
new(Layout): Add `centerAlign` prop to layouts.

### DIFF
--- a/packages/layouts/src/components/Layout/index.tsx
+++ b/packages/layouts/src/components/Layout/index.tsx
@@ -3,6 +3,8 @@ import useStyles from '@airbnb/lunar/lib/hooks/useStyles';
 import { styleSheet } from './styles';
 
 export type Props = {
+  /** Horizontally center main content. */
+  centerAlign?: boolean;
   /** The primary main content. */
   children: NonNullable<React.ReactNode>;
   /** Expand main content to full width of viewport. */
@@ -26,6 +28,7 @@ export type AsideProps = {
 export default function Layout({
   after,
   before,
+  centerAlign,
   children,
   fluid,
   minHeight,
@@ -46,7 +49,15 @@ export default function Layout({
           noPadding && styles.main_noPadding,
         )}
       >
-        <div className={cx(!fluid && styles.mainContent)}>{children}</div>
+        <div
+          className={cx(
+            styles.mainContent,
+            centerAlign && styles.mainContent_centerAlign,
+            fluid && styles.mainContent_fluid,
+          )}
+        >
+          {children}
+        </div>
       </main>
 
       {after}

--- a/packages/layouts/src/components/Layout/story.tsx
+++ b/packages/layouts/src/components/Layout/story.tsx
@@ -22,7 +22,19 @@ standardLayout.story = {
   name: 'Standard layout.',
 };
 
-export function withAFixedHeight() {
+export function standardLayoutCentered() {
+  return (
+    <Layout fluid>
+      <LoremIpsum />
+    </Layout>
+  );
+}
+
+standardLayoutCentered.story = {
+  name: 'Wtih `centerAlign`.',
+};
+
+export function withMinHeight() {
   return (
     <Layout minHeight={300}>
       <LoremIpsum />
@@ -30,7 +42,7 @@ export function withAFixedHeight() {
   );
 }
 
-withAFixedHeight.story = {
+withMinHeight.story = {
   name: 'With a custom min-height.',
 };
 

--- a/packages/layouts/src/components/Layout/story.tsx
+++ b/packages/layouts/src/components/Layout/story.tsx
@@ -24,7 +24,7 @@ standardLayout.story = {
 
 export function standardLayoutCentered() {
   return (
-    <Layout fluid>
+    <Layout centerAlign>
       <LoremIpsum />
     </Layout>
   );

--- a/packages/layouts/src/components/Layout/styles.ts
+++ b/packages/layouts/src/components/Layout/styles.ts
@@ -24,6 +24,14 @@ const styleSheet: StyleSheet = ({ breakpoints, color, unit }) => ({
   mainContent: {
     maxWidth: breakpoints.medium,
   },
+
+  mainContent_centerAlign: {
+    margin: '0 auto',
+  },
+
+  mainContent_fluid: {
+    maxWidth: '100%',
+  },
 });
 
 export default styleSheet;

--- a/packages/layouts/test/components/Layout.test.tsx
+++ b/packages/layouts/test/components/Layout.test.tsx
@@ -20,6 +20,18 @@ describe('<Layout />', () => {
     );
 
     expect(wrapper.find('main')).toHaveLength(1);
+    expect(wrapper.find('main').prop('className')).toMatch('main main_noBackground main_noPadding');
+  });
+
+  it('renders center align', () => {
+    const wrapper = shallow(<Layout centerAlign>Child</Layout>);
+
+    expect(
+      wrapper
+        .find('main')
+        .childAt(0)
+        .prop('className'),
+    ).toMatch('mainContent mainContent_centerAlign');
   });
 
   it('renders a before aside', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

towards https://github.com/airbnb/lunar/issues/267

> Right now non-fluid layouts have a max width, but there's no way to center the layouts on the screen. There should be a center prop on the layout that adds margin: auto on the container so that it is visually centered.

## Motivation and Context

centering main content is nice

## Testing

- added a story
- added a test

## Screenshots

default:
<img width="1984" alt="Layouts : Layout - Standard Layout ⋅ Storybook 2019-12-17 13-13-10" src="https://user-images.githubusercontent.com/306275/71034774-03113580-20cf-11ea-9d5f-41c796fa0c8b.png">

with `centerAlign`:
<img width="1984" alt="Layouts : Layout - Standard Layout Centered ⋅ Storybook 2019-12-17 13-14-07" src="https://user-images.githubusercontent.com/306275/71034854-23d98b00-20cf-11ea-9049-82dad8162fc2.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
