### PR TITLE
new(FormActions): Add `block` option to buttons.

### DIFF
--- a/packages/core/src/components/FormActions/index.tsx
+++ b/packages/core/src/components/FormActions/index.tsx
@@ -6,6 +6,8 @@ import MutedButton from '../MutedButton';
 import ButtonGroup from '../ButtonGroup';
 
 export type Props = {
+  /** Render buttons as a block with full width. */
+  block?: boolean;
   /** Text to display in the cancel button. Defaults to "Cancel". */
   cancelText?: React.ReactNode;
   /** Text to display in the continue/submit button. Defaults to "Submit". */
@@ -49,6 +51,7 @@ export default class FormActions extends React.PureComponent<Props> {
 
   render() {
     const {
+      block,
       cancelText,
       continueText,
       danger,
@@ -65,9 +68,10 @@ export default class FormActions extends React.PureComponent<Props> {
     const Button = danger ? DangerButton : NormalButton;
 
     return (
-      <ButtonGroup>
+      <ButtonGroup stacked={block}>
         <Button
           type="submit"
+          block={block}
           disabled={disabled}
           loading={processing}
           small={small}
@@ -87,7 +91,13 @@ export default class FormActions extends React.PureComponent<Props> {
         </Button>
 
         {!hideCancel && (
-          <MutedButton inverted small={small} disabled={processing} onClick={onCancel}>
+          <MutedButton
+            inverted
+            block={block}
+            small={small}
+            disabled={processing}
+            onClick={onCancel}
+          >
             {cancelText || (
               <T
                 k="lunar.common.cancel"
@@ -99,7 +109,7 @@ export default class FormActions extends React.PureComponent<Props> {
         )}
 
         {showReset && (
-          <MutedButton inverted type="reset" small={small} disabled={processing}>
+          <MutedButton inverted block={block} type="reset" small={small} disabled={processing}>
             {resetText || (
               <T k="lunar.common.reset" phrase="Reset" context="Button label to reset a form" />
             )}

--- a/packages/core/src/components/FormActions/story.tsx
+++ b/packages/core/src/components/FormActions/story.tsx
@@ -62,3 +62,11 @@ export function inADangerState() {
 inADangerState.story = {
   name: 'In a danger state.',
 };
+
+export function withBlockButton() {
+  return <FormActions block />;
+}
+
+withBlockButton.story = {
+  name: 'Full width buttons, stacked with `block`.',
+};

--- a/packages/core/test/components/FormActions.test.tsx
+++ b/packages/core/test/components/FormActions.test.tsx
@@ -92,4 +92,10 @@ describe('<FormActions />', () => {
 
     wrapper.find(Button).forEach(button => expect(button.prop('small')).toBeFalsy());
   });
+
+  it('renders buttons with block', () => {
+    const wrapper = shallowWithStyles(<FormActions block />);
+
+    expect(wrapper.find(Button).prop('block')).toBe(true);
+  });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

adds a `block`prop, to render FormActions buttons full width

## Motivation and Context

sometimes, you want a submit button that's full width! cancel/reset stack with `block` enabled

## Testing

storybook
tests

## Screenshots

<img width="1279" alt="Screen Shot 2020-02-03 at 12 10 46 PM" src="https://user-images.githubusercontent.com/306275/73697011-690f4780-4692-11ea-8fa0-f82a2a389c4c.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
