### PR TITLE
breaking: Replace form fields `compact` with `small` and `large`.

### DIFF
--- a/codemods/v3/formCompactToSmall.ts
+++ b/codemods/v3/formCompactToSmall.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-param-reassign */
+// npx jscodeshift --extensions=js,jsx,ts,tsx --parser=tsx --transform=./codemods/v3/formCompactToSmall.ts ./src
+
+import { FileInfo, API, Options } from 'jscodeshift';
+import { Codemod } from '../helpers';
+
+function convertCompactToSmall(mod: Codemod, name: string) {
+  mod.source.find(mod.cs.JSXOpeningElement, { name: { name } }).forEach(({ node }) => {
+    node.attributes.forEach(attr => {
+      if (attr.type === 'JSXAttribute' && attr.name.name === 'compact') {
+        attr.name.name = 'small';
+      }
+    });
+  });
+}
+
+module.exports = function formCompactToSmall(
+  fileInfo: FileInfo,
+  api: API,
+  options: Options,
+): string | null | undefined | void {
+  const mod = new Codemod(fileInfo, api);
+  const inputTypes = [
+    'Autocomplete',
+    'CheckBox',
+    'CheckBoxController',
+    'DatePickerInput',
+    'DateTimeSelect',
+    'FileInput',
+    'FormField',
+    'FormField/Prefix',
+    'FormField/Suffix',
+    'Input',
+    'Multicomplete',
+    'RadioButton',
+    'RadioButtonController',
+    'Select',
+    'Switch',
+    'TextArea',
+    'ToggleButtonController',
+  ];
+
+  // Full path imports
+  ['@airbnb/lunar/lib/components', '@airbnb/lunar-forms/lib/components'].forEach(importPath => {
+    inputTypes.forEach(type => {
+      const compName = mod.getComponentNameFromDefaultImport(`${importPath}/${type}`);
+
+      if (compName) {
+        convertCompactToSmall(mod, compName);
+      }
+    });
+  });
+
+  // Named forms imports
+  inputTypes.forEach(type => {
+    mod
+      .getComponentNameFromNamedImports('@airbnb/lunar-forms', [type])
+      .forEach(compName => convertCompactToSmall(mod, compName));
+  });
+
+  // Prefix and suffix imports
+  mod
+    .getComponentNameFromNamedImports('@airbnb/lunar/lib/components/FormField', [
+      'Prefix',
+      'Suffix',
+    ])
+    .forEach(compName => convertCompactToSmall(mod, compName));
+
+  return mod.toSource(options);
+};

