### PR TITLE
update(DataTable): Reduce padding for first/last column.

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -84,7 +84,7 @@ export default function ColumnLabels({
         !columnMetadata || !columnMetadata[key] || columnMetadata[key].disableSorting !== 1;
 
       const newHeader = (
-        <Spacing left={indent ? 2 : 0}>
+        <Spacing left={indent && !isLeftmost ? 2 : 0}>
           <div style={heightStyle} className={cx(showDivider && styles && styles.column_divider)}>
             <div
               style={columnMetadata?.[key]?.rightAlign ? rightAlignmentStyle : {}}

--- a/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
+++ b/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
@@ -44,6 +44,7 @@ export default function renderDataColumns<T>(
     const { isChild } = metadata;
     const customRenderer = renderers?.[key];
     const isLeftmost = columnIndex === 0;
+    const isRightmost = columnIndex === keys.length - 1;
     const indentSize = !expandable || !isLeftmost ? 2 : 2.5;
     const spacing = isChild || !(expandable && isLeftmost) ? indentSize : 0;
     const rendererArguments: RendererProps<T> = {
@@ -66,7 +67,7 @@ export default function renderDataColumns<T>(
     const contents = React.createElement(customRenderer || DefaultRenderer, rendererArguments);
 
     return (
-      <Spacing left={spacing} right={2}>
+      <Spacing left={isLeftmost ? 0 : spacing} right={isRightmost ? 0 : 2}>
         {contents || ''}
       </Spacing>
     );

--- a/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
@@ -24,7 +24,7 @@ export default function renderExpandableColumn(
           onClick={expandRow(originalIndex)}
           onKeyPress={expandRow(originalIndex)}
         >
-          <Spacing left={1.5}>
+          <Spacing left={0.5}>
             <ExpandableIcon expanded={expandedRows.has(originalIndex)} size="1.6em" />
           </Spacing>
         </div>

--- a/packages/core/src/components/DataTable/constants.tsx
+++ b/packages/core/src/components/DataTable/constants.tsx
@@ -31,4 +31,4 @@ export const DEFAULT_WIDTH_PROPERTIES: WidthProperties = {
   minWidth: 0,
 };
 
-export const EXPANDABLE_COLUMN_WIDTH = 50;
+export const EXPANDABLE_COLUMN_WIDTH = 32;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Removing padding from the first and last columns of DataTable. They were inconsistent with @kenchendesign's mocks, and required negative margins to correct against, which is super messy.

![Screen Shot 2020-02-03 at 5 01 43 PM](https://user-images.githubusercontent.com/8676510/73704107-e2b13080-46a6-11ea-9bd4-092176b3e2cf.png)
![Screen Shot 2020-02-03 at 5 01 50 PM](https://user-images.githubusercontent.com/8676510/73704122-e47af400-46a6-11ea-95fb-58f36ef5df71.png)

<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
