### PR TITLE
update: Add `submitOnEnter` prop and hotkey negation.

### DIFF
--- a/packages/composer/package.json
+++ b/packages/composer/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@airbnb/lunar-icons": "^2.8.1",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "uuid": "^3.4.0"
   }
 }

--- a/packages/composer/src/Composer.story.tsx
+++ b/packages/composer/src/Composer.story.tsx
@@ -202,6 +202,18 @@ defaultStory.story = {
   name: 'Default.',
 };
 
+export function submitsOnEnter() {
+  return (
+    <Wrapper>
+      <Composer {...props} submitOnEnter />
+    </Wrapper>
+  );
+}
+
+submitsOnEnter.story = {
+  name: 'Submits on enter.',
+};
+
 export function disabledInput() {
   return (
     <Wrapper>

--- a/packages/composer/src/components/Composer.tsx
+++ b/packages/composer/src/components/Composer.tsx
@@ -39,6 +39,8 @@ export type ComposerProps = {
   onSubmit?: SubmitHandler;
   /** Placeholder for the private note writing mode. */
   privateNotePlaceholder?: string;
+  /** Trigger submit on enter instead of adding a new line. */
+  submitOnEnter?: boolean;
   /** Default writing mode. */
   writingMode?: WritingMode;
 };
@@ -71,6 +73,7 @@ export default function Composer({
   messagePlaceholder,
   privateNotePlaceholder,
   propagateRef,
+  submitOnEnter,
   writingMode,
 }: ComposerProps) {
   const [styles, cx] = useStyles(composerStyleSheet);
@@ -167,6 +170,7 @@ export default function Composer({
                 messagePlaceholder={messagePlaceholder}
                 privateNotePlaceholder={privateNotePlaceholder}
                 propagateRef={propagateRef}
+                submitOnEnter={submitOnEnter}
                 onChange={onChange}
                 onSubmit={onSubmit}
               />

--- a/packages/composer/src/components/Composer.tsx
+++ b/packages/composer/src/components/Composer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState, useReducer } from 'react';
 import useStyles from '@airbnb/lunar/lib/hooks/useStyles';
 import FormErrorMessage from '@airbnb/lunar/lib/components/FormErrorMessage';
+import uuid from 'uuid/v4';
 import ComposerContext from '../contexts/ComposerContext';
 import Footer from './Footer';
 import Input, { InputProps } from './Input';
@@ -80,6 +81,7 @@ export default function Composer({
   const [menu, setMenu] = useState(isShortcutCommand(defaultValues.value) ? MENU_SHORTCUTS : '');
   const [mode, setMode] = useState<WritingMode>(writingMode ?? MODE_MESSAGE);
   const [error, setError] = useState('');
+  const [id] = useState(() => uuid());
   const [data, setData] = useReducer(reducer, {
     focused: false,
     shadowValue: '',
@@ -130,14 +132,14 @@ export default function Composer({
       // Always focus the input when a menu is opened.
       // We need to focus so that hotkeys can be triggered.
       setTimeout(() => {
-        const composer = document.getElementById('composer');
+        const composer = document.getElementById(id);
 
         if (composer && document.activeElement !== composer) {
           composer.focus();
         }
       }, 0);
     },
-    [setMenu],
+    [setMenu, id],
   );
 
   return (
@@ -146,6 +148,7 @@ export default function Composer({
         changeHandlers,
         data,
         flags,
+        id,
         menu,
         mode,
         onChange: handleChange,
@@ -186,7 +189,7 @@ export default function Composer({
               flags.afterButton && styles.footer_after,
             )}
           >
-            {invalid ? <FormErrorMessage id="composer" error={error} /> : <Footer />}
+            {invalid ? <FormErrorMessage id={id} error={error} /> : <Footer />}
             {children}
           </div>
         </div>

--- a/packages/composer/src/components/Composer.tsx
+++ b/packages/composer/src/components/Composer.tsx
@@ -81,7 +81,7 @@ export default function Composer({
   const [menu, setMenu] = useState(isShortcutCommand(defaultValues.value) ? MENU_SHORTCUTS : '');
   const [mode, setMode] = useState<WritingMode>(writingMode ?? MODE_MESSAGE);
   const [error, setError] = useState('');
-  const [id] = useState(() => uuid());
+  const [id] = useState(() => (process.env.NODE_ENV === 'test' ? 'composer' : uuid()));
   const [data, setData] = useReducer(reducer, {
     focused: false,
     shadowValue: '',

--- a/packages/composer/src/components/Footer/index.tsx
+++ b/packages/composer/src/components/Footer/index.tsx
@@ -28,12 +28,18 @@ export default function Footer() {
       {tips.map(tip => (
         <Tip key={tip.name || tip.combo}>
           <Mark>
-            {tip.combo.split('+').map((symbol, i) => (
-              <span key={symbol}>
-                {i !== 0 && ' + '}
-                <Symbol char={SYMBOLS[symbol] || symbol.toLowerCase()} />
-              </span>
-            ))}
+            {tip.combo.split('+').map((symbol, i) => {
+              if (symbol.startsWith('!')) {
+                return null;
+              }
+
+              return (
+                <span key={symbol}>
+                  {i !== 0 && ' + '}
+                  <Symbol char={SYMBOLS[symbol] || symbol.toLowerCase()} />
+                </span>
+              );
+            })}
           </Mark>
 
           {tip.label}

--- a/packages/composer/src/components/Input/index.tsx
+++ b/packages/composer/src/components/Input/index.tsx
@@ -14,8 +14,8 @@ import {
   showWhenValueNotEmptyCondition,
   closeMenu,
   activeWhenMenuOpen,
+  OS_KEY,
 } from '../../helpers/hotkeys';
-import { isMac } from '../../helpers/platform';
 import {
   processChangeHandlers,
   processSubmitHandlers,
@@ -36,6 +36,7 @@ export type InputProps = {
   messagePlaceholder?: string;
   privateNotePlaceholder?: string;
   propagateRef?: React.Ref<HTMLTextAreaElement>;
+  submitOnEnter?: boolean;
 };
 
 export default function Input({
@@ -47,6 +48,7 @@ export default function Input({
   messagePlaceholder,
   privateNotePlaceholder,
   propagateRef,
+  submitOnEnter = false,
 }: InputProps) {
   const ref = useRef<HTMLTextAreaElement | null>(null);
   const context = useContext(ComposerContext);
@@ -194,7 +196,7 @@ export default function Input({
 
         <Hotkey
           preventDefault
-          combo={isMac() ? 'cmd+enter' : 'ctrl+enter'}
+          combo={submitOnEnter ? 'enter+!shift' : `${OS_KEY}+enter`}
           condition={showWhenValueNotEmptyCondition}
           name="submit"
           label={

--- a/packages/composer/src/components/Input/index.tsx
+++ b/packages/composer/src/components/Input/index.tsx
@@ -171,7 +171,7 @@ export default function Input({
           }}
           className={cx(styles.input, styles.input_original)}
           disabled={disabled}
-          id="composer"
+          id={context.id}
           name="message"
           placeholder={placeholder}
           rows={context.mode === MODE_EMAIL ? 3 : 1}
@@ -189,7 +189,7 @@ export default function Input({
             })}
             disabled={blocked}
             icon={IconPlayAlt}
-            id="composer-submit-button"
+            id={`${context.id}-submit-button`}
             onClick={handleSubmit}
           />
         </span>

--- a/packages/composer/src/components/Menu/index.tsx
+++ b/packages/composer/src/components/Menu/index.tsx
@@ -42,7 +42,7 @@ export default function Menu({
   width,
 }: MenuProps) {
   const [styles, cx] = useStyles(menuStyleSheet);
-  const { flags, menu, setMenu } = useContext(ComposerContext);
+  const { flags, id, menu, setMenu } = useContext(ComposerContext);
   const { unit } = useTheme();
 
   // Handlers
@@ -54,7 +54,7 @@ export default function Menu({
       // Never close when clicking the textarea or the toggle button
       if (
         target &&
-        (isElementWithID(target, 'textarea', 'composer') ||
+        (isElementWithID(target, 'textarea', id) ||
           isElementWithID(target, 'button', `toggle-button-${name}`))
       ) {
         return;
@@ -67,7 +67,7 @@ export default function Menu({
       // Always close active menu
       setMenu('');
     },
-    [onClickOutside, name, setMenu],
+    [onClickOutside, name, setMenu, id],
   );
 
   // Only display if menu is active

--- a/packages/composer/src/components/Preview/index.tsx
+++ b/packages/composer/src/components/Preview/index.tsx
@@ -28,7 +28,7 @@ export default function Preview({
 
     // Force a submission after context propagates
     setTimeout(() => {
-      const button = document.getElementById('composer-submit-button');
+      const button = document.getElementById(`${context.id}-submit-button`);
 
       if (button) {
         button.click();

--- a/packages/composer/src/contexts/ComposerContext.ts
+++ b/packages/composer/src/contexts/ComposerContext.ts
@@ -6,6 +6,7 @@ export const defaultContext: Context = {
   changeHandlers: new Set(),
   data: { focused: false, shadowValue: '', value: '' },
   flags: {},
+  id: 'composer',
   menu: '',
   mode: MODE_MESSAGE,
   onChange() {},

--- a/packages/composer/src/helpers/hotkeys.ts
+++ b/packages/composer/src/helpers/hotkeys.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MENU_SHORTCUTS } from '../constants';
 import { HotkeyComparator, HotkeyConfig, ReadableContext, WritableContext } from '../types';
+import { isMac } from './platform';
 
 export const SYMBOLS: { [key: string]: string } = {
   cmd: '⌘',
@@ -20,6 +21,8 @@ export const SYMBOLS: { [key: string]: string } = {
   right: '>',
 };
 
+export const OS_KEY = isMac() ? 'cmd' : 'ctrl';
+
 export function parseComboIntoComparator(hotkey: string): HotkeyComparator {
   const comp: HotkeyComparator = {};
 
@@ -27,24 +30,32 @@ export function parseComboIntoComparator(hotkey: string): HotkeyComparator {
     .toLowerCase()
     .replace(/\s/g, '')
     .split('+')
-    .forEach(key => {
+    .forEach(k => {
+      let key = k;
+      let pressed = true;
+
+      if (key.startsWith('!')) {
+        pressed = false;
+        key = key.slice(1);
+      }
+
       // istanbul ignore next
       switch (key) {
         case 'cmd':
         case 'command':
-          comp.metaKey = true;
+          comp.metaKey = pressed;
           break;
         case 'ctrl':
         case 'control':
-          comp.ctrlKey = true;
+          comp.ctrlKey = pressed;
           break;
         case 'alt':
         case 'opt':
         case 'option':
-          comp.altKey = true;
+          comp.altKey = pressed;
           break;
         case 'shift':
-          comp.shiftKey = true;
+          comp.shiftKey = pressed;
           break;
         case 'enter':
         case 'return':

--- a/packages/composer/src/helpers/shortcuts.ts
+++ b/packages/composer/src/helpers/shortcuts.ts
@@ -1,3 +1,4 @@
+import T from '@airbnb/lunar/lib/components/Translate';
 import { MENU_SHORTCUTS } from '../constants';
 import {
   ShortcutArgument,
@@ -29,7 +30,13 @@ export function filterAndSortShortcuts(
   const usedNames = new Set();
   const filteredShortcuts: Required<ShortcutConfig>[] = shortcuts.map(config => {
     if (usedNames.has(config.name)) {
-      throw new Error(`Shortcut with name "${config.name}" already exists.`);
+      throw new Error(
+        T.phrase(
+          'Shortcut with name "%{name}" already exists.',
+          { name: config.name },
+          { key: 'lunar.composer.shortcuts.nameExists' },
+        ),
+      );
     } else {
       usedNames.add(config.name);
     }
@@ -100,13 +107,23 @@ export function onSubmitExecuteShortcut(
 
   // Validate shortcut
   if (!shortcut) {
-    throw new Error(`Invalid shortcut "${name}".`);
+    throw new Error(
+      T.phrase(
+        'Invalid shortcut "%{name}".',
+        { name },
+        { key: 'lunar.composer.shortcuts.invalidName' },
+      ),
+    );
   }
 
   const args = shortcut.arguments ?? [];
 
   if (params.length > args.length) {
-    throw new Error(`Too many shortcut arguments provided.`);
+    throw new Error(
+      T.phrase('Too many shortcut arguments provided.', null, {
+        key: 'lunar.composer.shortcuts.tooManyArgs',
+      }),
+    );
   }
 
   // Validate arguments
@@ -114,7 +131,15 @@ export function onSubmitExecuteShortcut(
     const param = params[index];
 
     if ((!arg.optional && !param) || param === `[${arg.name}]` || param === `<${arg.name}>`) {
-      throw new Error(`Shortcut argument "${arg.name}" is required.`);
+      throw new Error(
+        T.phrase(
+          'Shortcut argument "%{name}" is required.',
+          { name: arg.name },
+          {
+            key: 'lunar.composer.shortcuts.argRequired',
+          },
+        ),
+      );
     }
 
     if (arg.validator) {

--- a/packages/composer/src/types.ts
+++ b/packages/composer/src/types.ts
@@ -25,6 +25,7 @@ export type Context = {
   changeHandlers: Set<ChangeHandler>;
   data: DataSet;
   flags: { [flag: string]: boolean };
+  id: string;
   menu: string;
   mode: WritingMode;
   onChange: (...handler: ChangeHandler[]) => void;
@@ -36,7 +37,7 @@ export type Context = {
   submitHandlers: Set<SubmitHandler>;
 };
 
-export type ReadableContext = Readonly<Pick<Context, 'data' | 'menu' | 'mode'>>;
+export type ReadableContext = Readonly<Pick<Context, 'data' | 'id' | 'menu' | 'mode'>>;
 
 export type WritableContext = ReadableContext &
   Readonly<Pick<Context, 'setData' | 'setError' | 'setMenu' | 'setMode'>>;

--- a/packages/composer/test/components/Composer.test.tsx
+++ b/packages/composer/test/components/Composer.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/consistent-function-scoping */
+
 import React from 'react';
 import { render, renderAndWait, DomElement, mockFetch } from 'rut-dom';
 import Interweave from '@airbnb/lunar/lib/components/Interweave';
@@ -7,7 +9,7 @@ import Composer, { ComposerProps } from '../../src/components/Composer';
 import Hotkey from '../../src/components/Hotkey';
 import Shortcuts from '../../src/components/Shortcuts';
 import { Selection } from '../../src/components/SelectList';
-// @ts-ignore dts file not being built for some reason
+// @ts-ignore Our build deletes story.d.ts files
 import { actions, shortcuts, loadSuggestions, checkText } from '../../src/Composer.story';
 import Menu from '../../src/components/Menu';
 import Actions, { ActionButton } from '../../src/components/Actions';
@@ -19,10 +21,11 @@ import Proofreader from '../../src/components/Preview/Proofreader';
 import Window from '../../src/components/Preview/Window';
 import { ShortcutConfig } from '../../src';
 
-// eslint-disable-next-line unicorn/consistent-function-scoping
 jest.mock('lodash/debounce', () => (cb: Function) => {
   return (...args: unknown[]) => cb(...args);
 });
+
+jest.mock('uuid/v4', () => () => 'composer');
 
 describe('<Composer />', () => {
   const props = {

--- a/packages/composer/test/components/Composer.test.tsx
+++ b/packages/composer/test/components/Composer.test.tsx
@@ -25,8 +25,6 @@ jest.mock('lodash/debounce', () => (cb: Function) => {
   return (...args: unknown[]) => cb(...args);
 });
 
-jest.mock('uuid/v4', () => () => 'composer');
-
 describe('<Composer />', () => {
   const props = {
     onChange() {},

--- a/packages/composer/test/components/Footer.test.tsx
+++ b/packages/composer/test/components/Footer.test.tsx
@@ -30,6 +30,13 @@ describe('<Footer />', () => {
       condition: ctx => ctx.menu === '',
       onRun() {},
     },
+    {
+      name: 'qux',
+      combo: 'cmd+!shift',
+      comparator: {},
+      condition: ctx => ctx.menu === 'negate',
+      onRun() {},
+    },
   ];
 
   it('renders nothing when no hotkeys defined', () => {
@@ -53,5 +60,13 @@ describe('<Footer />', () => {
 
     expect(root.find(Mark)).toHaveLength(1);
     expect(root.find(Symbol)).toHaveLength(2);
+  });
+
+  it('doesnt render negaqted symbols', () => {
+    const { root } = render<{}>(<Footer />, {
+      wrapper: <Wrapper hotkeys={hotkeys} menu="negative" />,
+    });
+
+    expect(root).not.toContainNode('!shift');
   });
 });

--- a/packages/composer/test/mocks.tsx
+++ b/packages/composer/test/mocks.tsx
@@ -32,6 +32,7 @@ export function Wrapper({
         ...defaultContext,
         data: { shadowValue: '', value },
         menu,
+        id: 'composer',
         ...composerContext,
       }}
     >


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Title.

## Motivation and Context

Some people don't like `shift+enter` to submit, so allow them to submit using just `enter`.

## Testing

Storybook.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
