### PR TITLE
style: Update dark mode danger colors.

### DIFF
--- a/packages/core/src/themes/dark.ts
+++ b/packages/core/src/themes/dark.ts
@@ -18,7 +18,7 @@ const color: Theme['color']['core'] = {
   // Yellow/Orange
   warning: ['#613806', '#97590E', '#AF6D1C', '#FF8C00', '#F7A800', '#FFB400', '#FFDA80'],
   // Red/Pink
-  danger: ['#5B0606', '#650B0B', '#710909', '#B71C1C', '#EF5D5D', '#FB8585', '#FFA8A8'],
+  danger: ['#350F0F', '#650B0B', '#882018', '#D84141', '#F84747', '#FB8585', '#FFA8A8'],
 };
 
 export default (fontFamily: string) =>


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

### before
<img width="552" alt="beforedanger" src="https://user-images.githubusercontent.com/306275/72835764-28e6a880-3c40-11ea-9198-67573954c8d8.png">

### after
<img width="553" alt="afterdanger" src="https://user-images.githubusercontent.com/306275/72835762-28e6a880-3c40-11ea-878e-f10744f0a995.png">

## Motivation and Context

previous reds were too...red and needed more contrast. thanks @adamirl 

## Testing

storybook

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
