### PR TITLE
fix(Tooltip, Overlay): Fix reflows on cDM, cDU, and render

### DIFF
--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -46,12 +46,11 @@ export default class Overlay extends React.PureComponent<Props, State> {
       this.rafHandle = requestAnimationFrame(() => {
         // getBoundingClientRect casues a reflow
         const { x, y } = current.getBoundingClientRect() as DOMRect;
-        if (x !== this.state.x) {
-          this.setState({ x });
-        }
 
-        if (y !== this.state.y) {
-          this.setState({ y });
+        if (x !== this.state.x || y !== this.state.y) {
+          this.rafHandle = requestAnimationFrame(() => {
+            this.setState({ x, y });
+          });
         }
       });
     }

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -48,9 +48,8 @@ export default class Overlay extends React.PureComponent<Props, State> {
         const { x, y } = current.getBoundingClientRect() as DOMRect;
 
         if (x !== this.state.x || y !== this.state.y) {
-          this.rafHandle = requestAnimationFrame(() => {
-            this.setState({ x, y });
-          });
+          // wrapping this in a second rAF caused the tooltip to render at 0,0 for a frame
+          this.setState({ x, y });
         }
       });
     }

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -32,6 +32,8 @@ export default class Overlay extends React.PureComponent<Props, State> {
     y: 0,
   };
 
+  rafHandle: number = 0;
+
   ref = React.createRef<HTMLDivElement>();
 
   scrollers: ArrayOfScrollables = [];