--- a/packages/composer/src/components/Input/InlineInput.tsx
+++ b/packages/composer/src/components/Input/InlineInput.tsx
@@ -45,8 +45,8 @@ export default function InlineInput({ label, name, value }: InlineInputProps) {
           hideLabel
           label={label}
           name={name}
-          prefix={<Prefix compact>{textLabel}</Prefix>}
-          suffix={<Suffix compact>{editButton}</Suffix>}
+          prefix={<Prefix small>{textLabel}</Prefix>}
+          suffix={<Suffix small>{editButton}</Suffix>}
           value={value}
           onChange={nextValue => {
             context.setData(name, nextValue);

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -25,11 +25,11 @@ export type Item = {
 export const CACHE_DURATION = toMilliseconds('5 minutes');
 
 function getItemValue(item: Item): string {
-  return String(item.value || item.id);
+  return String(item.value ?? item.id);
 }
 
 function renderItem(item: Item): NonNullable<React.ReactNode> {
-  return <Text>{item.name || item.title || item.value}</Text>;
+  return <Text>{item.name ?? item.title ?? item.value}</Text>;
 }
 
 export type ItemResponseType<T> = T[] | { items?: T[]; results?: T[] };
@@ -144,7 +144,7 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
     items: [],
     loading: false,
     open: false,
-    value: this.props.value || '',
+    value: this.props.value ?? '',
   };
 
   componentDidMount() {
@@ -167,7 +167,7 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
     }
 
     if (this.props.value !== prevProps.value) {
-      this.loadItems(this.props.value || '');
+      this.loadItems(this.props.value ?? '');
     }
 
     if (value !== prevState.value || (value !== '' && highlightedIndex === null)) {
@@ -446,22 +446,11 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
   }
 
   getInputProps(props: AutocompleteProps<T>) {
-    const {
-      compact,
-      disabled,
-      invalid,
-      name,
-      optional,
-      placeholder,
-      onBlur,
-      onFocus,
-      small,
-    } = props;
+    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large } = props;
     const { id } = this.state;
 
     // Should match the props passed within `Input`
     return {
-      compact,
       disabled,
       id,
       invalid,
@@ -469,8 +458,9 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
       onBlur,
       onFocus,
       optional,
-      placeholder: placeholder || T.phrase('lunar.common.search', 'Search'),
+      placeholder: placeholder ?? T.phrase('lunar.common.search', 'Search'),
       small,
+      large,
       type: 'text',
     };
   }
@@ -517,7 +507,7 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
         if (Array.isArray(response)) {
           items = response;
         } else {
-          items = response.results || response.items || [];
+          items = response.results ?? response.items ?? [];
         }
 
         if (!disableCache) {
@@ -711,13 +701,6 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
   render() {
     const { id, open, value } = this.state;
     const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
-
-    if (__DEV__) {
-      if (inputProps.compact) {
-        // eslint-disable-next-line no-console
-        console.log('Autocomplete: `compact` prop is deprecated, please use `small` instead.');
-      }
-    }
 
     return (
       <FormField {...fieldProps} id={id}>

--- a/packages/core/src/components/Autocomplete/story.tsx
+++ b/packages/core/src/components/Autocomplete/story.tsx
@@ -128,7 +128,7 @@ disableSelectedItemsWithIsItemSelectable.story = {
   name: 'Disable selected items with `isItemSelectable`.',
 };
 
-export function withCustomStatesInASmallForm() {
+export function withCustomStatesInDifferentSizes() {
   return (
     <>
       <Autocomplete
@@ -136,7 +136,7 @@ export function withCustomStatesInASmallForm() {
         small
         accessibilityLabel="Label"
         name="autocomplete-state-error"
-        label="Error"
+        label="Error (small)"
         renderError={error => <div>{error.message}</div>}
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
@@ -145,10 +145,9 @@ export function withCustomStatesInASmallForm() {
 
       <Autocomplete
         loadItemsOnMount
-        small
         accessibilityLabel="Label"
         name="autocomplete-state-loading"
-        label="Loading"
+        label="Loading (regular)"
         renderLoading={() => <div>Loading...</div>}
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
@@ -157,10 +156,10 @@ export function withCustomStatesInASmallForm() {
 
       <Autocomplete
         loadItemsOnMount
-        small
+        large
         accessibilityLabel="Label"
         name="autocomplete-state-empty"
-        label="No results"
+        label="No results (large)"
         renderNoResults={() => <div>Nothing to see here!</div>}
         onChange={action('onChange')}
         onSelectItem={action('onSelectItem')}
@@ -170,8 +169,8 @@ export function withCustomStatesInASmallForm() {
   );
 }
 
-withCustomStatesInASmallForm.story = {
-  name: 'With custom states in a small form.',
+withCustomStatesInDifferentSizes.story = {
+  name: 'With custom states in different sizes.',
 };
 
 export function canSelectUnknownValueWhenHittingEnter() {

--- a/packages/core/src/components/CheckBox/story.tsx
+++ b/packages/core/src/components/CheckBox/story.tsx
@@ -16,6 +16,20 @@ aStandardCheckboxField.story = {
   name: 'A standard checkbox field.',
 };
 
+export function inDifferentSizes() {
+  return (
+    <>
+      <CheckBox small name="cb-small" label="Small" onChange={action('onChange')} />
+      <CheckBox name="cb-regular" label="Regular" onChange={action('onChange')} />
+      <CheckBox large name="cb-large" label="Large" onChange={action('onChange')} />
+    </>
+  );
+}
+
+inDifferentSizes.story = {
+  name: 'In different sizes.',
+};
+
 export function withAnErrorMessageInAnInvalidState() {
   return (
     <CheckBox
@@ -137,7 +151,7 @@ export function asACompactClickableButton() {
   return (
     <CheckBox
       button
-      compact
+      small
       name="cb-basic"
       label="Label"
       labelDescription="This is a label description."

--- a/packages/core/src/components/CheckBoxController/story.tsx
+++ b/packages/core/src/components/CheckBoxController/story.tsx
@@ -80,3 +80,53 @@ export function handlesDisabledStateWithNoSpacing() {
 handlesDisabledStateWithNoSpacing.story = {
   name: 'Handles disabled state, with no spacing.',
 };
+
+export function asSmall() {
+  return (
+    <CheckBoxController
+      optional
+      small
+      label="Favorite colors?"
+      name="color"
+      value={['green']}
+      onChange={action('onChange')}
+    >
+      {CheckBox => (
+        <div>
+          <CheckBox label="❤️ Red" value="red" />
+          <CheckBox label="💙 Blue" value="blue" />
+          <CheckBox label="💚 Green" value="green" />
+        </div>
+      )}
+    </CheckBoxController>
+  );
+}
+
+asSmall.story = {
+  name: 'As small.',
+};
+
+export function asLarge() {
+  return (
+    <CheckBoxController
+      optional
+      large
+      label="Favorite colors?"
+      name="color"
+      value={['green']}
+      onChange={action('onChange')}
+    >
+      {CheckBox => (
+        <div>
+          <CheckBox label="❤️ Red" value="red" />
+          <CheckBox label="💙 Blue" value="blue" />
+          <CheckBox label="💚 Green" value="green" />
+        </div>
+      )}
+    </CheckBoxController>
+  );
+}
+
+asLarge.story = {
+  name: 'As large.',
+};

--- a/packages/core/src/components/DatePickerInput/index.tsx
+++ b/packages/core/src/components/DatePickerInput/index.tsx
@@ -58,7 +58,7 @@ export default class DatePickerInput extends React.Component<
     const { value } = event.currentTarget;
     const date = this.parseDate(value);
 
-    this.props.onChange(value, date || null, event);
+    this.props.onChange(value, date ?? null, event);
   };
 
   private handleDayChange = (day?: Date) => {
@@ -79,14 +79,14 @@ export default class DatePickerInput extends React.Component<
   };
 
   getFormat(): string {
-    return this.props.format || mdyCalendarBundle.get(this.props.locale);
+    return this.props.format ?? mdyCalendarBundle.get(this.props.locale);
   }
 
   parseDate = (value: string, format?: string, locale?: string) => {
     try {
       return createDateTime(value, {
-        sourceFormat: format || this.getFormat(),
-        locale: locale || this.props.locale,
+        sourceFormat: format ?? this.getFormat(),
+        locale: locale ?? this.props.locale,
       }).toJSDate();
     } catch (error) {
       return undefined;
@@ -94,13 +94,13 @@ export default class DatePickerInput extends React.Component<
   };
 
   formatDate = (date: Date | string, baseFormat?: string, locale?: string) => {
-    const format = baseFormat || this.getFormat();
+    const format = baseFormat ?? this.getFormat();
 
     return DateTime.format({
       at: date,
       format,
       sourceFormat: format,
-      locale: locale || this.props.locale,
+      locale: locale ?? this.props.locale,
       noTime: true,
       noTimezone: true,
     });
@@ -136,7 +136,7 @@ export default class DatePickerInput extends React.Component<
           format={format}
           clickUnselectsDay={clearOnDayClick}
           hideOnDayClick={hideOnDayClick}
-          placeholder={restProps.placeholder || format.toUpperCase()}
+          placeholder={restProps.placeholder ?? format.toUpperCase()}
           parseDate={this.parseDate}
           formatDate={this.formatDate}
           onDayPickerHide={onHidePicker}

--- a/packages/core/src/components/DatePickerInput/story.tsx
+++ b/packages/core/src/components/DatePickerInput/story.tsx
@@ -107,6 +107,42 @@ aSingleMonth.story = {
   name: 'A single month.',
 };
 
+export function asSmall() {
+  return (
+    <DatePickerInput
+      small
+      name="date"
+      label="Label"
+      datePickerProps={{
+        onMonthChange: action('onMonthChange'),
+      }}
+      onChange={action('onChange')}
+    />
+  );
+}
+
+asSmall.story = {
+  name: 'As small.',
+};
+
+export function asLarge() {
+  return (
+    <DatePickerInput
+      large
+      name="date"
+      label="Label"
+      datePickerProps={{
+        onMonthChange: action('onMonthChange'),
+      }}
+      onChange={action('onChange')}
+    />
+  );
+}
+
+asLarge.story = {
+  name: 'As large.',
+};
+
 export function aCustomFormat() {
   return (
     <DatePickerInput

--- a/packages/core/src/components/DateTimeSelect/story.tsx
+++ b/packages/core/src/components/DateTimeSelect/story.tsx
@@ -25,13 +25,13 @@ standardSelectFieldForDatesAndTimes.story = {
   name: 'Standard select field for dates and times.',
 };
 
-export function withACompactSmallerView() {
+export function inDifferentSizes() {
   return (
     <>
       <DateTimeSelect
-        compact
-        name="dts-compact"
-        label="Compact"
+        small
+        name="dts-small"
+        label="Small"
         value={fixedDate}
         onChange={action('onChange')}
       />
@@ -41,12 +41,19 @@ export function withACompactSmallerView() {
         value={fixedDate}
         onChange={action('onChange')}
       />
+      <DateTimeSelect
+        large
+        name="dts-large"
+        label="Large"
+        value={fixedDate}
+        onChange={action('onChange')}
+      />
     </>
   );
 }
 
-withACompactSmallerView.story = {
-  name: 'With a compact smaller view.',
+inDifferentSizes.story = {
+  name: 'In different sizes.',
 };
 
 export function withAnInvalidState() {

--- a/packages/core/src/components/FileInput/index.tsx
+++ b/packages/core/src/components/FileInput/index.tsx
@@ -139,7 +139,8 @@ export default class FileInput extends React.Component<FileInputProps, FileInput
         <FormInputButton
           inverted
           invalid={fieldProps.invalid}
-          small={fieldProps.compact}
+          small={fieldProps.small}
+          large={fieldProps.large}
           disabled={props.disabled}
           afterIcon={<Icon decorative size="1.25em" />}
           onClick={this.handleClick}
@@ -155,7 +156,7 @@ export default class FileInput extends React.Component<FileInputProps, FileInput
 
         {files.length > 0 && !fieldProps.inline && (
           <Spacing top={1}>
-            <Text small={fieldProps.compact}>
+            <Text small={fieldProps.small}>
               <Table compact striped>
                 <tbody>
                   {files.map((file, i) => (

--- a/packages/core/src/components/FileInput/story.tsx
+++ b/packages/core/src/components/FileInput/story.tsx
@@ -34,23 +34,18 @@ supportsMultipleFilesOfImageOnlyWhileHidingFilePreviewColumns.story = {
   name: 'Supports multiple files, of image only, while hiding file preview columns.',
 };
 
-export function withACompactSmallerViewOnlySupportingAudioAndVideo() {
+export function inDifferentSizesAndFileTypes() {
   return (
     <>
-      <FileInput
-        onlyAudio
-        compact
-        name="input-compact"
-        label="Compact"
-        onChange={action('onChange')}
-      />
+      <FileInput onlyAudio small name="input-small" label="Small" onChange={action('onChange')} />
       <FileInput onlyVideo name="input-regular" label="Regular" onChange={action('onChange')} />
+      <FileInput onlyImages large name="input-large" label="Large" onChange={action('onChange')} />
     </>
   );
 }
 
-withACompactSmallerViewOnlySupportingAudioAndVideo.story = {
-  name: 'With a compact smaller view, only supporting audio and video.',
+inDifferentSizesAndFileTypes.story = {
+  name: 'In different sizes and file types.',
 };
 
 export function withAnErrorMessageInAnInvalidState() {

--- a/packages/core/src/components/FormField/Prefix.tsx
+++ b/packages/core/src/components/FormField/Prefix.tsx
@@ -4,10 +4,10 @@ import FieldAffix, { FieldAffixProps } from '../private/FieldAffix';
 /** A prefix to display before an input within a form field. */
 export default class Prefix extends React.PureComponent<FieldAffixProps> {
   render() {
-    const { children, compact, disabled } = this.props;
+    const { children, small, large, disabled } = this.props;
 
     return (
-      <FieldAffix before compact={compact} disabled={disabled}>
+      <FieldAffix before small={small} large={large} disabled={disabled}>
         {children}
       </FieldAffix>
     );

--- a/packages/core/src/components/FormField/Suffix.tsx
+++ b/packages/core/src/components/FormField/Suffix.tsx
@@ -4,10 +4,10 @@ import FieldAffix, { FieldAffixProps } from '../private/FieldAffix';
 /** A suffix to display after an input within a form field. */
 export default class Suffix extends React.PureComponent<FieldAffixProps> {
   render() {
-    const { children, compact, disabled } = this.props;
+    const { children, small, large, disabled } = this.props;
 
     return (
-      <FieldAffix after compact={compact} disabled={disabled}>
+      <FieldAffix after small={small} large={large} disabled={disabled}>
         {children}
       </FieldAffix>
     );

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -10,8 +10,6 @@ import Suffix from './Suffix';
 import { styleSheet } from './styles';
 
 export type FormFieldProps = {
-  /** @deprecated Decrease label font size and spacing. */
-  compact?: boolean;
   /** @ignore Decrease bottom margin of the field. (Internal use only) */
   compactSpacing?: boolean;
   /** Mark the field as disabled. */
@@ -68,7 +66,6 @@ export { partitionFieldProps, Prefix, Suffix };
 /** A abstract form field wrapper that handles labels, affixes, errors, states, and more. */
 export default function FormField({
   children,
-  compact,
   compactSpacing,
   disabled,
   errorMessage,
@@ -115,7 +112,7 @@ export default function FormField({
     <section
       className={cx(
         styles.field,
-        (compact || compactSpacing || small) && !noSpacing && styles.field_compactSpacing,
+        (compactSpacing || small) && !noSpacing && styles.field_compactSpacing,
         noSpacing && styles.field_noSpacing,
       )}
     >
@@ -134,7 +131,7 @@ export default function FormField({
           <StatusText
             danger={invalid}
             muted={disabled}
-            small={compact || small}
+            small={small}
             large={large}
             bold={!renderLargeLabel}
           >

--- a/packages/core/src/components/FormField/partitionFieldProps.ts
+++ b/packages/core/src/components/FormField/partitionFieldProps.ts
@@ -26,7 +26,6 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
 } {
   const {
     children,
-    compact = false,
     compactSpacing = false,
     disabled = false,
     errorMessage = '',
@@ -50,7 +49,6 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
     children,
     field,
     fieldProps: {
-      compact,
       compactSpacing,
       disabled,
       errorMessage,
@@ -71,7 +69,6 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
     inputProps: {
       value: '',
       ...inputProps,
-      compact,
       disabled,
       hasPrefix: !!prefix,
       hasSuffix: !!suffix,

--- a/packages/core/src/components/FormField/story.tsx
+++ b/packages/core/src/components/FormField/story.tsx
@@ -119,7 +119,7 @@ export function supportsBothAPrefixAndSuffixAndACompactState() {
   return (
     <>
       <Input
-        compact
+        small
         name="both-input"
         label="Input"
         prefix={<Prefix compact>http://</Prefix>}
@@ -128,7 +128,7 @@ export function supportsBothAPrefixAndSuffixAndACompactState() {
       />
 
       <TextArea
-        compact
+        small
         disabled
         name="both-textarea"
         label="TextArea"
@@ -149,7 +149,7 @@ export function supportsBothAPrefixAndSuffixAndACompactState() {
 }
 
 supportsBothAPrefixAndSuffixAndACompactState.story = {
-  name: 'Supports both a prefix and suffix, and a compact state.',
+  name: 'Supports both a prefix and suffix in a small state.',
 };
 
 export function supportsInline() {

--- a/packages/core/src/components/FormField/story.tsx
+++ b/packages/core/src/components/FormField/story.tsx
@@ -115,15 +115,15 @@ supportsASuffix.story = {
   name: 'Supports a suffix.',
 };
 
-export function supportsBothAPrefixAndSuffixAndACompactState() {
+export function supportsBothAPrefixAndSuffixAndASmallState() {
   return (
     <>
       <Input
         small
         name="both-input"
         label="Input"
-        prefix={<Prefix compact>http://</Prefix>}
-        suffix={<Suffix compact>.com</Suffix>}
+        prefix={<Prefix small>http://</Prefix>}
+        suffix={<Suffix small>.com</Suffix>}
         onChange={action('onChange')}
       />
 
@@ -133,12 +133,12 @@ export function supportsBothAPrefixAndSuffixAndACompactState() {
         name="both-textarea"
         label="TextArea"
         prefix={
-          <Prefix compact disabled>
+          <Prefix small disabled>
             Hello
           </Prefix>
         }
         suffix={
-          <Suffix compact disabled>
+          <Suffix small disabled>
             Goodbye
           </Suffix>
         }
@@ -148,8 +148,45 @@ export function supportsBothAPrefixAndSuffixAndACompactState() {
   );
 }
 
-supportsBothAPrefixAndSuffixAndACompactState.story = {
+supportsBothAPrefixAndSuffixAndASmallState.story = {
   name: 'Supports both a prefix and suffix in a small state.',
+};
+
+export function supportsBothAPrefixAndSuffixAndALargeState() {
+  return (
+    <>
+      <Input
+        large
+        name="both-input"
+        label="Input"
+        prefix={<Prefix large>http://</Prefix>}
+        suffix={<Suffix large>.com</Suffix>}
+        onChange={action('onChange')}
+      />
+
+      <TextArea
+        large
+        disabled
+        name="both-textarea"
+        label="TextArea"
+        prefix={
+          <Prefix large disabled>
+            Hello
+          </Prefix>
+        }
+        suffix={
+          <Suffix large disabled>
+            Goodbye
+          </Suffix>
+        }
+        onChange={action('onChange')}
+      />
+    </>
+  );
+}
+
+supportsBothAPrefixAndSuffixAndALargeState.story = {
+  name: 'Supports both a prefix and suffix in a large state.',
 };
 
 export function supportsInline() {

--- a/packages/core/src/components/Input/story.tsx
+++ b/packages/core/src/components/Input/story.tsx
@@ -23,7 +23,7 @@ aStandardTextField.story = {
   name: 'A standard text field.',
 };
 
-export function withDifferentSizingSmallDefaultOrLarge() {
+export function inDifferentSizes() {
   return (
     <>
       <Input
@@ -50,8 +50,8 @@ export function withDifferentSizingSmallDefaultOrLarge() {
   );
 }
 
-withDifferentSizingSmallDefaultOrLarge.story = {
-  name: 'With different sizing: small, default or large.',
+inDifferentSizes.story = {
+  name: 'In different sizes.',
 };
 
 export function withAnErrorMessageInAnInvalidState() {

--- a/packages/core/src/components/Multicomplete/story.tsx
+++ b/packages/core/src/components/Multicomplete/story.tsx
@@ -192,3 +192,67 @@ export function renderACustomChip() {
 renderACustomChip.story = {
   name: 'Render a custom selected value instead of a Chip.',
 };
+
+export function asSmall() {
+  return (
+    <Multicomplete
+      small
+      accessibilityLabel="Favorite color?"
+      label="Favorite color?"
+      name="autocomplete"
+      renderItem={(item, highlighted, selected) => (
+        <Text bold={selected} muted={highlighted}>
+          {item.name}
+        </Text>
+      )}
+      onChange={action('onChange')}
+      onSelectItem={action('onSelectItem')}
+      onLoadItems={value =>
+        Promise.resolve(
+          [
+            { value: 'red', name: 'Red' },
+            { value: 'black', name: 'Black' },
+            { value: 'blue', name: 'Blue' },
+            { value: 'green', name: 'Green' },
+          ].filter(item => item.name.toLowerCase().match(value.toLowerCase())),
+        )
+      }
+    />
+  );
+}
+
+asSmall.story = {
+  name: 'As small.',
+};
+
+export function asLarge() {
+  return (
+    <Multicomplete
+      large
+      accessibilityLabel="Favorite color?"
+      label="Favorite color?"
+      name="autocomplete"
+      renderItem={(item, highlighted, selected) => (
+        <Text bold={selected} muted={highlighted}>
+          {item.name}
+        </Text>
+      )}
+      onChange={action('onChange')}
+      onSelectItem={action('onSelectItem')}
+      onLoadItems={value =>
+        Promise.resolve(
+          [
+            { value: 'red', name: 'Red' },
+            { value: 'black', name: 'Black' },
+            { value: 'blue', name: 'Blue' },
+            { value: 'green', name: 'Green' },
+          ].filter(item => item.name.toLowerCase().match(value.toLowerCase())),
+        )
+      }
+    />
+  );
+}
+
+asLarge.story = {
+  name: 'As large.',
+};

--- a/packages/core/src/components/RadioButton/story.tsx
+++ b/packages/core/src/components/RadioButton/story.tsx
@@ -19,6 +19,32 @@ aStandardRadioButtonField.story = {
   name: 'A standard radio button field.',
 };
 
+export function inDifferentSizes() {
+  return (
+    <>
+      <RadioButton
+        small
+        name="radio-small"
+        label="Small"
+        value="foo"
+        onChange={action('onChange')}
+      />
+      <RadioButton name="radio-regular" label="Regular" value="foo" onChange={action('onChange')} />
+      <RadioButton
+        large
+        name="radio-large"
+        label="Large"
+        value="foo"
+        onChange={action('onChange')}
+      />
+    </>
+  );
+}
+
+inDifferentSizes.story = {
+  name: 'In different sizes.',
+};
+
 export function withAnErrorMessageInAnInvalidState() {
   return (
     <RadioButton
@@ -169,7 +195,7 @@ export function asACompactClickableButton() {
   return (
     <RadioButton
       button
-      compact
+      small
       name="radio-basic"
       label="Label"
       labelDescription="This is a label description."
@@ -182,5 +208,5 @@ export function asACompactClickableButton() {
 }
 
 asACompactClickableButton.story = {
-  name: 'As a compact, clickable button.',
+  name: 'As a small clickable button.',
 };

--- a/packages/core/src/components/RadioButtonController/story.tsx
+++ b/packages/core/src/components/RadioButtonController/story.tsx
@@ -32,6 +32,54 @@ controlsMultipleRadioButtons.story = {
   name: 'Controls multiple radio buttons.',
 };
 
+export function asSmall() {
+  return (
+    <RadioButtonController
+      optional
+      small
+      label="Favorite food?"
+      name="food"
+      onChange={action('onChange')}
+    >
+      {RadioButton => (
+        <div>
+          <RadioButton label="🍕 Pizza" value="pizza" />
+          <RadioButton label="🍔 Burger" value="burger" />
+          <RadioButton label="🍜 Ramen" value="ramen" />
+        </div>
+      )}
+    </RadioButtonController>
+  );
+}
+
+asSmall.story = {
+  name: 'As small.',
+};
+
+export function asLarge() {
+  return (
+    <RadioButtonController
+      optional
+      large
+      label="Favorite food?"
+      name="food"
+      onChange={action('onChange')}
+    >
+      {RadioButton => (
+        <div>
+          <RadioButton label="🍕 Pizza" value="pizza" />
+          <RadioButton label="🍔 Burger" value="burger" />
+          <RadioButton label="🍜 Ramen" value="ramen" />
+        </div>
+      )}
+    </RadioButtonController>
+  );
+}
+
+asLarge.story = {
+  name: 'As large.',
+};
+
 export function handlesInvalidStateWithNoSpacing() {
   return (
     <RadioButtonController invalid label="Favorite food?" name="food" onChange={action('onChange')}>

--- a/packages/core/src/components/Select/story.tsx
+++ b/packages/core/src/components/Select/story.tsx
@@ -24,10 +24,10 @@ aStandardSelectField.story = {
   name: 'A standard select field.',
 };
 
-export function withACompactSmallerView() {
+export function inDifferentSizes() {
   return (
     <>
-      <Select compact name="select-compact" label="Compact" onChange={action('onChange')}>
+      <Select small name="select-small" label="Small" onChange={action('onChange')}>
         <option value="foo">Foo</option>
         <option disabled value="bar">
           Bar
@@ -42,12 +42,20 @@ export function withACompactSmallerView() {
         </option>
         <option value="baz">Baz</option>
       </Select>
+
+      <Select large name="select-regular" label="Large" onChange={action('onChange')}>
+        <option value="foo">Foo</option>
+        <option disabled value="bar">
+          Bar
+        </option>
+        <option value="baz">Baz</option>
+      </Select>
     </>
   );
 }
 
-withACompactSmallerView.story = {
-  name: 'With a compact smaller view.',
+inDifferentSizes.story = {
+  name: 'In different sizes.',
 };
 
 export function withAnErrorMessageInAnInvalidState() {

--- a/packages/core/src/components/Switch/story.tsx
+++ b/packages/core/src/components/Switch/story.tsx
@@ -16,6 +16,20 @@ aStandardSwitchField.story = {
   name: 'A standard switch field.',
 };
 
+export function inDifferentSizes() {
+  return (
+    <>
+      <Switch small name="switch-small" label="Small" onChange={action('onChange')} />
+      <Switch name="switch-regular" label="Regular" onChange={action('onChange')} />
+      <Switch large name="switch-large" label="Large" onChange={action('onChange')} />
+    </>
+  );
+}
+
+inDifferentSizes.story = {
+  name: 'In different sizes.',
+};
+
 export function withAnErrorMessageInAnInvalidState() {
   return (
     <Switch

--- a/packages/core/src/components/TextArea/story.tsx
+++ b/packages/core/src/components/TextArea/story.tsx
@@ -195,7 +195,7 @@ export function displayWithInlineLabelAndAPrefix() {
       inline
       name="both-textarea"
       label="TextArea"
-      prefix={<Prefix compact>Hello</Prefix>}
+      prefix={<Prefix>Hello</Prefix>}
       onChange={action('onChange')}
     />
   );

--- a/packages/core/src/components/TextArea/story.tsx
+++ b/packages/core/src/components/TextArea/story.tsx
@@ -111,17 +111,18 @@ aStandardTextareaField.story = {
   name: 'A standard textarea field.',
 };
 
-export function withACompactSmallerView() {
+export function inDifferentSizes() {
   return (
     <>
-      <TextArea compact name="textarea-compact" label="Compact" onChange={action('onChange')} />
+      <TextArea small name="textarea-small" label="Small" onChange={action('onChange')} />
       <TextArea name="textarea-regular" label="Regular" onChange={action('onChange')} />
+      <TextArea large name="textarea-large" label="Large" onChange={action('onChange')} />
     </>
   );
 }
 
-withACompactSmallerView.story = {
-  name: 'With a compact smaller view.',
+inDifferentSizes.story = {
+  name: 'In different sizes.',
 };
 
 export function withAnErrorMessageInAnInvalidState() {

--- a/packages/core/src/components/ToggleButtonController/index.tsx
+++ b/packages/core/src/components/ToggleButtonController/index.tsx
@@ -68,7 +68,7 @@ export default class ToggleButtonController extends React.Component<
   };
 
   renderButton = proxyComponent(BaseButton, ({ children, value, ...props }: PropsProvided) => {
-    const { compact, disabled, invalid } = this.props;
+    const { small, disabled, invalid, large } = this.props;
     const { id, value: selectedValue } = this.state;
     const selected = value === selectedValue;
 
@@ -81,7 +81,8 @@ export default class ToggleButtonController extends React.Component<
         disabled={disabled}
         inverted={!selected}
         invalid={invalid}
-        small={compact}
+        small={small}
+        large={large}
         onClick={this.handleClick}
       >
         {children}

--- a/packages/core/src/components/ToggleButtonController/story.tsx
+++ b/packages/core/src/components/ToggleButtonController/story.tsx
@@ -99,10 +99,10 @@ handlesDisabledState.story = {
   name: 'Handles disabled state.',
 };
 
-export function withCompact() {
+export function asSmall() {
   return (
     <ToggleButtonController
-      compact
+      small
       value="red"
       name="button-group-controller"
       label="Favorite color?"
@@ -125,8 +125,38 @@ export function withCompact() {
   );
 }
 
-withCompact.story = {
-  name: 'With `compact`',
+asSmall.story = {
+  name: 'As small.',
+};
+
+export function asLarge() {
+  return (
+    <ToggleButtonController
+      large
+      value="red"
+      name="button-group-controller"
+      label="Favorite color?"
+      onChange={action('onChange')}
+    >
+      {ControlledButton => (
+        <ButtonGroup>
+          <ControlledButton key="red" value="red">
+            Red
+          </ControlledButton>
+          <ControlledButton key="blue" value="blue">
+            Blue
+          </ControlledButton>
+          <ControlledButton key="green" value="green">
+            Green
+          </ControlledButton>
+        </ButtonGroup>
+      )}
+    </ToggleButtonController>
+  );
+}
+
+asLarge.story = {
+  name: 'As large.',
 };
 
 export function withInline() {

--- a/packages/core/src/components/private/BaseAffix.tsx
+++ b/packages/core/src/components/private/BaseAffix.tsx
@@ -3,6 +3,7 @@ import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import { WithStylesProps } from '../../composers/withStyles';
 
 const dirProp = mutuallyExclusiveTrueProps('after', 'before');
+const sizeProp = mutuallyExclusiveTrueProps('small', 'large');
 
 export type BaseAffixProps = {
   /** @ignore */
@@ -11,18 +12,22 @@ export type BaseAffixProps = {
   before?: boolean;
   /** Content within the affix. */
   children: NonNullable<React.ReactNode>;
-  /** Decrease font size and padding. */
-  compact?: boolean;
+  /** Increase font size and padding. */
+  large?: boolean;
   /** Mark the affix as disabled. */
   disabled?: boolean;
   /** Align using flexbox. */
   flex?: boolean;
+  /** Decrease font size and padding. */
+  small?: boolean;
 };
 
 export default class BaseAffix extends React.PureComponent<BaseAffixProps & WithStylesProps> {
   static propTypes = {
     after: dirProp,
     before: dirProp,
+    large: sizeProp,
+    small: sizeProp,
   };
 
   static defaultProps = {
@@ -34,13 +39,14 @@ export default class BaseAffix extends React.PureComponent<BaseAffixProps & With
   };
 
   render() {
-    const { cx, after, before, children, compact, disabled, flex, styles } = this.props;
+    const { cx, after, before, children, small, large, disabled, flex, styles } = this.props;
 
     return (
       <div
         className={cx(
           styles.affix,
-          compact && styles.affix_compact,
+          small && styles.affix_small,
+          large && styles.affix_large,
           before && styles.affix_before,
           after && styles.affix_after,
           disabled && styles.affix_disabled,

--- a/packages/core/src/components/private/BaseCheckBox.tsx
+++ b/packages/core/src/components/private/BaseCheckBox.tsx
@@ -83,7 +83,7 @@ export default function BaseCheckBox({
   button,
   checked,
   children,
-  compact,
+  small,
   disabled,
   hideLabel,
   id,
@@ -150,7 +150,7 @@ export default function BaseCheckBox({
         checked && styles.button_checked,
         invalid && styles.button_invalid,
         disabled && styles.button_disabled,
-        compact && styles.button_compact,
+        small && styles.button_small,
       )}
     >
       {checkbox}

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -85,7 +85,7 @@ export default function BaseRadioButton({
   button,
   checked,
   children,
-  compact,
+  small,
   disabled,
   hideLabel,
   id,
@@ -151,7 +151,7 @@ export default function BaseRadioButton({
         checked && styles.button_checked,
         invalid && styles.button_invalid,
         disabled && styles.button_disabled,
-        compact && styles.button_compact,
+        small && styles.button_small,
       )}
     >
       {radioButton}

--- a/packages/core/src/components/private/BaseSelect.tsx
+++ b/packages/core/src/components/private/BaseSelect.tsx
@@ -12,7 +12,7 @@ const styleSheet: StyleSheet = ({ pattern, unit }) => ({
 
   arrow: {
     position: 'absolute',
-    right: unit,
+    right: unit / 2,
     top: '50%',
     transform: 'translateY(-50%)',
     pointerEvents: 'none',
@@ -27,8 +27,12 @@ const styleSheet: StyleSheet = ({ pattern, unit }) => ({
     ...pattern.invalid,
   },
 
-  arrow_compact: {
-    right: unit * 0.75,
+  arrow_small: {
+    right: unit * 0.25,
+  },
+
+  arrow_large: {
+    right: unit,
   },
 });
 
@@ -70,7 +74,8 @@ export default function BaseSelect({
           styles.arrow,
           restProps.disabled && styles.arrow_disabled,
           restProps.invalid && styles.arrow_invalid,
-          restProps.compact && styles.arrow_compact,
+          restProps.small && styles.arrow_small,
+          restProps.large && styles.arrow_large,
         )}
       >
         <IconCaretDown decorative size="2em" />

--- a/packages/core/src/components/private/FieldAffix.tsx
+++ b/packages/core/src/components/private/FieldAffix.tsx
@@ -16,10 +16,16 @@ export default withStyles(({ color, font, unit, ui, pattern }) => ({
     paddingRight: unit * 1.5,
   },
 
-  affix_compact: {
+  affix_small: {
     ...font.textSmall,
     paddingLeft: unit,
     paddingRight: unit,
+  },
+
+  affix_large: {
+    ...font.textLarge,
+    paddingLeft: unit * 2,
+    paddingRight: unit * 2,
   },
 
   affix_after: {

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -27,8 +27,6 @@ export type IgnoreAttributes =
   | 'security';
 
 export type FormInputProps<T = unknown> = {
-  /** @deprecated decrease font size and padding to small. */
-  compact?: boolean;
   /** Mark the field as important. */
   important?: boolean;
   /** Mark the field as invalid. */
@@ -74,7 +72,6 @@ export type PrivateProps = FormInputProps & {
 
 function FormInput({
   children,
-  compact,
   disabled,
   hasPrefix,
   hasSuffix,
@@ -97,7 +94,8 @@ function FormInput({
     ...restProps,
     className: cx(
       styles.input,
-      (compact || small) && styles.input_compact,
+      small && styles.input_small,
+      large && styles.input_large,
       disabled && styles.input_disabled,
       hasPrefix && styles.input_hasPrefix,
       hasSuffix && styles.input_hasSuffix,
@@ -105,20 +103,13 @@ function FormInput({
       important && styles.input_important,
       invalid && styles.input_invalid,
       isSelect && styles.select,
-      isSelect && compact && styles.select_compact,
-      large && styles.input_large,
+      isSelect && small && styles.select_small,
+      isSelect && large && styles.select_large,
     ),
     disabled,
     id,
     required: !optional,
   };
-
-  if (__DEV__) {
-    if (compact) {
-      // eslint-disable-next-line no-console
-      console.log('Input: `compact` prop is deprecated, please use `small` instead.');
-    }
-  }
 
   // Only populate when invalid, otherwise it will break some CSS selectors
   if (invalid) {
@@ -140,10 +131,9 @@ function FormInput({
   return <Tag {...props} ref={propagateRef} data-gramm="false" data-enable-grammarly="false" />;
 }
 
-const sizingProp = mutuallyExclusiveTrueProps('small', 'compact', 'large');
+const sizingProp = mutuallyExclusiveTrueProps('small', 'large');
 
 FormInput.propTypes = {
-  compact: sizingProp,
   large: sizingProp,
   small: sizingProp,
 };

--- a/packages/core/src/themes/inputStyleSheet.ts
+++ b/packages/core/src/themes/inputStyleSheet.ts
@@ -99,7 +99,7 @@ const inputStyleSheet = ({ color, pattern, ui, unit, transition }: Theme): Sheet
       backgroundColor: color.core.danger[0],
     },
 
-    input_compact: {
+    input_small: {
       ...pattern.smallButton,
     },
 
@@ -152,11 +152,15 @@ const inputStyleSheet = ({ color, pattern, ui, unit, transition }: Theme): Sheet
 
     select: {
       appearance: 'none',
-      paddingRight: unit * 4.5,
+      paddingRight: unit * 4,
     },
 
-    select_compact: {
+    select_small: {
       paddingRight: unit * 3,
+    },
+
+    select_large: {
+      paddingRight: unit * 5,
     },
 
     button: {
@@ -173,7 +177,7 @@ const inputStyleSheet = ({ color, pattern, ui, unit, transition }: Theme): Sheet
       ...commonChecked,
     },
 
-    button_compact: {
+    button_small: {
       padding: unit * 2,
     },
 

--- a/packages/core/test/components/FileInput.test.tsx
+++ b/packages/core/test/components/FileInput.test.tsx
@@ -44,8 +44,8 @@ describe('<FileInput />', () => {
     expect(wrapper.find(FormInputButton).prop('invalid')).toBe(true);
   });
 
-  it('marks button as small when compact', () => {
-    const wrapper = shallow(<FileInput {...props} compact />);
+  it('marks button as small when small', () => {
+    const wrapper = shallow(<FileInput {...props} small />);
 
     expect(wrapper.find(FormInputButton).prop('small')).toBe(true);
   });

--- a/packages/core/test/components/ToggleButtonController.test.tsx
+++ b/packages/core/test/components/ToggleButtonController.test.tsx
@@ -129,9 +129,9 @@ describe('<ToggleButtonController />', () => {
     ).toBeTruthy();
   });
 
-  it('`compact` renders `small` buttons', () => {
+  it('renders `small` buttons', () => {
     const wrapper = shallow(
-      <ToggleButtonController {...props} compact value="1">
+      <ToggleButtonController {...props} small value="1">
         {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>

--- a/packages/core/test/components/private/BaseSelect.test.tsx
+++ b/packages/core/test/components/private/BaseSelect.test.tsx
@@ -34,14 +34,14 @@ describe('<BaseSelect />', () => {
     expect(wrapper.find('span').prop('className')).toMatch('arrow_invalid');
   });
 
-  it('renders compact', () => {
+  it('renders small', () => {
     const wrapper = shallow(
-      <BaseSelect compact name="foo" onChange={() => {}}>
+      <BaseSelect small name="foo" onChange={() => {}}>
         <option value="bar">Bar</option>
       </BaseSelect>,
     );
 
-    expect(wrapper.find('span').prop('className')).toMatch('arrow_compact');
+    expect(wrapper.find('span').prop('className')).toMatch('arrow_small');
   });
 
   it('renders options via children', () => {

--- a/packages/core/test/components/private/FieldAffix.test.tsx
+++ b/packages/core/test/components/private/FieldAffix.test.tsx
@@ -15,14 +15,24 @@ describe('<FieldAffix />', () => {
     expect(wrapper.prop('className')).not.toBe(beforeClass);
   });
 
-  it('renders compact', () => {
+  it('renders small', () => {
     const wrapper = shallowWithStyles(
-      <FieldAffix after compact>
+      <FieldAffix after small>
         Child
       </FieldAffix>,
     );
 
-    expect(wrapper.prop('className')).toMatch('affix_compact');
+    expect(wrapper.prop('className')).toMatch('affix_small');
+  });
+
+  it('renders large', () => {
+    const wrapper = shallowWithStyles(
+      <FieldAffix after large>
+        Child
+      </FieldAffix>,
+    );
+
+    expect(wrapper.prop('className')).toMatch('affix_large');
   });
 
   it('errors if both props used', () => {

--- a/packages/core/test/components/private/FormInput.test.tsx
+++ b/packages/core/test/components/private/FormInput.test.tsx
@@ -33,16 +33,16 @@ describe('<FormInput />', () => {
     expect(wrapper.is('select')).toBe(true);
   });
 
-  it('renders compact', () => {
-    const wrapper = shallow(<FormInput compact tagName="input" {...props} />);
+  it('renders small', () => {
+    const wrapper = shallow(<FormInput small tagName="input" {...props} />);
 
-    expect(wrapper.prop('className')).toMatch('input_compact');
+    expect(wrapper.prop('className')).toMatch('input_small');
   });
 
-  it('renders select compact', () => {
-    const wrapper = shallow(<FormInput compact tagName="select" {...props} />);
+  it('renders select small', () => {
+    const wrapper = shallow(<FormInput small tagName="select" {...props} />);
 
-    expect(wrapper.prop('className')).toMatch('select select_compact');
+    expect(wrapper.prop('className')).toMatch('select select_small');
   });
 
   it('renders important', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Title.

## Motivation and Context

We need more variation. Compact was already deprecated, this just removes it entirely.

## Testing

Yup.

## Screenshots

Added lots of stories, check the happo diffs.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
