### PR TITLE
new(ProgressBar): Add status color options.

### DIFF
--- a/packages/core/src/components/ProgressBar/index.tsx
+++ b/packages/core/src/components/ProgressBar/index.tsx
@@ -4,22 +4,50 @@ import useStyles from '../../hooks/useStyles';
 import { styleSheet } from './styles';
 
 export type Props = {
+  /** Dangerous/failure status (red). */
+  danger?: boolean;
   /** Disable leading rounded corners. */
   leading?: boolean;
+  /** Muted/disabled status (gray). */
+  muted?: boolean;
+  /** Notice status. */
+  notice?: boolean;
   /** Percent in which the progess is complete, ranging from 0 to 100. */
   percent: number;
+  /** Successful status (green). */
+  success?: boolean;
   /** Disable trailing rounded corners. */
   trailing?: boolean;
+  /** Warning status (yellow). */
+  warning?: boolean;
 };
 
 /** A bar to represent the progress to completion. */
-function ProgressBar({ percent, leading, trailing }: Props) {
+function ProgressBar({
+  danger,
+  leading,
+  muted,
+  notice,
+  percent,
+  success,
+  trailing,
+  warning,
+}: Props) {
   const [styles, cx] = useStyles(styleSheet);
 
   return (
     <div className={cx(styles.wrapper)}>
       <div
-        className={cx(styles.bar, !leading && styles.bar_leading, !trailing && styles.bar_trailing)}
+        className={cx(
+          styles.bar,
+          danger && styles.bar_danger,
+          muted && styles.bar_muted,
+          notice && styles.bar_notice,
+          success && styles.bar_success,
+          warning && styles.bar_warning,
+          !leading && styles.bar_leading,
+          !trailing && styles.bar_trailing,
+        )}
       >
         <div
           className={cx(
@@ -27,6 +55,11 @@ function ProgressBar({ percent, leading, trailing }: Props) {
             !leading && styles.bar_leading,
             !trailing && styles.bar_trailing,
             styles.progress,
+            danger && styles.progress_danger,
+            muted && styles.progress_muted,
+            notice && styles.progress_notice,
+            success && styles.progress_success,
+            warning && styles.progress_warning,
           )}
           style={{ width: `${percent}%` }}
         />

--- a/packages/core/src/components/ProgressBar/index.tsx
+++ b/packages/core/src/components/ProgressBar/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { between } from 'airbnb-prop-types';
+import { mutuallyExclusiveTrueProps, between } from 'airbnb-prop-types';
 import useStyles from '../../hooks/useStyles';
 import { styleSheet } from './styles';
+import { STATUSES } from '../../constants';
 
 export type Props = {
   /** Dangerous/failure status (red). */
@@ -68,8 +69,16 @@ function ProgressBar({
   );
 }
 
+const statusPropType = mutuallyExclusiveTrueProps(...STATUSES);
+
 ProgressBar.propTypes = {
+  danger: statusPropType,
+  info: statusPropType,
+  muted: statusPropType,
+  notice: statusPropType,
   percent: between({ gte: 0, lte: 100 }).isRequired,
+  success: statusPropType,
+  warning: statusPropType,
 };
 
 export default ProgressBar;

--- a/packages/core/src/components/ProgressBar/story.tsx
+++ b/packages/core/src/components/ProgressBar/story.tsx
@@ -39,3 +39,25 @@ export function canDisableLeadingAndTrailingEdgesNoRoundedCorners() {
 canDisableLeadingAndTrailingEdgesNoRoundedCorners.story = {
   name: 'Can disable leading and trailing edges (no rounded corners).',
 };
+
+export function progressBarWithStatus() {
+  return (
+    <>
+      <ProgressBar percent={8} />
+      <br />
+      <ProgressBar danger percent={16} />
+      <br />
+      <ProgressBar muted percent={48} />
+      <br />
+      <ProgressBar notice percent={64} />
+      <br />
+      <ProgressBar success percent={80} />
+      <br />
+      <ProgressBar warning percent={95} />
+    </>
+  );
+}
+
+progressBarWithStatus.story = {
+  name: 'Progress bar: default, danger, muted, notice, success, and warning.',
+};

--- a/packages/core/src/components/ProgressBar/styles.ts
+++ b/packages/core/src/components/ProgressBar/styles.ts
@@ -42,27 +42,27 @@ const styleSheet: StyleSheet = ({ color, ui, unit }) => ({
   },
 
   progress: {
-    background: color.core.primary[5],
+    background: color.core.primary[6],
   },
 
   progress_danger: {
-    background: color.core.danger[5],
+    background: color.core.danger[6],
   },
 
   progress_muted: {
-    background: color.core.neutral[5],
+    background: color.core.neutral[6],
   },
 
   progress_notice: {
-    background: color.core.secondary[5],
+    background: color.core.secondary[6],
   },
 
   progress_success: {
-    background: color.core.success[5],
+    background: color.core.success[6],
   },
 
   progress_warning: {
-    background: color.core.warning[5],
+    background: color.core.warning[6],
   },
 });
 

--- a/packages/core/src/components/ProgressBar/styles.ts
+++ b/packages/core/src/components/ProgressBar/styles.ts
@@ -11,6 +11,26 @@ const styleSheet: StyleSheet = ({ color, ui, unit }) => ({
     background: color.core.primary[1],
   },
 
+  bar_danger: {
+    background: color.core.danger[1],
+  },
+
+  bar_muted: {
+    background: color.core.neutral[2],
+  },
+
+  bar_notice: {
+    background: color.core.secondary[1],
+  },
+
+  bar_success: {
+    background: color.core.success[1],
+  },
+
+  bar_warning: {
+    background: color.core.warning[1],
+  },
+
   bar_leading: {
     borderTopRightRadius: ui.borderRadius,
     borderBottomRightRadius: ui.borderRadius,
@@ -22,7 +42,27 @@ const styleSheet: StyleSheet = ({ color, ui, unit }) => ({
   },
 
   progress: {
-    background: color.core.primary[6],
+    background: color.core.primary[5],
+  },
+
+  progress_danger: {
+    background: color.core.danger[5],
+  },
+
+  progress_muted: {
+    background: color.core.neutral[5],
+  },
+
+  progress_notice: {
+    background: color.core.secondary[5],
+  },
+
+  progress_success: {
+    background: color.core.success[5],
+  },
+
+  progress_warning: {
+    background: color.core.warning[5],
   },
 });
 

--- a/packages/core/test/components/ProgressBar.test.tsx
+++ b/packages/core/test/components/ProgressBar.test.tsx
@@ -31,6 +31,61 @@ describe('<ProgressBar />', () => {
     ).toMatch('bar_trailing');
   });
 
+  it('renders danger', () => {
+    const wrapper = shallow(<ProgressBar danger percent={50} />);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .prop('className'),
+    ).toMatch('bar_danger');
+  });
+
+  it('renders muted', () => {
+    const wrapper = shallow(<ProgressBar muted percent={50} />);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .prop('className'),
+    ).toMatch('bar_muted');
+  });
+
+  it('renders notice', () => {
+    const wrapper = shallow(<ProgressBar notice percent={50} />);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .prop('className'),
+    ).toMatch('bar_notice');
+  });
+
+  it('renders success', () => {
+    const wrapper = shallow(<ProgressBar success percent={50} />);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .prop('className'),
+    ).toMatch('bar_success');
+  });
+
+  it('renders warning', () => {
+    const wrapper = shallow(<ProgressBar warning percent={50} />);
+
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .prop('className'),
+    ).toMatch('bar_warning');
+  });
+
   it('can change width with percent prop', () => {
     const wrapper = shallow(<ProgressBar percent={15} />);
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

cc: @williaster 

## Description

adds status color options to progress bar, based off of colors in StatusText:
- danger
- muted
- notice
- success
- warning

## Motivation and Context

request and the options are helpful

## Testing

storybook
unit tests

## Screenshots

<img width="1268" alt="Core : ProgressBar - Progress bar : default , danger , muted , notice , success , and warning   ⋅ Storybook 2020-02-13 14-26-23" src="https://user-images.githubusercontent.com/306275/74484156-e7c36c00-4e6c-11ea-8b0f-becb4b7b25fb.png">

<img width="1268" alt="Core : ProgressBar - Progress bar : default , danger , muted , notice , success , and warning   ⋅ Storybook 2020-02-13 14-26-43" src="https://user-images.githubusercontent.com/306275/74484166-eb56f300-4e6c-11ea-8b7f-7ae425e68cae.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
