### PR TITLE
fix(Overlay): Prevent Overlay from rendering at 0, 0

### DIFF
--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -101,13 +101,9 @@ export default class Overlay extends React.PureComponent<Props, State> {
     const { onClose, open, children, noBackground } = this.props as Required<Props>;
     const { x, y, targetRectReady } = this.state;
 
-    if (!targetRectReady) {
-      return null;
-    }
-
     return (
       <div ref={this.ref}>
-        {open && (
+        {open && targetRectReady && (
           <Portal
             x={x}
             y={y}

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -18,6 +18,7 @@ export type Props = {
 export type State = {
   x: number;
   y: number;
+  targetRectReady: boolean;
 };
 
 /** An overlay that masks the entire viewport and displays a chunk of content over it. */
@@ -30,6 +31,7 @@ export default class Overlay extends React.PureComponent<Props, State> {
   state = {
     x: 0,
     y: 0,
+    targetRectReady: false,
   };
 
   rafHandle: number = 0;
@@ -48,8 +50,9 @@ export default class Overlay extends React.PureComponent<Props, State> {
         const { x, y } = current.getBoundingClientRect() as DOMRect;
 
         if (x !== this.state.x || y !== this.state.y) {
-          // wrapping this in a second rAF caused the tooltip to render at 0,0 for a frame
-          this.setState({ x, y });
+          this.rafHandle = requestAnimationFrame(() => {
+            this.setState({ x, y, targetRectReady: true });
+          });
         }
       });
     }
@@ -96,7 +99,11 @@ export default class Overlay extends React.PureComponent<Props, State> {
 
   render() {
     const { onClose, open, children, noBackground } = this.props as Required<Props>;
-    const { x, y } = this.state;
+    const { x, y, targetRectReady } = this.state;
+
+    if (!targetRectReady) {
+      return null;
+    }
 
     return (
       <div ref={this.ref}>

--- a/packages/core/test/components/Overlay.test.tsx
+++ b/packages/core/test/components/Overlay.test.tsx
@@ -29,6 +29,7 @@ describe('<Overlay />', () => {
     const eventSpy = jest.spyOn(window, 'addEventListener');
     const closeSpy = jest.fn();
     const wrapper = mountWithStyles(<Overlay onClose={closeSpy}>hello world</Overlay>);
+    wrapper.setState({ targetRectReady: true });
 
     expect(portalSpy).toHaveBeenCalledWith(null, expect.anything());
 
@@ -56,6 +57,7 @@ describe('<Overlay />', () => {
         hello world
       </Overlay>,
     );
+    wrapper.setState({ targetRectReady: true });
     const spy = jest.spyOn(wrapper.instance(), 'forceUpdate');
 
     wrapper.find(Portal).prop('onResize')();
@@ -65,6 +67,7 @@ describe('<Overlay />', () => {
 
   it('does not calls addScrollListeners', () => {
     const wrapper = mountWithStyles<Overlay>(<Overlay {...props}>hello world</Overlay>);
+    wrapper.setState({ targetRectReady: true });
     // @ts-ignore Method not being found on class
     const spy = jest.spyOn(wrapper.instance(), 'addScrollListeners');
 
@@ -84,6 +87,7 @@ describe('<Overlay />', () => {
           hello world
         </Overlay>,
       );
+      wrapper.setState({ targetRectReady: true });
     });
 
     it('calls addScrollListeners when open', () => {
@@ -124,6 +128,7 @@ describe('<Overlay />', () => {
       wrapper = shallowWithStyles(
         <Portal {...props} noBackground onResize={resizeSpy} onClose={closeSpy} />,
       );
+      wrapper.setState({ targetRectReady: true });
       instance = wrapper.instance();
     });
 

--- a/packages/core/test/components/Overlay.test.tsx
+++ b/packages/core/test/components/Overlay.test.tsx
@@ -128,7 +128,6 @@ describe('<Overlay />', () => {
       wrapper = shallowWithStyles(
         <Portal {...props} noBackground onResize={resizeSpy} onClose={closeSpy} />,
       );
-      wrapper.setState({ targetRectReady: true });
       instance = wrapper.instance();
     });
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Fixes tooltips from rendering at 0,0. 

## Motivation and Context

Tooltips are initially rendering at 0,0.

## Testing

Updated tests. 

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
