### PR TITLE
fix: Update phrase keys and add extraction script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ storybook-static/
 # Custom
 *.min.js
 *.map
+phrases.json
 
 # Configs (provided by Nimbus)
 .babelrc
@@ -42,5 +43,4 @@ prettier.config.js
 tsconfig.json
 tsconfig.eslint.json
 *.tsbuildinfo
-
 .prettierrc

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "yarn run type && yarn run babel && yarn run clean:story",
     "build:sizes": "yarn run ts ./scripts/tasks/computeBuildSizes.ts",
     "build:storybook": "build-storybook",
+    "build:phrases": "yarn run ts ./scripts/tasks/extractPhrases.ts",
     "check:build": "yarn run ts ./scripts/checks/compareBuildSizes.ts",
     "check:happo:dark": "THEME=dark happo-ci-travis",
     "check:happo:light": "THEME=light happo-ci-travis",

--- a/packages/composer/src/components/Actions/ActionButton.tsx
+++ b/packages/composer/src/components/Actions/ActionButton.tsx
@@ -8,7 +8,7 @@ export default function ActionButton() {
   return (
     <ToggleButton
       accessibilityLabel={T.phrase('Open actions menu', null, {
-        key: 'composer.labels.openActionsMenu',
+        key: 'lunar.composer.labels.openActionsMenu',
       })}
       icon={IconAddAlt}
       menu={MENU_ACTIONS}

--- a/packages/composer/src/components/Actions/index.tsx
+++ b/packages/composer/src/components/Actions/index.tsx
@@ -39,7 +39,7 @@ export default function Actions({ actions, endAlign, noWritingModes }: ActionsPr
     <Menu borderless startAlign={!endAlign} endAlign={endAlign} name={MENU_ACTIONS} width={215}>
       <ItemMenu
         overflow
-        accessibilityLabel={T.phrase('Actions menu', null, { key: 'composer.actions.label' })}
+        accessibilityLabel={T.phrase('Actions menu', null, { key: 'lunar.composer.actions.label' })}
         maxHeight={MAX_MENU_HEIGHT}
       >
         {Object.entries(groupedActions).map(([group, acts], index) => (

--- a/packages/composer/src/components/Emojis/EmojiButton.tsx
+++ b/packages/composer/src/components/Emojis/EmojiButton.tsx
@@ -8,7 +8,7 @@ export default function EmojiButton() {
   return (
     <ToggleButton
       accessibilityLabel={T.phrase('Open emoji picker', null, {
-        key: 'composer.labels.openEmojiPicker',
+        key: 'lunar.composer.labels.openEmojiPicker',
       })}
       icon={IconStarAlt}
       menu={MENU_EMOJIS}

--- a/packages/composer/src/components/Input/InlineInput.tsx
+++ b/packages/composer/src/components/Input/InlineInput.tsx
@@ -26,7 +26,11 @@ export default function InlineInput({ label, name, value }: InlineInputProps) {
       {label}
     </Text>
   );
-  const editLabel = T.phrase('Edit %{name} field', { name }, { key: 'composer.labels.editField' });
+  const editLabel = T.phrase(
+    'Edit %{name} field',
+    { name },
+    { key: 'lunar.composer.labels.editField' },
+  );
   const editButton = (
     <IconButton onClick={() => setEditing(!editing)}>
       {editing ? (

--- a/packages/composer/src/components/Input/index.tsx
+++ b/packages/composer/src/components/Input/index.tsx
@@ -56,15 +56,16 @@ export default function Input({
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const blocked = disabled || invalid || context.data.value.trim() === '';
   let placeholder =
-    messagePlaceholder ?? T.phrase('Send message…', null, { key: 'composer.labels.sendMessage' });
+    messagePlaceholder ??
+    T.phrase('Send message…', null, { key: 'lunar.composer.labels.sendMessage' });
 
   if (context.mode === MODE_EMAIL) {
     placeholder =
-      emailPlaceholder ?? T.phrase('Send email…', null, { key: 'composer.labels.sendEmail' });
+      emailPlaceholder ?? T.phrase('Send email…', null, { key: 'lunar.composer.labels.sendEmail' });
   } else if (context.mode === MODE_PRIVATE_NOTE) {
     placeholder =
       privateNotePlaceholder ??
-      T.phrase('Private to Airbnb', null, { key: 'composer.labels.privateToAirbnb' });
+      T.phrase('Private to Airbnb', null, { key: 'lunar.composer.labels.privateToAirbnb' });
   }
 
   // Form handlers
@@ -131,13 +132,13 @@ export default function Input({
       {context.mode === MODE_EMAIL && (
         <>
           <InlineInput
-            label={T.phrase('Re:', null, { key: 'composer.email.subjectLine' })}
+            label={T.phrase('Re:', null, { key: 'lunar.composer.email.subjectLine' })}
             name="emailSubject"
             value={context.data.emailSubject}
           />
 
           <InlineInput
-            label={T.phrase('To:', null, { key: 'composer.email.toLine' })}
+            label={T.phrase('To:', null, { key: 'lunar.composer.email.toLine' })}
             name="emailTo"
             value={context.data.emailTo}
           />
@@ -182,7 +183,7 @@ export default function Input({
         <span className={cx(styles.submitButton)}>
           <IconButton
             accessibilityLabel={T.phrase('Submit composer', null, {
-              key: 'composer.labels.submitComposer',
+              key: 'lunar.composer.labels.submitComposer',
             })}
             disabled={blocked}
             icon={IconPlayAlt}
@@ -198,8 +199,8 @@ export default function Input({
           name="submit"
           label={
             context.flags.previewConfirm
-              ? T.phrase('to preview', null, { key: 'composer.hotkey.returnToPreview' })
-              : T.phrase('to send', null, { key: 'composer.hotkey.returnToSend' })
+              ? T.phrase('to preview', null, { key: 'lunar.composer.hotkey.returnToPreview' })
+              : T.phrase('to send', null, { key: 'lunar.composer.hotkey.returnToSend' })
           }
           order={100}
           onRun={handleSubmit}
@@ -210,7 +211,7 @@ export default function Input({
           combo="esc"
           condition={activeWhenMenuOpen}
           name="closeMenu"
-          label={T.phrase('to dismiss', null, { key: 'composer.hotkey.toDismiss' })}
+          label={T.phrase('to dismiss', null, { key: 'lunar.composer.hotkey.toDismiss' })}
           onRun={closeMenu}
         />
       </div>

--- a/packages/composer/src/components/Preview/Window.tsx
+++ b/packages/composer/src/components/Preview/Window.tsx
@@ -23,7 +23,7 @@ export default function Window({ children, controls, onConfirm }: WindowProps) {
           middleAlign
           after={
             <Button small onClick={onConfirm}>
-              <T phrase="Send" k="composer.labels.send" />
+              <T phrase="Send" k="lunar.composer.labels.send" />
             </Button>
           }
         >

--- a/packages/composer/src/components/Preview/index.tsx
+++ b/packages/composer/src/components/Preview/index.tsx
@@ -53,7 +53,7 @@ export default function Preview({
           !requireConfirmation && !!data.focused && data.value !== '' && !data.value.startsWith('/')
         }
         name="showPreview"
-        label={T.phrase('to preview', null, { key: 'composer.hotkey.returnToPreview' })}
+        label={T.phrase('to preview', null, { key: 'lunar.composer.hotkey.returnToPreview' })}
         order={100}
         onRun={ctx => onSubmitShowPreview(ctx.data, ctx)}
       />
@@ -61,7 +61,7 @@ export default function Preview({
       <Menu
         centerAlign
         name={MENU_PREVIEW}
-        title={<T k="composer.preview.title" phrase="Preview" />}
+        title={<T k="lunar.composer.preview.title" phrase="Preview" />}
       >
         {onProofread ? (
           <Proofreader

--- a/packages/composer/src/components/Shortcuts.tsx
+++ b/packages/composer/src/components/Shortcuts.tsx
@@ -74,7 +74,7 @@ export default function Shortcuts({ shortcuts }: ShortcutsProps) {
         combo="/"
         condition={showWhenNoMenuOrValueCondition}
         name="openShortcutMenu"
-        label={T.phrase('to shortcuts', null, { key: 'composer.shortcuts.hotkey.toOpen' })}
+        label={T.phrase('to shortcuts', null, { key: 'lunar.composer.shortcuts.hotkey.toOpen' })}
         onRun={openShortcutsMenu}
       />
 
@@ -83,7 +83,7 @@ export default function Shortcuts({ shortcuts }: ShortcutsProps) {
         combo="up"
         condition={activeWhenShortcutsMenuOpen}
         name="moveUpShortcutMenu"
-        label={T.phrase('up', null, { key: 'composer.shortcuts.hotkey.moveUp' })}
+        label={T.phrase('up', null, { key: 'lunar.composer.shortcuts.hotkey.moveUp' })}
         onRun={moveUp}
       />
 
@@ -92,7 +92,7 @@ export default function Shortcuts({ shortcuts }: ShortcutsProps) {
         combo="down"
         condition={activeWhenShortcutsMenuOpen}
         name="moveDownShortcutMenu"
-        label={T.phrase('down', null, { key: 'composer.shortcuts.hotkey.moveDown' })}
+        label={T.phrase('down', null, { key: 'lunar.composer.shortcuts.hotkey.moveDown' })}
         onRun={moveDown}
       />
 
@@ -101,19 +101,19 @@ export default function Shortcuts({ shortcuts }: ShortcutsProps) {
         combo="enter"
         condition={activeWhenShortcutsMenuOpen}
         name="selectShortcut"
-        label={T.phrase('to select', null, { key: 'composer.shortcuts.hotkey.toSelect' })}
+        label={T.phrase('to select', null, { key: 'lunar.composer.shortcuts.hotkey.toSelect' })}
         onRun={selectShortcut}
       />
 
       <Menu
         centerAlign
         name={MENU_SHORTCUTS}
-        title={<T k="composer.shortcuts.title" phrase="Shortcuts" />}
+        title={<T k="lunar.composer.shortcuts.title" phrase="Shortcuts" />}
       >
         <SelectList
           noResults={
             <T
-              k="composer.shortcuts.noResults"
+              k="lunar.composer.shortcuts.noResults"
               phrase="No shortcuts found for %{name}."
               name={inputName}
             />

--- a/packages/composer/src/components/Suggestions.tsx
+++ b/packages/composer/src/components/Suggestions.tsx
@@ -59,7 +59,7 @@ export default function Suggestions({ noCache = false, throttle = 200, onLoad }:
       combo="tab"
       condition={activeWhenShadowExists}
       name="tabSelectSuggestion"
-      label={T.phrase('to select', null, { key: 'composer.suggestions.hotkey.select' })}
+      label={T.phrase('to select', null, { key: 'lunar.composer.suggestions.hotkey.select' })}
       onRun={selectShadowSuggestion}
     />
   );

--- a/packages/composer/src/helpers/actions.ts
+++ b/packages/composer/src/helpers/actions.ts
@@ -6,13 +6,13 @@ import { MODE_MESSAGE, MODE_EMAIL, MODE_PRIVATE_NOTE } from '../constants';
 import { ActionConfig, GroupedActions } from '../types';
 
 export function getWritingModeActions(): ActionConfig[] {
-  const groupLabel = T.phrase('New…', null, { key: 'composer.actions.group.new' });
+  const groupLabel = T.phrase('New…', null, { key: 'lunar.composer.actions.group.new' });
 
   return [
     {
       condition: ({ mode }) => mode !== MODE_MESSAGE,
       group: groupLabel,
-      label: T.phrase('Message', null, { key: 'composer.actions.label.message' }),
+      label: T.phrase('Message', null, { key: 'lunar.composer.actions.label.message' }),
       icon: IconChatGroup,
       onRun: ({ setMode }) => {
         setMode(MODE_MESSAGE);
@@ -21,7 +21,7 @@ export function getWritingModeActions(): ActionConfig[] {
     {
       condition: ({ mode }) => mode !== MODE_EMAIL,
       group: groupLabel,
-      label: T.phrase('Email', null, { key: 'composer.actions.label.email' }),
+      label: T.phrase('Email', null, { key: 'lunar.composer.actions.label.email' }),
       icon: IconEmail,
       onRun: ({ setMode }) => {
         setMode(MODE_EMAIL);
@@ -30,7 +30,7 @@ export function getWritingModeActions(): ActionConfig[] {
     {
       condition: ({ mode }) => mode !== MODE_PRIVATE_NOTE,
       group: groupLabel,
-      label: T.phrase('Private note', null, { key: 'composer.actions.label.privateNote' }),
+      label: T.phrase('Private note', null, { key: 'lunar.composer.actions.label.privateNote' }),
       icon: IconLock,
       onRun: ({ setMode }) => {
         setMode(MODE_PRIVATE_NOTE);

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -3,7 +3,7 @@ import withStyles, { WithStylesProps } from '../../composers/withStyles';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
-import Translate from '../Translate';
+import T from '../Translate';
 import { HeaderButton, SelectedRows } from './types';
 import { styleSheetTableHeader as styleSheet } from './styles';
 
@@ -80,23 +80,19 @@ export function TableHeader({
 
   const editModeButtons = instantEdit ? (
     <Button key="Done" small onClick={onDisableEditMode}>
-      <Translate k="lunar.common.done" phrase="Done" context="This button exits edit mode." />
+      <T k="lunar.common.done" phrase="Done" context="This button exits edit mode." />
     </Button>
   ) : (
     [
       <Button key="Cancel" small inverted onClick={onDisableEditMode}>
-        <Translate
+        <T
           k="lunar.common.cancel"
           phrase="Cancel"
           context="This button cancels out of edit mode without applying changes."
         />
       </Button>,
       <Button key="Apply" small onClick={onEnactEdits}>
-        <Translate
-          k="lunar.common.apply"
-          phrase="Apply"
-          context="This button applies all live edits."
-        />
+        <T k="lunar.common.apply" phrase="Apply" context="This button applies all live edits." />
       </Button>,
     ]
   );
@@ -105,7 +101,7 @@ export function TableHeader({
     editModeButtons
   ) : (
     <Button inverted small onClick={onEnableEditMode}>
-      <Translate k="lunar.common.edit" phrase="Edit" context="This button enables edit mode." />
+      <T k="lunar.common.edit" phrase="Edit" context="This button enables edit mode." />
     </Button>
   );
 

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -173,7 +173,8 @@ class SearchDemo extends React.Component {
 export default {
   title: 'Core/DataTable',
   parameters: {
-    happo: { delay: 50 },
+    // Causes OOM errors
+    happo: false,
     inspectComponents: [DataTable],
   },
 };

--- a/packages/core/src/components/ImageViewer/RotateControls.tsx
+++ b/packages/core/src/components/ImageViewer/RotateControls.tsx
@@ -29,22 +29,20 @@ export default function RotateControls(props: Props) {
     <ButtonGroup>
       <IconButton onClick={handleRotateLeft}>
         <IconRotateLeft
-          accessibilityLabel={T.phrase(
-            'Rotate counter clockwise',
-            null,
-            'Label for button that rotates an image counter clockwise',
-          )}
+          accessibilityLabel={T.phrase('Rotate counter clockwise', null, {
+            key: 'lunar.image.rotateCounterClockwise',
+            context: 'Label for button that rotates an image counter clockwise',
+          })}
           size="2em"
         />
       </IconButton>
 
       <IconButton onClick={handleRotateRight}>
         <IconRotateRight
-          accessibilityLabel={T.phrase(
-            'Rotate clockwise',
-            null,
-            'Label for button that rotates an image clockwise',
-          )}
+          accessibilityLabel={T.phrase('Rotate clockwise', null, {
+            key: 'lunar.image.rotateClockwise',
+            context: 'Label for button that rotates an image clockwise',
+          })}
           size="2em"
         />
       </IconButton>

--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -69,7 +69,11 @@ export default function ZoomControls(props: Props) {
       <ButtonGroup>
         <IconButton disabled={scale === 1} onClick={handleZoomOut}>
           <IconRemove
-            accessibilityLabel={T.phrase('Zoom out', {}, 'Label for zoom out button')}
+            accessibilityLabel={T.phrase(
+              'Zoom out',
+              {},
+              { key: 'lunar.image.zoomOut', context: 'Label for zoom out button' },
+            )}
             size="2em"
           />
         </IconButton>
@@ -80,7 +84,11 @@ export default function ZoomControls(props: Props) {
 
         <IconButton onClick={handleZoomIn}>
           <IconAdd
-            accessibilityLabel={T.phrase('Zoom in', {}, 'Label for zoom in button')}
+            accessibilityLabel={T.phrase(
+              'Zoom in',
+              {},
+              { key: 'lunar.image.zoomIn', context: 'Label for zoom in button' },
+            )}
             size="2em"
           />
         </IconButton>
@@ -92,7 +100,7 @@ export default function ZoomControls(props: Props) {
             accessibilityLabel={T.phrase(
               'Zoom dropdown menu',
               {},
-              'Label for dropdown menu with zoom options',
+              { key: 'lunar.image.zoomMenu', context: 'Label for dropdown menu with zoom options' },
             )}
           >
             {zoomOptions.map(zoom => (

--- a/packages/core/src/components/Lightbox/Header.tsx
+++ b/packages/core/src/components/Lightbox/Header.tsx
@@ -119,7 +119,11 @@ export class Header extends React.PureComponent<Props & WithStylesProps> {
             hasPrev={activeIndex > 0}
             hasNext={activeIndex < imageCount - 1}
             page={activeIndex + 1}
-            pageLabel={T.phrase('Photo', {}, 'Label for photo pagination')}
+            pageLabel={T.phrase(
+              'Photo',
+              {},
+              { key: 'lunar.image.photoLabel', context: 'Label for photo pagination' },
+            )}
             pageCount={imageCount}
             onNext={this.handleNext}
             onPrevious={this.handlePrev}
@@ -144,8 +148,22 @@ export class Header extends React.PureComponent<Props & WithStylesProps> {
           <div className={cx(styles.infoButton)}>
             <Button small onClick={this.props.onToggleAside}>
               {hideAside
-                ? T.phrase('Show Info', {}, 'Shows sidebar information in the Lightbox')
-                : T.phrase('Hide Info', {}, 'Hides sidebar information in the Lightbox')}
+                ? T.phrase(
+                    'Show info',
+                    {},
+                    {
+                      key: 'lunar.image.showInfo',
+                      context: 'Shows sidebar information in the Lightbox',
+                    },
+                  )
+                : T.phrase(
+                    'Hide info',
+                    {},
+                    {
+                      key: 'lunar.image.hideInfo',
+                      context: 'Hides sidebar information in the Lightbox',
+                    },
+                  )}
             </Button>
           </div>
         )}

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -157,7 +157,7 @@ function Pagination({
     showBookends && pageCount ? (
       <T
         k="lunar.pagination.pageCount"
-        phrase={'%{pageNumber} of %{pageCount}'}
+        phrase="%{pageNumber} of %{pageCount}"
         pageCount={pageCount}
         pageNumber={page}
         context="Showing the current page number and total page count"
@@ -171,7 +171,7 @@ function Pagination({
       showBookends && pageCount ? (
         <T
           k="lunar.pagination.pageCountLabeled"
-          phrase={'%{pageLabel} %{pageNumber} of %{pageCount}'}
+          phrase="%{pageLabel} %{pageNumber} of %{pageCount}"
           pageLabel={pageLabel}
           pageCount={pageCount}
           pageNumber={page}
@@ -180,7 +180,7 @@ function Pagination({
       ) : (
         <T
           k="lunar.pagination.pageNumberLabeled"
-          phrase={'%{pageLabel} %{pageNumber}'}
+          phrase="%{pageLabel} %{pageNumber}"
           pageLabel={pageLabel}
           pageNumber={page}
           context="Showing the current page number"

--- a/packages/core/src/components/Pagination/story.tsx
+++ b/packages/core/src/components/Pagination/story.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Pagination from '.';
-import T from '../Translate';
 
 export default {
   title: 'Core/Pagination',
@@ -58,7 +57,7 @@ export function withLabel() {
     <Pagination
       hasPrev
       hasNext
-      pageLabel={T.phrase('Photo', {}, 'Label for photo pagination')}
+      pageLabel="Photo"
       page={2}
       onNext={action('onNext')}
       onPrevious={action('onPrevious')}

--- a/packages/core/src/components/Proofreader/helpers.ts
+++ b/packages/core/src/components/Proofreader/helpers.ts
@@ -53,7 +53,7 @@ export function getLocaleDefinition(locale: string): LocaleDefinition {
         {},
         {
           context: 'No language selected for spell and grammar checking',
-          key: 'composer.proofreader.noLanguageSelected',
+          key: 'lunar.proofreader.noLanguageSelected',
         },
       ),
     };
@@ -67,7 +67,7 @@ export function getLocaleDefinition(locale: string): LocaleDefinition {
         {},
         {
           context: 'Auto-detect language for spell and grammar checking',
-          key: 'composer.proofreader.autoDetectLanguage',
+          key: 'lunar.proofreader.autoDetectLanguage',
         },
       ),
     };

--- a/packages/core/src/components/Translate/story.tsx
+++ b/packages/core/src/components/Translate/story.tsx
@@ -74,11 +74,7 @@ handleContextualMessagesBasedOnCounts.story = {
 export function returnAStringInsteadOfRenderingAComponent() {
   return (
     <div>
-      {Translate.phrase(
-        'Hello %{name}',
-        { name: 'Bruce' },
-        'This message is for translation editors.',
-      )}
+      {T.phrase('Hello %{name}', { name: 'Bruce' }, 'This message is for translation editors.')}
     </div>
   );
 }

--- a/packages/core/src/components/Translate/story.tsx
+++ b/packages/core/src/components/Translate/story.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import Text from '../Text';
-import Translate from '.';
+import T from '.';
 
 export default {
   title: 'Core/Translate',
   parameters: {
-    inspectComponents: [Translate],
+    inspectComponents: [T],
   },
 };
 
 export function displayAMessageWithAnEditorRelatedContext() {
   return (
     <Text>
-      <Translate
+      <T
         phrase="This content should be translated."
         context="This message is for translation editors."
       />
@@ -27,7 +27,7 @@ displayAMessageWithAnEditorRelatedContext.story = {
 export function interpolateVariablesAlsoSupportHtml() {
   return (
     <Text>
-      <Translate
+      <T
         html
         phrase="Hello %{name}!"
         name={<b>Bruce</b>}
@@ -44,21 +44,21 @@ interpolateVariablesAlsoSupportHtml.story = {
 export function handleContextualMessagesBasedOnCounts() {
   return (
     <Text>
-      <Translate
+      <T
         phrase="%{smartCount} item||||%{smartCount} items"
         smartCount={0}
         context="This message is for translation editors."
       />
       <br />
       <br />
-      <Translate
+      <T
         phrase="%{smartCount} item||||%{smartCount} items"
         smartCount={1}
         context="This message is for translation editors."
       />
       <br />
       <br />
-      <Translate
+      <T
         phrase="%{smartCount} item||||%{smartCount} items"
         smartCount={2}
         context="This message is for translation editors."

--- a/packages/core/src/utils/getLanguageFromLocale.ts
+++ b/packages/core/src/utils/getLanguageFromLocale.ts
@@ -1,4 +1,4 @@
-import Core from '..';
+import T from '../components/Translate';
 import { Locale } from '../types';
 
 let loaded = false;
@@ -8,19 +8,71 @@ export default function getLanguageFromLocale(locale: Locale): string {
   if (!loaded) {
     loaded = true;
     languages = {
-      nl: Core.translate('Dutch', {}, 'Language name within a language selector'),
-      en: Core.translate('English', {}, 'Language name within a language selector'),
-      fr: Core.translate('French', {}, 'Language name within a language selector'),
-      de: Core.translate('German', {}, 'Language name within a language selector'),
-      it: Core.translate('Italian', {}, 'Language name within a language selector'),
-      ja: Core.translate('Japanese', {}, 'Language name within a language selector'),
-      ko: Core.translate('Korean', {}, 'Language name within a language selector'),
-      zh: Core.translate('Mandarin', {}, 'Language name within a language selector'),
-      ms: Core.translate('Malay', {}, 'Language name within a language selector'),
-      pt: Core.translate('Portuguese', {}, 'Language name within a language selector'),
-      ru: Core.translate('Russian', {}, 'Language name within a language selector'),
-      es: Core.translate('Spanish', {}, 'Language name within a language selector'),
-      tr: Core.translate('Turkish', {}, 'Language name within a language selector'),
+      nl: T.phrase(
+        'Dutch',
+        {},
+        { key: 'lunar.language.dutch', context: 'Language name within a language selector' },
+      ),
+      en: T.phrase(
+        'English',
+        {},
+        { key: 'lunar.language.english', context: 'Language name within a language selector' },
+      ),
+      fr: T.phrase(
+        'French',
+        {},
+        { key: 'lunar.language.french', context: 'Language name within a language selector' },
+      ),
+      de: T.phrase(
+        'German',
+        {},
+        { key: 'lunar.language.german', context: 'Language name within a language selector' },
+      ),
+      it: T.phrase(
+        'Italian',
+        {},
+        { key: 'lunar.language.italian', context: 'Language name within a language selector' },
+      ),
+      ja: T.phrase(
+        'Japanese',
+        {},
+        { key: 'lunar.language.japanese', context: 'Language name within a language selector' },
+      ),
+      ko: T.phrase(
+        'Korean',
+        {},
+        { key: 'lunar.language.korean', context: 'Language name within a language selector' },
+      ),
+      zh: T.phrase(
+        'Mandarin',
+        {},
+        { key: 'lunar.language.mandarin', context: 'Language name within a language selector' },
+      ),
+      ms: T.phrase(
+        'Malay',
+        {},
+        { key: 'lunar.language.malay', context: 'Language name within a language selector' },
+      ),
+      pt: T.phrase(
+        'Portuguese',
+        {},
+        { key: 'lunar.language.portuguese', context: 'Language name within a language selector' },
+      ),
+      ru: T.phrase(
+        'Russian',
+        {},
+        { key: 'lunar.language.russian', context: 'Language name within a language selector' },
+      ),
+      es: T.phrase(
+        'Spanish',
+        {},
+        { key: 'lunar.language.spanish', context: 'Language name within a language selector' },
+      ),
+      tr: T.phrase(
+        'Turkish',
+        {},
+        { key: 'lunar.language.turkish', context: 'Language name within a language selector' },
+      ),
     };
   }
 

--- a/packages/core/src/utils/getMemberName.ts
+++ b/packages/core/src/utils/getMemberName.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import Core from '..';
+import T from '../components/Translate';
 
 type Member = {
   first_name?: string;
@@ -13,7 +13,14 @@ export default function getMemberName(
   copy: string = '',
 ): string {
   if (!member.first_name) {
-    return copy || Core.translate('Unknown member', {}, 'Member name does not exist');
+    return (
+      copy ||
+      T.phrase(
+        'Unknown member',
+        {},
+        { key: 'lunar.common.unknownMember', context: 'Member name does not exist' },
+      )
+    );
   }
 
   const firstName = member.first_name;

--- a/packages/core/test/components/Lightbox/Header.test.tsx
+++ b/packages/core/test/components/Lightbox/Header.test.tsx
@@ -33,7 +33,7 @@ describe('<LightboxHeader />', () => {
           .find(Button)
           .at(0)
           .prop('children'),
-      ).toBe('Hide Info');
+      ).toBe('Hide info');
     });
 
     it('with "Show Info" if hideAside is true', () => {
@@ -44,7 +44,7 @@ describe('<LightboxHeader />', () => {
           .find(Button)
           .at(0)
           .prop('children'),
-      ).toBe('Show Info');
+      ).toBe('Show info');
     });
   });
 

--- a/packages/forms/src/components/FeedbackForm/index.tsx
+++ b/packages/forms/src/components/FeedbackForm/index.tsx
@@ -92,7 +92,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
             name="type"
             label={
               <T
-                k="lunar.feedback.typeMessage"
+                k="lunar.form.feedback.typeMessage"
                 phrase="What kind of feedback are you giving?"
                 context="Feedback form"
               />
@@ -107,7 +107,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
                   value="bug"
                   label={
                     <T
-                      k="lunar.feedback.reportBug"
+                      k="lunar.form.feedback.reportBug"
                       phrase="Report a bug"
                       context="Feedback form type option"
                     />
@@ -119,7 +119,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
                   value="feedback"
                   label={
                     <T
-                      k="lunar.feedback.giveFeedback"
+                      k="lunar.form.feedback.giveFeedback"
                       phrase="Give product feedback"
                       context="Feedback form type option"
                     />
@@ -134,7 +134,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
           name="category"
           label={
             <T
-              k="lunar.feedback.featureMessage"
+              k="lunar.form.feedback.featureMessage"
               phrase="Which feature is this about?"
               context="Feedback form"
             />
@@ -144,7 +144,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
             {},
             {
               context: 'Selecting a feature within the feedback form',
-              key: 'lunar.feedback.selectFeature',
+              key: 'lunar.form.feedback.selectFeature',
             },
           )}
           validator={this.validate}
@@ -160,7 +160,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
           name="feedback"
           label={
             <T
-              k="lunar.feedback.moreMessage"
+              k="lunar.form.feedback.moreMessage"
               phrase="Tell us a little bit more"
               context="Feedback form"
             />
@@ -173,7 +173,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
                   {
                     context:
                       'Default description in the feedback form when submitting a bug report',
-                    key: 'lunar.feedback.moreBug',
+                    key: 'lunar.form.feedback.moreBug',
                   },
                 )
               : T.phrase(
@@ -182,7 +182,7 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
                   {
                     context:
                       'Default description in the feedback form when submitting general feedback',
-                    key: 'lunar.feedback.moreFeedback',
+                    key: 'lunar.form.feedback.moreFeedback',
                   },
                 )
           }
@@ -192,14 +192,14 @@ export default class FeedbackForm extends React.PureComponent<Props, State> {
         <FormActions
           continueText={
             <T
-              k="lunar.feedback.send"
+              k="lunar.form.feedback.send"
               phrase="Send Feedback"
               context="Feedback form submit button label"
             />
           }
           processingText={
             <T
-              k="lunar.feedback.sending"
+              k="lunar.form.feedback.sending"
               phrase="Sending…"
               context="Feedback form submit button label"
             />

--- a/packages/forms/src/components/FilterMenu/index.tsx
+++ b/packages/forms/src/components/FilterMenu/index.tsx
@@ -101,7 +101,7 @@ export default function FilterMenu({
   const activeCountLabel =
     activeCount && activeCount > 0 ? (
       <T
-        k="lunar.filter.filterCount"
+        k="lunar.form.filter.filterCount"
         phrase="%{smartCount} Filter||||%{smartCount} Filters"
         smartCount={activeCount}
         context="Number of filters applied within a form"
@@ -109,9 +109,13 @@ export default function FilterMenu({
     ) : null;
 
   const toggleLabel = opened ? (
-    <T k="lunar.filter.close" phrase="Close filters" context="Filter menu toggle button label" />
+    <T
+      k="lunar.form.filter.close"
+      phrase="Close filters"
+      context="Filter menu toggle button label"
+    />
   ) : (
-    <T k="lunar.filter.open" phrase="Open filters" context="Filter menu toggle button label" />
+    <T k="lunar.form.filter.open" phrase="Open filters" context="Filter menu toggle button label" />
   );
 
   return (

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import chalk from 'chalk';
+import glob from 'fast-glob';
+import * as t from '@babel/types';
+import * as parser from '@babel/parser';
+import traverse from '@babel/traverse';
+
+interface Phrase {
+  key: string;
+  message: string;
+  contexts: string[];
+}
+
+type OnExtract = (key: string, phrase: string, context: string) => void;
+
+function parseAndTraverse(filePath: string, cb: OnExtract) {
+  console.log(`  ${chalk.gray(filePath.split('packages/')[1])}`);
+
+  const code = fs.readFileSync(filePath, 'utf8');
+  const ast = parser.parse(code, {
+    sourceFilename: filePath,
+    sourceType: 'module',
+    plugins: [
+      'jsx',
+      'typescript',
+      'classProperties',
+      'dynamicImport',
+      'nullishCoalescingOperator',
+      'objectRestSpread',
+      'optionalCatchBinding',
+      'optionalChaining',
+    ],
+  });
+
+  traverse(ast, {
+    JSXOpeningElement({ node }) {
+      if (t.isJSXIdentifier(node.name, { name: 'T' })) {
+        let key = '';
+        let phrase = '';
+        let context = '';
+
+        node.attributes.forEach(attr => {
+          if (
+            t.isJSXAttribute(attr) &&
+            t.isJSXIdentifier(attr.name) &&
+            t.isStringLiteral(attr.value)
+          ) {
+            switch (attr.name.name) {
+              case 'k':
+                key = attr.value.value;
+                break;
+              case 'phrase':
+                phrase = attr.value.value;
+                break;
+              case 'context':
+                context = attr.value.value;
+                break;
+            }
+          }
+        });
+
+        if (!key) {
+          throw new Error('<T/> found without a `k` prop.');
+        } else if (!phrase) {
+          throw new Error('<T/> found without a `phrase` prop.');
+        }
+
+        cb(key, phrase, context);
+      }
+    },
+  });
+}
+
+glob(['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'], {
+  absolute: true,
+  cwd: process.cwd(),
+})
+  .then(files => {
+    console.log('Extracting...');
+
+    const phrases: { [key: string]: Phrase } = {};
+
+    const handleExtract: OnExtract = (key, message, context) => {
+      if (!key.startsWith('lunar')) {
+        throw new Error(`Key "${key}" does not start with "lunar".`);
+      }
+
+      const phrase = phrases[key];
+
+      if (phrase) {
+        if (message !== phrase.message) {
+          throw new Error(`Key "${key}" found with different phrase messages.`);
+        }
+
+        phrase.contexts.push(context);
+      } else {
+        phrases[key] = {
+          key,
+          message,
+          contexts: context ? [context] : [],
+        };
+      }
+    };
+
+    files.forEach(file => {
+      if (file.includes('story')) {
+        return;
+      }
+
+      parseAndTraverse(file, handleExtract);
+    });
+
+    return phrases;
+  })
+  .then(phrases => {
+    console.log(`Found ${Object.keys(phrases).length} phrases`);
+
+    fs.writeFileSync('phrases.json', JSON.stringify(phrases, null, 2), 'utf8');
+
+    console.log('Complete!');
+  })
+  .catch(error => {
+    console.error(chalk.red(error));
+  });

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -137,7 +137,6 @@ glob(['src/**/*.{ts,tsx,js,jsx}', 'packages/*/src/**/*.{ts,tsx,js,jsx}'], {
       }
 
       const phrase = phrases[key];
-      const dupe = messages[message];
 
       if (phrase) {
         if (message !== phrase.phrase) {
@@ -147,6 +146,8 @@ glob(['src/**/*.{ts,tsx,js,jsx}', 'packages/*/src/**/*.{ts,tsx,js,jsx}'], {
         if (context) {
           phrase.contexts.add(context);
         }
+
+        const dupe = messages[message.toLocaleLowerCase()];
 
         if (dupe && !dupe.includes(key)) {
           console.warn(chalk.yellow(`Duplicate phrase message found for keys: ${dupe.join(', ')}`));
@@ -160,7 +161,7 @@ glob(['src/**/*.{ts,tsx,js,jsx}', 'packages/*/src/**/*.{ts,tsx,js,jsx}'], {
           contexts: new Set(context ? [context] : []),
         };
 
-        messages[message] = [key];
+        messages[message.toLocaleLowerCase()] = [key];
       }
     };
 

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -174,7 +174,7 @@ glob(
     };
 
     files.forEach(file => {
-      if (file.endsWith('story.tsx')) {
+      if (file.match(/(\.|\/)story\.tsx?$/i)) {
         return;
       }
 

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -6,6 +6,7 @@ import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
 
 const { I18N_PREFIX = 'lunar' } = process.env;
+const CWD = process.argv[2] || process.cwd();
 
 interface Phrase {
   key: string;
@@ -16,7 +17,11 @@ interface Phrase {
 type OnExtract = (key: string, phrase: string, context: string) => void;
 
 function parseAndTraverse(filePath: string, cb: OnExtract) {
-  console.log(`  ${chalk.gray(filePath.split('packages/')[1])}`);
+  const shortPath = filePath.includes('packages')
+    ? filePath.split('packages/')[1]
+    : filePath.split('src/')[1];
+
+  console.log(`  ${chalk.gray(shortPath)}`);
 
   const code = fs.readFileSync(filePath, 'utf8');
   const ast = parser.parse(code, {
@@ -116,9 +121,9 @@ function parseAndTraverse(filePath: string, cb: OnExtract) {
   });
 }
 
-glob(['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'], {
+glob(['src/**/*.ts', 'src/**/*.tsx', 'packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'], {
   absolute: true,
-  cwd: process.cwd(),
+  cwd: CWD,
 })
   .then(files => {
     console.log('Extracting...');

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -5,6 +5,8 @@ import * as t from '@babel/types';
 import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
 
+const { I18N_PREFIX = 'lunar' } = process.env;
+
 interface Phrase {
   key: string;
   message: string;
@@ -33,40 +35,83 @@ function parseAndTraverse(filePath: string, cb: OnExtract) {
   });
 
   traverse(ast, {
-    JSXOpeningElement({ node }) {
-      if (t.isJSXIdentifier(node.name, { name: 'T' })) {
-        let key = '';
-        let phrase = '';
-        let context = '';
-
-        node.attributes.forEach(attr => {
-          if (
-            t.isJSXAttribute(attr) &&
-            t.isJSXIdentifier(attr.name) &&
-            t.isStringLiteral(attr.value)
-          ) {
-            switch (attr.name.name) {
-              case 'k':
-                key = attr.value.value;
-                break;
-              case 'phrase':
-                phrase = attr.value.value;
-                break;
-              case 'context':
-                context = attr.value.value;
-                break;
-            }
-          }
-        });
-
-        if (!key) {
-          throw new Error('<T/> found without a `k` prop.');
-        } else if (!phrase) {
-          throw new Error('<T/> found without a `phrase` prop.');
-        }
-
-        cb(key, phrase, context);
+    CallExpression({ node }) {
+      if (
+        !t.isMemberExpression(node.callee) ||
+        !t.isIdentifier(node.callee.object, { name: 'T' }) ||
+        !t.isIdentifier(node.callee.property, { name: 'phrase' })
+      ) {
+        return;
       }
+
+      const args = node.arguments;
+      const obj = args[2];
+
+      let key = '';
+      let phrase = t.isStringLiteral(args[0]) ? args[0].value : '';
+      let context = '';
+
+      if (!t.isObjectExpression(obj)) {
+        throw new Error('T.phrase() requires an object as the 3rd argument.');
+      }
+
+      obj.properties.forEach(prop => {
+        if (t.isObjectProperty(prop) && t.isIdentifier(prop.key) && t.isStringLiteral(prop.value)) {
+          const { name } = prop.key;
+          const { value } = prop.value;
+
+          if (name === 'key') {
+            key = value;
+          } else if (name === 'context') {
+            context = value;
+          }
+        }
+      });
+
+      if (!key) {
+        throw new Error('T.phrase() found without a `key`.');
+      } else if (!phrase) {
+        throw new Error('T.phrase() found without a `phrase`.');
+      }
+
+      cb(key, phrase, context);
+    },
+
+    JSXOpeningElement({ node }) {
+      if (!t.isJSXIdentifier(node.name, { name: 'T' })) {
+        return;
+      }
+
+      let key = '';
+      let phrase = '';
+      let context = '';
+
+      node.attributes.forEach(attr => {
+        if (
+          t.isJSXAttribute(attr) &&
+          t.isJSXIdentifier(attr.name) &&
+          t.isStringLiteral(attr.value)
+        ) {
+          const { name } = attr.name;
+          const { value } = attr.value;
+
+          if (name === 'k') {
+            key = value;
+          } else if (name === 'phrase') {
+            phrase = value;
+          } else if (name === 'context') {
+            context = value;
+          }
+        }
+      });
+
+      if (!key) {
+        throw new Error('<T/> found without a `k` prop.');
+      } else if (!phrase) {
+        throw new Error('<T/> found without a `phrase` prop.');
+      }
+
+      cb(key, phrase, context);
     },
   });
 }
@@ -81,8 +126,8 @@ glob(['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'], {
     const phrases: { [key: string]: Phrase } = {};
 
     const handleExtract: OnExtract = (key, message, context) => {
-      if (!key.startsWith('lunar')) {
-        throw new Error(`Key "${key}" does not start with "lunar".`);
+      if (!key.startsWith(I18N_PREFIX)) {
+        throw new Error(`Key "${key}" does not start with "${I18N_PREFIX}".`);
       }
 
       const phrase = phrases[key];
@@ -103,7 +148,7 @@ glob(['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx'], {
     };
 
     files.forEach(file => {
-      if (file.includes('story')) {
+      if (file.endsWith('story.tsx')) {
         return;
       }
 

--- a/scripts/tasks/extractPhrases.ts
+++ b/scripts/tasks/extractPhrases.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import chalk from 'chalk';
 import glob from 'fast-glob';
 import * as t from '@babel/types';
@@ -6,7 +7,11 @@ import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
 
 const I18N_PREFIX = (process.env.I18N_PREFIX || 'lunar').split(',');
-const CWD = process.argv[2] || process.cwd();
+const SEARCH_PATHS = process.argv.slice(2);
+
+if (SEARCH_PATHS.length === 0) {
+  SEARCH_PATHS.push('src', 'packages/*/src');
+}
 
 interface Phrase {
   key: string;
@@ -121,10 +126,13 @@ function parseAndTraverse(filePath: string, cb: OnExtract) {
   });
 }
 
-glob(['src/**/*.{ts,tsx,js,jsx}', 'packages/*/src/**/*.{ts,tsx,js,jsx}'], {
-  absolute: true,
-  cwd: CWD,
-})
+glob(
+  SEARCH_PATHS.map(sp => path.join(sp, '**/*.{ts,tsx,js,jsx}')),
+  {
+    absolute: true,
+    cwd: process.cwd(),
+  },
+)
   .then(files => {
     console.log('Extracting...');
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Updates all our translations to have a key that starts with `lunar.`. Also wrote a script to extract them all.

## Motivation and Context

We're gonna localize this soon.

## Testing

Locally.

## Screenshots

Example output:

```json
[
  {
    "key": "lunar.common.apply",
    "phrase": "Apply",
    "contexts": [
      "This button applies all live edits.",
      "Apply filters button label"
    ]
  },
  {
    "key": "lunar.common.cancel",
    "phrase": "Cancel",
    "contexts": [
      "This button cancels out of edit mode without applying changes.",
      "Button label to cancel a form action"
    ]
  },
  {
    "key": "lunar.common.close",
    "phrase": "Close",
    "contexts": [
      "Close the alert",
      "Close a sheet popup",
      "Close a toast popup",
      "Close a modal popup"
    ]
  },
  {
    "key": "lunar.common.collapse",
    "phrase": "Collapse",
    "contexts": [
      "Collapse"
    ]
  },
]
```

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
