### PR TITLE
fix: Use tab instead of enter for shortcut selection.

### DIFF
--- a/packages/composer/src/components/Shortcuts.tsx
+++ b/packages/composer/src/components/Shortcuts.tsx
@@ -98,7 +98,7 @@ export default function Shortcuts({ shortcuts }: ShortcutsProps) {
 
       <Hotkey
         preventDefault
-        combo="enter"
+        combo="tab"
         condition={activeWhenShortcutsMenuOpen}
         name="selectShortcut"
         label={T.phrase('to select', null, { key: 'lunar.composer.shortcuts.hotkey.toSelect' })}

--- a/packages/composer/test/components/Composer.test.tsx
+++ b/packages/composer/test/components/Composer.test.tsx
@@ -392,7 +392,7 @@ describe('<Composer />', () => {
       expect(root.findAt(Selection, 1)).toHaveProp('active', false);
 
       // Trigger a select
-      root.findOne('textarea').dispatch('onKeyDown', { key: 'Enter' });
+      root.findOne('textarea').dispatch('onKeyDown', { key: 'Tab' });
 
       // Check input has been updated
       expect(root.findOne('textarea')).toHaveValue('/call');


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Switches from `enter` to `tab`.

## Motivation and Context

Relying on enter interferes with using enter to submit the form. So switching to tab, which aligns with the way suggestions are selected.

## Testing

Yes

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
