### PR TITLE
update(HierarchyPicker): Pass the current item object to `onItemPicked`.

### DIFF
--- a/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyItem.tsx
@@ -54,10 +54,10 @@ export default function HierarchyItem({
 
   const maybePick = () => {
     if (item.readonly) {
-      onItemPicked(null);
+      onItemPicked(null, null);
       goDeeper();
     } else {
-      onItemPicked(definition);
+      onItemPicked(definition, item);
     }
   };
 

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyList.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/HierarchyList.tsx
@@ -111,7 +111,7 @@ export default function HierarchyList({
           className={cx(styles.asideButton)}
           tabIndex={-1}
           type="button"
-          onClick={() => onItemPicked([...parents, item.name])}
+          onClick={() => onItemPicked([...parents, item.name], item)}
         >
           <ItemDescription item={item} />
         </button>

--- a/packages/core/src/components/HierarchyPicker/Hierarchy/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Hierarchy/index.tsx
@@ -80,8 +80,8 @@ export default class Hierarchy extends React.Component<Props, State> {
     }
   };
 
-  private handleItemPicked = (chosen: TreePath | null) => {
-    this.props.onItemPicked(chosen, { origin: 'Hierarchy' });
+  private handleItemPicked = (chosen: TreePath | null, item: ItemShape | null) => {
+    this.props.onItemPicked(chosen, item, { origin: 'Hierarchy' });
   };
 
   render() {

--- a/packages/core/src/components/HierarchyPicker/Picker/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Picker/index.tsx
@@ -98,10 +98,14 @@ export class Picker extends React.Component<Props & WithStylesProps, State> {
     this.setState({ searchQuery });
   };
 
-  private handleItemPicked = (def: TreePath | null, details?: ChoiceDetails) => {
+  private handleItemPicked = (
+    def: TreePath | null,
+    item: ItemShape | null,
+    details?: ChoiceDetails,
+  ) => {
     if (def) {
       // null if item.readonly
-      this.props.onItemPicked(def, details);
+      this.props.onItemPicked(def, item, details);
       this.props.onClose();
     }
   };

--- a/packages/core/src/components/HierarchyPicker/Search/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/index.tsx
@@ -123,7 +123,8 @@ export class Search extends React.Component<Props & WithStylesProps> {
 
   handleItemPicked = (itemValue: string, result: SearchItemResult | null) => {
     const { query, onItemPicked } = this.props;
-    onItemPicked((result && result.item.definition) || null, {
+
+    onItemPicked(result?.item?.definition ?? null, result?.item ?? null, {
       origin: 'Search',
       charCount: query!.length,
     });

--- a/packages/core/src/components/HierarchyPicker/story.tsx
+++ b/packages/core/src/components/HierarchyPicker/story.tsx
@@ -285,8 +285,8 @@ class PickerDemo extends React.Component<Partial<Props>, { chosen: Props['chosen
           searchWidth={400}
           searchPlaceholder="Search all the things"
           noResultsLabel="No results match your query."
-          onItemPicked={(nextChosen: string[] | null) => {
-            action('onItemPicked')(nextChosen);
+          onItemPicked={(nextChosen: string[] | null, item: object | null, details?: object) => {
+            action('onItemPicked')(nextChosen, item, details);
             this.setState({ chosen: nextChosen || undefined });
           }}
           {...passThroughProps}

--- a/packages/core/src/components/HierarchyPicker/types.ts
+++ b/packages/core/src/components/HierarchyPicker/types.ts
@@ -1,6 +1,8 @@
 import { Item as AutocompleteItem } from '../Autocomplete';
 
 export interface ItemShape {
+  /** Unique ID of the item. */
+  id?: string | number;
   /** Identifier used in chosen definition. */
   name: string;
   /** Localized content displayed in lieu of name. */
@@ -50,7 +52,11 @@ export type ItemRenderer = (
   focused: boolean,
 ) => NonNullable<React.ReactNode>;
 
-export type ItemPickedHandler = (chosen: TreePath | null, details?: ChoiceDetails) => void;
+export type ItemPickedHandler = (
+  chosen: TreePath | null,
+  item: ItemShape | null,
+  details?: ChoiceDetails,
+) => void;
 
 export type DeepFocusHandler = () => void;
 

--- a/packages/core/test/components/HierarchyPicker/Hierarchy.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Hierarchy.test.tsx
@@ -43,8 +43,8 @@ describe('<Hierarchy />', () => {
       const handlePicked = jest.fn();
       const wrapper = shallow(<Hierarchy {...props} onItemPicked={handlePicked} />);
       expect(handlePicked).not.toHaveBeenCalled();
-      wrapper.find(HierarchyList).simulate('itemPicked', ['foo']);
-      expect(handlePicked).toHaveBeenCalledWith(['foo'], {
+      wrapper.find(HierarchyList).simulate('itemPicked', ['foo'], testItems[0]);
+      expect(handlePicked).toHaveBeenCalledWith(['foo'], testItems[0], {
         origin: 'Hierarchy',
       } as ChoiceDetails);
     });

--- a/packages/core/test/components/HierarchyPicker/Picker.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Picker.test.tsx
@@ -115,10 +115,10 @@ describe('<Picker />', () => {
     describe('handleItemPicked', () => {
       it('calls close if passed something', () => {
         const details = { origin: 'Search' };
-        wrapper.find(Search).simulate('itemPicked', ['foo'], details);
+        wrapper.find(Search).simulate('itemPicked', ['foo'], testItems[0], details);
 
         expect(myProps.onClose).toHaveBeenCalled();
-        expect(myProps.onItemPicked).toHaveBeenCalledWith(['foo'], details);
+        expect(myProps.onItemPicked).toHaveBeenCalledWith(['foo'], testItems[0], details);
       });
 
       it('does not call close if passed falsy', () => {

--- a/packages/core/test/components/HierarchyPicker/Search.test.tsx
+++ b/packages/core/test/components/HierarchyPicker/Search.test.tsx
@@ -56,11 +56,19 @@ describe('<Search />', () => {
       v: string,
       r: SearchItemResult,
     ) => void;
+    const item = {
+      ...testItems[0],
+      definition: ['foo'],
+      label: '',
+      formattedParents: '',
+      name: '',
+    };
+
     onSelectItem('', {
-      item: { definition: ['foo'], label: '', formattedParents: '', name: '' },
+      item,
       matches: [],
     });
-    expect(handlePicked).toHaveBeenCalledWith(['foo'], {
+    expect(handlePicked).toHaveBeenCalledWith(['foo'], item, {
       charCount: query.length,
       origin: 'Search',
     } as ChoiceDetails);


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Passes the current item/node object as the 2nd argument to `onItemPicked`. The previous 2nd argument is shifted to the 3rd argument (this only exists for legacy usage).

## Motivation and Context

We need a simple way to access the ID or other metadata for the item being selected. Previously, we only passes the path as an array, which required us to manually walk the tree each time. This change will mitigate that.

## Testing

Unit tests and storybook.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
