### PR TITLE
fix(Tooltip): Prevent tooltip from rendering at 0, 0

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -41,6 +41,7 @@ export type State = {
   open: boolean;
   tooltipHeight: number;
   targetRect: ClientRect;
+  targetRectReady: boolean;
 };
 
 export type PositionStruct = {
@@ -69,6 +70,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     open: false,
     tooltipHeight: 0,
     targetRect: EMPTY_TARGET_RECT,
+    targetRectReady: false,
   };
 
   containerRef = React.createRef<HTMLSpanElement>();
@@ -97,7 +99,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
       // use a second rAF in case setState causes layout thrashing
       this.rafHandle = requestAnimationFrame(() => {
-        this.setState({ targetRect });
+        this.setState({ targetRect, targetRectReady: true });
       });
     });
   }
@@ -183,10 +185,10 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
 
   private renderPopUp() {
     const { cx, styles, theme, width: widthProp, content, inverted } = this.props;
-    const { open, targetRect, tooltipHeight } = this.state;
+    const { open, targetRect, tooltipHeight, targetRectReady } = this.state;
 
     // render null until targetRect is initialized by cDM
-    if (targetRect.top === 0 && targetRect.left === 0) {
+    if (!targetRectReady) {
       return null;
     }
 

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -185,6 +185,11 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
     const { cx, styles, theme, width: widthProp, content, inverted } = this.props;
     const { open, targetRect, tooltipHeight } = this.state;
 
+    // render null until targetRect is initialized by cDM
+    if (targetRect.top === 0 && targetRect.left === 0) {
+      return null;
+    }
+
     const { unit } = theme!;
     const width = widthProp! * unit;
 

--- a/packages/core/test/components/Tooltip.test.tsx
+++ b/packages/core/test/components/Tooltip.test.tsx
@@ -16,6 +16,7 @@ describe('<Tooltip />', () => {
         <a href="/">hello world</a>
       </Tooltip>,
     );
+    wrapper.setState({ targetRectReady: true });
     childContainer = wrapper.find('div[aria-labelledby]');
   });
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @gaarf 

## Description

The `Tooltip` can render for one frame at position `0, 0` while `state.targetRect` is being asynchronously set from `componentDidMount` 

## Motivation and Context

Prevent a UI regression.

## Testing

Storybook and existing tests. 

Can log the `state.targetRect` to see its values at render time

**before**
![image](https://user-images.githubusercontent.com/2336595/71858894-bc957200-30a1-11ea-9fc4-39b7cc95597d.png)


## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
