### PR TITLE
new(Row): Reduce inline padding [WIP]

### DIFF
--- a/packages/core/src/components/Row/index.tsx
+++ b/packages/core/src/components/Row/index.tsx
@@ -51,11 +51,12 @@ export default function Row({
       className={cx(
         styles.row,
         { maxHeight, minHeight },
-        compact && styles.row_compact,
+        compact && !inline && styles.row_compact,
         spacious && styles.row_spacious,
         middleAlign && styles.row_middleAlign,
         baseline && styles.row_baseline,
         topline && styles.row_topline,
+        inline && styles.row_inline,
       )}
     >
       {before && (
@@ -64,6 +65,7 @@ export default function Row({
             styles.before,
             inline && styles.inline,
             (inline || compact) && styles.before_compact,
+            inline && compact && styles.before_compact_inline,
           )}
         >
           {before}
@@ -85,6 +87,7 @@ export default function Row({
             styles.after,
             inline && styles.inline,
             (inline || compact) && styles.after_compact,
+            inline && compact && styles.after_compact_inline,
           )}
         >
           {after}

--- a/packages/core/src/components/Row/story.tsx
+++ b/packages/core/src/components/Row/story.tsx
@@ -142,6 +142,16 @@ export function allPaddingOptions() {
       <Row baseline after={<Button>Take an action</Button>}>
         <Text>A row with no padding.</Text>
       </Row>
+
+      <Row inline after={<Button>Take an action</Button>}>
+        <Text>An inline row with no vertical padding.</Text>
+      </Row>
+
+      <Row compact inline after={<Button>Take an action</Button>}>
+        <Text>
+          A inline and compact row with no vertical padding and low horizontal padding (4px).
+        </Text>
+      </Row>
     </div>
   );
 }

--- a/packages/core/src/components/Row/styles.ts
+++ b/packages/core/src/components/Row/styles.ts
@@ -27,6 +27,11 @@ const styleSheet: StyleSheet = ({ ui, unit }) => ({
     borderTop: ui.border,
   },
 
+  row_inline: {
+    borderTop: 0,
+    borderBottom: 0,
+  },
+
   after: {
     paddingLeft: unit * 2,
     flexShrink: 0,
@@ -36,6 +41,10 @@ const styleSheet: StyleSheet = ({ ui, unit }) => ({
     paddingLeft: unit,
   },
 
+  after_compact_inline: {
+    paddingLeft: 0.5 * unit,
+  },
+
   before: {
     paddingRight: unit * 2,
     flexShrink: 0,
@@ -43,6 +52,10 @@ const styleSheet: StyleSheet = ({ ui, unit }) => ({
 
   before_compact: {
     paddingRight: unit,
+  },
+
+  before_compact_inline: {
+    paddingRight: 0.5 * unit,
   },
 
   primary: {


### PR DESCRIPTION
## Description
Discussed in Lunar Project Planning (see agenda).

With `compact` and `inline` both enabled, before/after padding down to `0.5 * unit`.
With `inline` enabled, no vertical padding.


<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
<img width="1162" alt="Screen Shot 2020-02-03 at 1 17 09 PM" src="https://user-images.githubusercontent.com/8676510/73691593-7ffc6c80-4687-11ea-8f17-d3af0a21a0b3.png">
<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
