### PR TITLE
fix(Proofreader): Default prop value to empty string

### DIFF
--- a/packages/core/src/components/TextArea/Proofreader/index.tsx
+++ b/packages/core/src/components/TextArea/Proofreader/index.tsx
@@ -84,6 +84,7 @@ export class Proofreader extends React.Component<Props & WithStylesProps, State,
     isRuleHighlighted: defaultIsRuleHighlighted,
     isRuleSecondary: defaultIsRuleSecondary,
     locale: NO_LOCALE,
+    value: '',
   };
 
   caretRef = React.createRef<HTMLDivElement>();

--- a/packages/core/src/components/TextArea/index.tsx
+++ b/packages/core/src/components/TextArea/index.tsx
@@ -36,6 +36,7 @@ export default class TextArea extends React.Component<Props, State> {
     noTranslate: false,
     proofread: false,
     proofreadProps: undefined,
+    value: '',
   };
 
   state = {

--- a/packages/core/test/components/TextArea/Proofreader.test.tsx
+++ b/packages/core/test/components/TextArea/Proofreader.test.tsx
@@ -87,6 +87,19 @@ describe('<Proofreader />', () => {
     expect(wrapper.state('text')).toBe('bar');
   });
 
+  it('does not error if value is undefined', () => {
+    // @ts-ignore
+    wrapper = shallowWithStyles(<Proofreader {...props} value={undefined} />);
+
+    expect(wrapper.state('text')).toBe('');
+
+    wrapper.setProps({
+      value: 'bar',
+    });
+
+    expect(wrapper.state('text')).toBe('bar');
+  });
+
   it('updates text state and checks new text if it ends with a non-word', () => {
     wrapper.setProps({
       value: 'Hello',


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Fix a case where `prevProps.value` is `undefined`.

## Motivation and Context

![image](https://user-images.githubusercontent.com/2336595/72936698-98ca6100-3d1c-11ea-9021-f49e9ffe80ed.png)


## Testing

Added test

## Screenshots

n/a

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
