### PR TITLE
new(Modal): Add `persistOnOutsideClick` prop.

### DIFF
--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -18,6 +18,8 @@ export type Props = ModalInnerContentProps & {
   image?: ModalImageConfig;
   /** Fluid width, no max width. */
   fluid?: boolean;
+  /** Keep modal open when clicking outside of the modal (in the blackout). */
+  persistOnOutsideClick?: boolean;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
@@ -48,7 +50,10 @@ export class ModalInner extends React.Component<Props & WithStylesProps> {
   private handleClickOutside = (event: React.MouseEvent | MouseEvent) => {
     const { current } = this.dialogRef;
 
-    if (current && current.contains(event.target as Element)) {
+    if (
+      (current && current.contains(event.target as Element)) ||
+      this.props.persistOnOutsideClick
+    ) {
       return;
     }
 

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -78,6 +78,31 @@ describe('<Modal />', () => {
     expect(closeSpy).toHaveBeenCalled();
   });
 
+  it('doesnt close when clicked outside and persist is enabled', () => {
+    const closeSpy = jest.fn();
+
+    const eventMap: EventMap = {
+      click: null,
+      mouseup: null,
+      mousedown: null,
+    };
+
+    jest.spyOn(document, 'addEventListener').mockImplementation((event, cb) => {
+      // @ts-ignore
+      eventMap[event] = cb;
+    });
+
+    shallowWithStyles(
+      <ModalInner persistOnOutsideClick onClose={closeSpy}>
+        Foo
+      </ModalInner>,
+    );
+
+    eventMap.click!();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
   it('does not close when clicked on self', () => {
     const target = document.createElement('div');
     const closeSpy = jest.fn();


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Keeps the modal open when clicking outside.

## Motivation and Context

We need this functionality. Somewhat related to: https://github.com/airbnb/lunar/issues/273

## Testing

Unit tests.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
