### PR TITLE
fix(Tooltip): Don't set text alignment of Tooltip content

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -221,7 +221,7 @@ export class Tooltip extends React.Component<Props & WithStylesProps, State> {
             textAlign: align,
           })}
         >
-          <div className={cx(styles.shadow)}>
+          <div className={cx(styles.notchedBoxContainer)}>
             <NotchedBox
               inverted={!inverted}
               notchOffset={notchOffset[align as keyof StyleStruct]}

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -79,7 +79,13 @@ export function displaysWhenAnElementIsHovered() {
       <div style={{ textAlign: 'right' }}>
         <Text inline>Also has a tooltip →</Text>
         <Tooltip
-          content="This uncomfortably wide tooltip should probably be right-aligned"
+          content={
+            <Text inverted>
+              This uncomfortably wide tooltip should have a right-notch
+              <br />
+              and left-aligned text.
+            </Text>
+          }
           width={100}
         >
           <Button>Hover Me</Button>

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -45,10 +45,11 @@ const styleSheet: StyleSheet = ({ unit, color, pattern, ui }) => ({
     },
   },
 
-  shadow: {
+  notchedBoxContainer: {
     display: 'inline-block',
     boxShadow: ui.boxShadowLarge,
     borderRadius: ui.borderRadius,
+    textAlign: 'initial',
   },
 });
 

--- a/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/Tooltip.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`<Tooltip /> once open supports changing content 1`] = `
       role="tooltip"
     >
       <div
-        className="shadow"
+        className="notchedBoxContainer"
       >
         <NotchedBox
           inverted={true}
@@ -172,7 +172,7 @@ exports[`<Tooltip /> opens up when hovered 1`] = `
       role="tooltip"
     >
       <div
-        className="shadow"
+        className="notchedBoxContainer"
       >
         <NotchedBox
           inverted={true}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Motivation and Context

Currently the text alignment of `Tooltip` content matches however the `Tooltip` popover is positioned (left, center, right). Because of this we **always** have to set `<Text startAlign>{...}</Text>` for our tooltip content to override the behavior and have consistent styles. After talking offline we agreed this wasn't really needed.

## Description

This updates the `Tooltip` component styles to _not_ affect the text alignment of the `Tooltip` content itself. `textAlign` is set on the `Tooltip` container and is needed to correctly position the popover (removing this entirely breaks right positioning).

_Note_: you can still obviously override the alignment by wrapping in a `<Text endAlign/centerAlign>` etc.

## Testing

- [x] CI
- [x] functional / updated storybook example

## Screenshots

**Before**
<img src="https://user-images.githubusercontent.com/4496521/74560048-94a7f280-4f1a-11ea-8956-f5416554aaad.png" width="300" />
<img src="https://user-images.githubusercontent.com/4496521/74560072-9ffb1e00-4f1a-11ea-9b4a-cbcf8b4ad244.png" width="200" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/74559975-6fb37f80-4f1a-11ea-893c-4aa86ff00abd.png" width="300" />
<img src="https://user-images.githubusercontent.com/4496521/74560087-a7222c00-4f1a-11ea-9d85-7eabd98b2daf.png" width="200" />

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
