### PR TITLE
fix(TextArea): Wrap reflow in requestAnimationFrame

### DIFF
--- a/packages/core/src/components/private/BaseTextArea.tsx
+++ b/packages/core/src/components/private/BaseTextArea.tsx
@@ -28,7 +28,7 @@ export default class BaseTextArea extends React.Component<Props> {
   reflowRaf: number | null = null;
 
   componentDidMount() {
-    this.reflowTextarea();
+    this.reflowRaf = window.requestAnimationFrame(this.reflowTextarea);
   }
 
   componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

The BaseTextArea's componentDidMount is causing some layout thrashing. This wraps the reflow in a requestAnimationFrame.

![image](https://user-images.githubusercontent.com/2336595/71755601-172f9380-2e40-11ea-9a49-b241f1b6fa2e.png)


## Motivation and Context

Profiling

## Testing

Tests pass 🤞 

## Screenshots

Storybook worked

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
