### PR TITLE
fix(FilterMenu): Close dropdown after filters are applied.

### DIFF
--- a/packages/core/src/components/MenuToggle/index.tsx
+++ b/packages/core/src/components/MenuToggle/index.tsx
@@ -42,6 +42,8 @@ export type Props = {
   toggleLabel: NonNullable<React.ReactNode>;
   /** Z-index of the menu. */
   zIndex?: number;
+  /** @ignore @private */
+  showDropdown?: boolean;
 };
 
 export type State = {
@@ -60,6 +62,7 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
     ignoreClickOutside: false,
     inverted: false,
     large: false,
+    showDropdown: false,
     small: false,
     zIndex: 1,
   };
@@ -67,8 +70,16 @@ export class MenuToggle extends React.Component<Props & WithStylesProps, State> 
   ref = React.createRef<HTMLDivElement>();
 
   state = {
-    opened: false,
+    opened: Boolean(this.props.showDropdown),
   };
+
+  componentDidUpdate(prevProp: Props & WithStylesProps, prevState: State) {
+    if (this.props.showDropdown !== prevProp.showDropdown) {
+      this.setState({
+        opened: Boolean(this.props.showDropdown),
+      });
+    }
+  }
 
   private handleItemClick = (onClick: () => void) => {
     if (onClick) {

--- a/packages/forms/src/components/FilterMenu/index.tsx
+++ b/packages/forms/src/components/FilterMenu/index.tsx
@@ -122,6 +122,7 @@ export default function FilterMenu({
       dropdownProps={dropdownProps}
       large={large}
       menuProps={menuProps}
+      showDropdown={opened}
       small={small}
       toggleLabel={activeCountLabel || toggleLabel}
       zIndex={zIndex}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

with the recent refactor of FilterMenu, the functionality of closing on apply broke. this fixes that!

## Motivation and Context

help unblock a team from updating

## Testing

storybook
tests still pass!

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