@@ -41,15 +43,17 @@ export default class Overlay extends React.PureComponent<Props, State> {
 
     /* istanbul ignore next: refs are hard */
     if (current) {
-      const { x, y } = current.getBoundingClientRect() as DOMRect;
+      this.rafHandle = requestAnimationFrame(() => {
+        // getBoundingClientRect casues a reflow
+        const { x, y } = current.getBoundingClientRect() as DOMRect;
+        if (x !== this.state.x) {
+          this.setState({ x });
+        }
 
-      if (x !== this.state.x) {
-        this.setState({ x });
-      }
-
-      if (y !== this.state.y) {
-        this.setState({ y });
-      }
+        if (y !== this.state.y) {
+          this.setState({ y });
+        }
+      });
     }
 
     this.removeScrollListeners();
@@ -61,6 +65,7 @@ export default class Overlay extends React.PureComponent<Props, State> {
 
   componentWillUnmount() {
     this.removeScrollListeners();
+    cancelAnimationFrame(this.rafHandle);
   }
 
   private addScrollListeners = debounce(() => {

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -92,10 +92,10 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
   componentDidMount() {
     this.mounted = true;
 
-    requestAnimationFrame(() => {
+    this.rafHandle = requestAnimationFrame(() => {
       const targetRect = document.body.getBoundingClientRect();
 
-      // use a second rAF in case setState becomes expensive
+      // use a second rAF in case setState causes layout thrashing
       this.rafHandle = requestAnimationFrame(() => {
         this.setState({ targetRect });
       });

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -181,42 +181,9 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     this.setState({ open: false });
   };
 
-  render() {
-    const {
-      cx,
-      styles,
-      theme,
-      width: widthProp,
-      children,
-      content,
-      disabled,
-      underlined,
-      inverted,
-    } = this.props;
-    const { open, targetRect, tooltipHeight, labelID } = this.state;
-
-    if (!open) {
-      return (
-        <span ref={this.containerRef} className={cx(styles.container)}>
-          <div
-            aria-labelledby={labelID}
-            className={cx(!disabled && underlined && styles.underlined)}
-            onMouseEnter={this.handleEnter}
-            onMouseLeave={this.handleClose}
-            onMouseDown={this.handleMouseDown}
-          >
-            {children}
-          </div>
-
-          {/* render off-screen element in a separate layer */}
-          <Portal>
-            <div id={labelID} className={cx(styles.offscreen)}>
-              {content}
-            </div>
-          </Portal>
-        </span>
-      );
-    }
+  private renderPopUp() {
+    const { cx, styles, theme, width: widthProp, content, inverted } = this.props;
+    const { open, targetRect, tooltipHeight } = this.state;
 
     const { unit } = theme!;
     const width = widthProp! * unit;
@@ -234,6 +201,38 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
       right: -width + targetWidth,
     };
     const distance = halfNotch + 1;
+
+    return (
+      <Overlay noBackground open={open} onClose={this.handleClose}>
+        <div
+          ref={this.handleTooltipRef}
+          role="tooltip"
+          className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
+            width,
+            marginLeft: marginLeft[align as keyof StyleStruct],
+            marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
+            textAlign: align,
+          })}
+        >
+          <div className={cx(styles.shadow)}>
+            <NotchedBox
+              inverted={!inverted}
+              notchOffset={notchOffset[align as keyof StyleStruct]}
+              notchBelow={above}
+            >
+              <Text inverted={!inverted}>{content}</Text>
+            </NotchedBox>
+          </div>
+        </div>
+      </Overlay>
+    );
+  }
+
+  render() {
+    const { cx, styles, children, content, disabled, underlined } = this.props;
+    const { open, labelID } = this.state;
+
+    const popUp = open ? this.renderPopUp() : null;
 
     return (
       <span ref={this.containerRef} className={cx(styles.container)}>
@@ -254,28 +253,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
           </div>
         </Portal>
 
-        <Overlay noBackground open={open} onClose={this.handleClose}>
-          <div
-            ref={this.handleTooltipRef}
-            role="tooltip"
-            className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
-              width,
-              marginLeft: marginLeft[align as keyof StyleStruct],
-              marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
-              textAlign: align,
-            })}
-          >
-            <div className={cx(styles.shadow)}>
-              <NotchedBox
-                inverted={!inverted}
-                notchOffset={notchOffset[align as keyof StyleStruct]}
-                notchBelow={above}
-              >
-                <Text inverted={!inverted}>{content}</Text>
-              </NotchedBox>
-            </div>
-          </div>
-        </Overlay>
+        {popUp}
       </span>
     );
   }

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -232,8 +232,6 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     const { cx, styles, children, content, disabled, underlined } = this.props;
     const { open, labelID } = this.state;
 
-    const popUp = open ? this.renderPopUp() : null;
-
     return (
       <span ref={this.containerRef} className={cx(styles.container)}>
         <div
@@ -253,7 +251,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
           </div>
         </Portal>
 
-        {popUp}
+        {open ? this.renderPopUp() : null}
       </span>
     );
   }

--- a/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
@@ -25,30 +25,6 @@ exports[`<Tooltip /> can underline 1`] = `
       test
     </div>
   </Portal>
-  <Overlay
-    noBackground={true}
-    onClose={[Function]}
-  >
-    <div
-      className="tooltip tooltip_below inline-0"
-      role="tooltip"
-    >
-      <div
-        className="shadow"
-      >
-        <NotchedBox
-          inverted={true}
-          notchBelow={false}
-        >
-          <Text
-            inverted={true}
-          >
-            test
-          </Text>
-        </NotchedBox>
-      </div>
-    </div>
-  </Overlay>
 </span>
 `;
 
@@ -77,30 +53,6 @@ exports[`<Tooltip /> disabled does not underline 1`] = `
       test
     </div>
   </Portal>
-  <Overlay
-    noBackground={true}
-    onClose={[Function]}
-  >
-    <div
-      className="tooltip tooltip_below inline-0"
-      role="tooltip"
-    >
-      <div
-        className="shadow"
-      >
-        <NotchedBox
-          inverted={true}
-          notchBelow={false}
-        >
-          <Text
-            inverted={true}
-          >
-            test
-          </Text>
-        </NotchedBox>
-      </div>
-    </div>
-  </Overlay>
 </span>
 `;
 
@@ -129,30 +81,6 @@ exports[`<Tooltip /> disabled does not up when hovered 1`] = `
       test
     </div>
   </Portal>
-  <Overlay
-    noBackground={true}
-    onClose={[Function]}
-  >
-    <div
-      className="tooltip tooltip_below inline-0"
-      role="tooltip"
-    >
-      <div
-        className="shadow"
-      >
-        <NotchedBox
-          inverted={true}
-          notchBelow={false}
-        >
-          <Text
-            inverted={true}
-          >
-            test
-          </Text>
-        </NotchedBox>
-      </div>
-    </div>
-  </Overlay>
 </span>
 `;
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
cc: @gaarf @lencioni @williaster 

## Description

Profiling found forced reflows from Tooltip and Overlay. It's hard to say how this affects load, but profiling this causes more layout renders than necessary during page load. My guess is in the order of 0.5 to 1 seconds could be saved based on reported render times. 

Here's a list of what will cause reflows: https://gist.github.com/paulirish/5d52fb081b3570c81e3a


![image](https://user-images.githubusercontent.com/2336595/71135652-126bae00-21b7-11ea-895e-178504b7cda5.png)
**With a 6x CPU throttle about 10% of the page load is rendering.** 

![image](https://user-images.githubusercontent.com/2336595/71135724-41821f80-21b7-11ea-8f8e-c160dbcc5f60.png)
**Here's what one reflow looks like from Tooltip**

## Motivation and Context

Defers calculating page layout via a requestAnimationFrame or until the layout calc is required for rendering.

## Testing

I will update tests after I reproduce this locally in lunar local dev. 

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
