### PR TITLE
breaking: Add generics to components that may use it.

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,0 +1,6 @@
+module.exports = {
+  compilerOptions: {
+    noErrorTruncation: false,
+    pretty: true,
+  },
+};

--- a/packages/core/src/components/CheckBox/index.tsx
+++ b/packages/core/src/components/CheckBox/index.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react';
 import uuid from 'uuid/v4';
-import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import BaseCheckBox, { BaseCheckBoxProps } from '../private/BaseCheckBox';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 import Text from '../Text';
-
-const stateProp = mutuallyExclusiveTrueProps('checked', 'indeterminate');
 
 export type CheckBoxProps<T extends string> = BaseCheckBoxProps<T> &
   FormFieldProps & {
@@ -14,7 +11,7 @@ export type CheckBoxProps<T extends string> = BaseCheckBoxProps<T> &
   };
 
 /** A controlled checkbox field. */
-function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
+export default function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
   const { children, fieldProps, inputProps } = partitionFieldProps<T, CheckBoxProps<T>>(props);
   const { topAlign, ...restProps } = inputProps;
   const [id] = useState(() => uuid());
@@ -31,7 +28,12 @@ function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
       renderFullWidth={inputProps.button}
       topAlign={topAlign}
     >
-      <BaseCheckBox<T> {...restProps} id={props.id || id} hideLabel={fieldProps.hideLabel}>
+      <BaseCheckBox<T>
+        value="1"
+        {...restProps}
+        id={props.id || id}
+        hideLabel={fieldProps.hideLabel}
+      >
         {children || (
           <>
             <Text bold>{fieldProps.label}</Text>
@@ -42,10 +44,3 @@ function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
     </FormField>
   );
 }
-
-CheckBox.propTypes = {
-  checked: stateProp,
-  indeterminate: stateProp,
-};
-
-export default CheckBox;

--- a/packages/core/src/components/CheckBox/index.tsx
+++ b/packages/core/src/components/CheckBox/index.tsx
@@ -7,7 +7,7 @@ import Text from '../Text';
 
 const stateProp = mutuallyExclusiveTrueProps('checked', 'indeterminate');
 
-export type CheckBoxProps = BaseCheckBoxProps &
+export type CheckBoxProps<T extends string> = BaseCheckBoxProps<T> &
   FormFieldProps & {
     /** Top align content. */
     topAlign?: boolean;
@@ -18,7 +18,10 @@ export type CheckBoxState = {
 };
 
 /** A controlled checkbox field. */
-export default class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
+export default class CheckBox<T extends string = string> extends React.Component<
+  CheckBoxProps<T>,
+  CheckBoxState
+> {
   static defaultProps = {
     button: false,
     checked: false,
@@ -39,7 +42,9 @@ export default class CheckBox extends React.Component<CheckBoxProps, CheckBoxSta
   };
 
   render() {
-    const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
+    const { children, fieldProps, inputProps } = partitionFieldProps<T, CheckBoxProps<T>>(
+      this.props,
+    );
     const { topAlign, ...restProps } = inputProps;
     const { id } = this.state;
     const { hideLabel } = fieldProps;
@@ -56,7 +61,7 @@ export default class CheckBox extends React.Component<CheckBoxProps, CheckBoxSta
         renderFullWidth={inputProps.button}
         topAlign={topAlign}
       >
-        <BaseCheckBox {...restProps} id={id} hideLabel={hideLabel}>
+        <BaseCheckBox<T> {...restProps} id={id} hideLabel={hideLabel}>
           {children || (
             <>
               <Text bold>{fieldProps.label}</Text>

--- a/packages/core/src/components/CheckBox/index.tsx
+++ b/packages/core/src/components/CheckBox/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'uuid/v4';
 import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import BaseCheckBox, { BaseCheckBoxProps } from '../private/BaseCheckBox';
@@ -13,63 +13,39 @@ export type CheckBoxProps<T extends string> = BaseCheckBoxProps<T> &
     topAlign?: boolean;
   };
 
-export type CheckBoxState = {
-  id: string;
+/** A controlled checkbox field. */
+function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
+  const { children, fieldProps, inputProps } = partitionFieldProps<T, CheckBoxProps<T>>(props);
+  const { topAlign, ...restProps } = inputProps;
+  const [id] = useState(() => uuid());
+
+  return (
+    <FormField
+      {...fieldProps}
+      inline
+      renderBeforeLabel
+      renderLargeLabel
+      stretchLabel
+      id={props.id || id}
+      hideLabel={fieldProps.hideLabel || inputProps.button}
+      renderFullWidth={inputProps.button}
+      topAlign={topAlign}
+    >
+      <BaseCheckBox<T> {...restProps} id={props.id || id} hideLabel={fieldProps.hideLabel}>
+        {children || (
+          <>
+            <Text bold>{fieldProps.label}</Text>
+            {fieldProps.labelDescription && <Text>{fieldProps.labelDescription}</Text>}
+          </>
+        )}
+      </BaseCheckBox>
+    </FormField>
+  );
+}
+
+CheckBox.propTypes = {
+  checked: stateProp,
+  indeterminate: stateProp,
 };
 
-/** A controlled checkbox field. */
-export default class CheckBox<T extends string = string> extends React.Component<
-  CheckBoxProps<T>,
-  CheckBoxState
-> {
-  static defaultProps = {
-    button: false,
-    checked: false,
-    children: null,
-    indeterminate: false,
-    topAlign: false,
-    value: '1',
-  };
-
-  static propTypes = {
-    checked: stateProp,
-    indeterminate: stateProp,
-  };
-
-  state = {
-    // Support for CheckBoxController
-    id: this.props.id || uuid(),
-  };
-
-  render() {
-    const { children, fieldProps, inputProps } = partitionFieldProps<T, CheckBoxProps<T>>(
-      this.props,
-    );
-    const { topAlign, ...restProps } = inputProps;
-    const { id } = this.state;
-    const { hideLabel } = fieldProps;
-
-    return (
-      <FormField
-        {...fieldProps}
-        inline
-        renderBeforeLabel
-        renderLargeLabel
-        stretchLabel
-        id={id}
-        hideLabel={fieldProps.hideLabel || inputProps.button}
-        renderFullWidth={inputProps.button}
-        topAlign={topAlign}
-      >
-        <BaseCheckBox<T> {...restProps} id={id} hideLabel={hideLabel}>
-          {children || (
-            <>
-              <Text bold>{fieldProps.label}</Text>
-              {fieldProps.labelDescription && <Text>{fieldProps.labelDescription}</Text>}
-            </>
-          )}
-        </BaseCheckBox>
-      </FormField>
-    );
-  }
-}
+export default CheckBox;

--- a/packages/core/src/components/CheckBoxController/index.tsx
+++ b/packages/core/src/components/CheckBoxController/index.tsx
@@ -5,31 +5,33 @@ import proxyComponent from '../../utils/proxyComponent';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 import CheckBox, { CheckBoxProps } from '../CheckBox';
 
-export type PropsProvided = Partial<CheckBoxProps> & {
-  label: NonNullable<React.ReactNode>;
-  value: string;
+export type PropsProvided<T extends string> = Omit<
+  CheckBoxProps<T>,
+  'checked' | 'hideOptionalLabel' | 'id' | 'onChange' | 'value'
+> & {
+  value: T;
 };
 
-export type CheckBoxControllerProps = FormFieldProps & {
+export type CheckBoxControllerProps<T extends string> = FormFieldProps & {
   /** Function children in which CheckBox components can be rendered. */
-  children: (component: React.ComponentType<PropsProvided>, values: string[], id: string) => void;
+  children: (component: React.ComponentType<PropsProvided<T>>, values: T[], id: string) => void;
   /** Unique name of the field. */
   name: string;
   /** Callback that is triggered when a child CheckBox is clicked. */
-  onChange: (values: string[], event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (values: T[], event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Default checked values. */
-  value?: string[];
+  value?: T[];
 };
 
-export type CheckBoxControllerState = {
+export type CheckBoxControllerState<T extends string> = {
   id: string;
-  values: Set<string>;
+  values: Set<T>;
 };
 
 /** Manage multiple checkboxes with the same input `name`. */
-export default class CheckBoxController extends React.Component<
-  CheckBoxControllerProps,
-  CheckBoxControllerState
+export default class CheckBoxController<T extends string = string> extends React.Component<
+  CheckBoxControllerProps<T>,
+  CheckBoxControllerState<T>
 > {
   static defaultProps = {
     value: [],
@@ -40,7 +42,7 @@ export default class CheckBoxController extends React.Component<
     values: new Set(this.props.value),
   };
 
-  componentDidUpdate(prevProps: CheckBoxControllerProps) {
+  componentDidUpdate(prevProps: CheckBoxControllerProps<T>) {
     if (!shallowEqual(this.props.value, prevProps.value!)) {
       this.setState({
         values: new Set(this.props.value),
@@ -50,7 +52,7 @@ export default class CheckBoxController extends React.Component<
 
   private handleChange = (
     checked: boolean,
-    value: string,
+    value: T,
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     this.setState(
@@ -73,12 +75,12 @@ export default class CheckBoxController extends React.Component<
     );
   };
 
-  renderCheckBox = proxyComponent(CheckBox, ({ value, ...props }: PropsProvided) => {
-    const { inputProps } = partitionFieldProps(this.props);
+  renderCheckBox = proxyComponent<PropsProvided<T>>(CheckBox, ({ value, ...props }) => {
+    const { inputProps } = partitionFieldProps<T, CheckBoxControllerProps<T>>(this.props);
     const { id, values } = this.state;
 
     return (
-      <CheckBox
+      <CheckBox<T>
         compactSpacing
         {...props}
         {...inputProps}

--- a/packages/core/src/components/CheckBoxController/index.tsx
+++ b/packages/core/src/components/CheckBoxController/index.tsx
@@ -5,16 +5,20 @@ import proxyComponent from '../../utils/proxyComponent';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 import CheckBox, { CheckBoxProps } from '../CheckBox';
 
-export type PropsProvided<T extends string> = Omit<
-  CheckBoxProps<T>,
-  'checked' | 'hideOptionalLabel' | 'id' | 'onChange' | 'value'
+export type CheckBoxControlledProps<T extends string> = Partial<
+  Omit<CheckBoxProps<T>, 'label' | 'value'>
 > & {
+  label: NonNullable<React.ReactNode>;
   value: T;
 };
 
 export type CheckBoxControllerProps<T extends string> = FormFieldProps & {
   /** Function children in which CheckBox components can be rendered. */
-  children: (component: React.ComponentType<PropsProvided<T>>, values: T[], id: string) => void;
+  children: (
+    component: React.ComponentType<CheckBoxControlledProps<T>>,
+    values: T[],
+    id: string,
+  ) => void;
   /** Unique name of the field. */
   name: string;
   /** Callback that is triggered when a child CheckBox is clicked. */
@@ -75,7 +79,7 @@ export default class CheckBoxController<T extends string = string> extends React
     );
   };
 
-  renderCheckBox = proxyComponent<PropsProvided<T>>(CheckBox, ({ value, ...props }) => {
+  renderCheckBox = proxyComponent<CheckBoxControlledProps<T>>(CheckBox, ({ value, ...props }) => {
     const { inputProps } = partitionFieldProps<T, CheckBoxControllerProps<T>>(this.props);
     const { id, values } = this.state;
 
@@ -94,7 +98,7 @@ export default class CheckBoxController<T extends string = string> extends React
   });
 
   render() {
-    const { children, fieldProps } = partitionFieldProps(this.props);
+    const { children, fieldProps } = partitionFieldProps<T, CheckBoxControllerProps<T>>(this.props);
     const { id, values } = this.state;
 
     return (

--- a/packages/core/src/components/CheckBoxController/story.tsx
+++ b/packages/core/src/components/CheckBoxController/story.tsx
@@ -9,9 +9,11 @@ export default {
   },
 };
 
+type Value = 'red' | 'green' | 'blue';
+
 export function controlsMultipleCheckboxes() {
   return (
-    <CheckBoxController
+    <CheckBoxController<Value>
       optional
       label="Favorite colors?"
       name="color"
@@ -35,7 +37,7 @@ controlsMultipleCheckboxes.story = {
 
 export function handlesInvalidStateWithNoSpacing() {
   return (
-    <CheckBoxController
+    <CheckBoxController<Value>
       invalid
       label="Favorite colors?"
       name="color"
@@ -59,7 +61,7 @@ handlesInvalidStateWithNoSpacing.story = {
 
 export function handlesDisabledStateWithNoSpacing() {
   return (
-    <CheckBoxController
+    <CheckBoxController<Value>
       disabled
       label="Favorite colors?"
       name="color"
@@ -83,7 +85,7 @@ handlesDisabledStateWithNoSpacing.story = {
 
 export function asSmall() {
   return (
-    <CheckBoxController
+    <CheckBoxController<Value>
       optional
       small
       label="Favorite colors?"
@@ -108,7 +110,7 @@ asSmall.story = {
 
 export function asLarge() {
   return (
-    <CheckBoxController
+    <CheckBoxController<Value>
       optional
       large
       label="Favorite colors?"

--- a/packages/core/src/components/FormField/partitionFieldProps.ts
+++ b/packages/core/src/components/FormField/partitionFieldProps.ts
@@ -1,8 +1,6 @@
 import { FormFieldProps } from '.';
 
-export type MaybeChildren = { children?: unknown };
-
-export type ExplicitProps = {
+export type ExplicitProps<T extends string> = {
   compact: boolean;
   disabled: boolean;
   hasPrefix: boolean;
@@ -11,10 +9,10 @@ export type ExplicitProps = {
   large: boolean;
   optional: boolean;
   small: boolean;
-  value: string;
+  value: T;
 };
 
-export default function partitionFieldProps<Props extends MaybeChildren = {}>(
+export default function partitionFieldProps<T extends string, Props extends object = {}>(
   props: FormFieldProps & Props,
 ): {
   // Need any for consumers to work correctly
@@ -22,9 +20,10 @@ export default function partitionFieldProps<Props extends MaybeChildren = {}>(
   children: any;
   field: object;
   fieldProps: FormFieldProps;
-  inputProps: Omit<Props, 'children'> & ExplicitProps;
+  inputProps: Omit<Props, 'children' | keyof ExplicitProps<T>> & ExplicitProps<T>;
 } {
   const {
+    // @ts-ignore
     children,
     compactSpacing = false,
     disabled = false,

--- a/packages/core/src/components/Input/index.tsx
+++ b/packages/core/src/components/Input/index.tsx
@@ -1,36 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'uuid/v4';
 import BaseInput, { BaseInputProps } from '../private/BaseInput';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 
 export type InputProps = Omit<BaseInputProps, 'id'> & FormFieldProps;
 
-export type InputState = {
-  id: string;
-};
-
 /** A controlled input field. */
-export default class Input extends React.Component<InputProps, InputState> {
-  static defaultProps = {
-    type: 'text',
-  };
+export default function Input(props: InputProps) {
+  const { fieldProps, inputProps } = partitionFieldProps(props);
+  const [id] = useState(() => uuid());
 
-  state = {
-    id: uuid(),
-  };
-
-  render() {
-    const { fieldProps, inputProps } = partitionFieldProps(this.props);
-    const { id } = this.state;
-
-    if (inputProps.type === 'hidden') {
-      return <BaseInput {...inputProps} hidden optional id={id} />;
-    }
-
-    return (
-      <FormField {...fieldProps} id={id}>
-        <BaseInput {...inputProps} id={id} />
-      </FormField>
-    );
+  if (inputProps.type === 'hidden') {
+    return <BaseInput {...inputProps} hidden optional id={id} />;
   }
+
+  return (
+    <FormField {...fieldProps} id={id}>
+      <BaseInput type="text" {...inputProps} id={id} />
+    </FormField>
+  );
 }

--- a/packages/core/src/components/RadioButton/index.tsx
+++ b/packages/core/src/components/RadioButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'uuid/v4';
 import { mutuallyExclusiveTrueProps } from 'airbnb-prop-types';
 import BaseRadioButton, { BaseRadioButtonProps } from '../private/BaseRadioButton';
@@ -7,7 +7,7 @@ import Text from '../Text';
 
 const stateProp = mutuallyExclusiveTrueProps('checked', 'indeterminate');
 
-export type RadioButtonProps = Omit<BaseRadioButtonProps, 'value'> &
+export type RadioButtonProps<T extends string> = Omit<BaseRadioButtonProps<T>, 'value'> &
   FormFieldProps & {
     /** Top align content. */
     topAlign?: boolean;
@@ -15,57 +15,39 @@ export type RadioButtonProps = Omit<BaseRadioButtonProps, 'value'> &
     value: string;
   };
 
-export type RadioButtonState = {
-  id: string;
+/** A controlled radio button field. */
+function RadioButton<T extends string = string>(props: RadioButtonProps<T>) {
+  const { children, fieldProps, inputProps } = partitionFieldProps<T, RadioButtonProps<T>>(props);
+  const { topAlign, ...restProps } = inputProps;
+  const [id] = useState(() => uuid());
+
+  return (
+    <FormField
+      {...fieldProps}
+      inline
+      renderBeforeLabel
+      renderLargeLabel
+      stretchLabel
+      id={props.id || id}
+      hideLabel={fieldProps.hideLabel || inputProps.button}
+      renderFullWidth={inputProps.button}
+      topAlign={topAlign}
+    >
+      <BaseRadioButton {...restProps} id={props.id || id} hideLabel={fieldProps.hideLabel}>
+        {children || (
+          <>
+            <Text bold>{fieldProps.label}</Text>
+            {fieldProps.labelDescription && <Text>{fieldProps.labelDescription}</Text>}
+          </>
+        )}
+      </BaseRadioButton>
+    </FormField>
+  );
+}
+
+RadioButton.propTypes = {
+  checked: stateProp,
+  indeterminate: stateProp,
 };
 
-/** A controlled radio button field. */
-export default class RadioButton extends React.Component<RadioButtonProps, RadioButtonState> {
-  static defaultProps = {
-    button: false,
-    checked: false,
-    children: null,
-    indeterminate: false,
-    topAlign: false,
-  };
-
-  static propTypes = {
-    checked: stateProp,
-    indeterminate: stateProp,
-  };
-
-  state = {
-    // Support for RadioButtonController
-    id: this.props.id || uuid(),
-  };
-
-  render() {
-    const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
-    const { topAlign, ...restProps } = inputProps;
-    const { id } = this.state;
-    const { hideLabel } = fieldProps;
-
-    return (
-      <FormField
-        {...fieldProps}
-        inline
-        renderBeforeLabel
-        renderLargeLabel
-        stretchLabel
-        id={id}
-        hideLabel={fieldProps.hideLabel || inputProps.button}
-        renderFullWidth={inputProps.button}
-        topAlign={topAlign}
-      >
-        <BaseRadioButton {...restProps} id={id} hideLabel={hideLabel}>
-          {children || (
-            <>
-              <Text bold>{fieldProps.label}</Text>
-              {fieldProps.labelDescription && <Text>{fieldProps.labelDescription}</Text>}
-            </>
-          )}
-        </BaseRadioButton>
-      </FormField>
-    );
-  }
-}
+export default RadioButton;

--- a/packages/core/src/components/RadioButtonController/index.tsx
+++ b/packages/core/src/components/RadioButtonController/index.tsx
@@ -4,31 +4,37 @@ import proxyComponent from '../../utils/proxyComponent';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 import RadioButton, { RadioButtonProps } from '../RadioButton';
 
-export type PropsProvided = Partial<RadioButtonProps> & {
+export type RadioButtonControlledProps<T extends string> = Partial<
+  Omit<RadioButtonProps<T>, 'label' | 'value'>
+> & {
   label: NonNullable<React.ReactNode>;
-  value: string;
+  value: T;
 };
 
-export type RadioButtonControllerProps = FormFieldProps & {
+export type RadioButtonControllerProps<T extends string> = FormFieldProps & {
   /** Function children in which RadioButton components can be rendered. */
-  children: (component: React.ComponentType<PropsProvided>, value: string, id: string) => void;
+  children: (
+    component: React.ComponentType<RadioButtonControlledProps<T>>,
+    value: T,
+    id: string,
+  ) => void;
   /** Unique name of the field. */
   name: string;
   /** Callback that is triggered when a child RadioButton is clicked. */
-  onChange: (value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (value: T, event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Default checked value. */
-  value?: string;
+  value?: T;
 };
 
-export type RadioButtonControllerState = {
+export type RadioButtonControllerState<T extends string> = {
   id: string;
-  value: string;
+  value: T;
 };
 
 /** Manage multiple radio buttons with the same input `name`. */
-export default class RadioButtonController extends React.Component<
-  RadioButtonControllerProps,
-  RadioButtonControllerState
+export default class RadioButtonController<T extends string = string> extends React.Component<
+  RadioButtonControllerProps<T>,
+  RadioButtonControllerState<T>
 > {
   static defaultProps = {
     value: '',
@@ -36,20 +42,20 @@ export default class RadioButtonController extends React.Component<
 
   state = {
     id: uuid(),
-    value: this.props.value || '',
+    value: this.props.value || ('' as T),
   };
 
-  componentDidUpdate(prevProps: RadioButtonControllerProps) {
+  componentDidUpdate(prevProps: RadioButtonControllerProps<T>) {
     if (this.props.value !== prevProps.value) {
       this.setState({
-        value: this.props.value || '',
+        value: this.props.value || ('' as T),
       });
     }
   }
 
   private handleChange = (
     checked: boolean,
-    value: string,
+    value: T,
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     if (value !== this.state.value) {
@@ -61,26 +67,31 @@ export default class RadioButtonController extends React.Component<
     }
   };
 
-  renderRadioButton = proxyComponent(RadioButton, ({ value, ...props }: PropsProvided) => {
-    const { inputProps } = partitionFieldProps(this.props);
-    const { id, value: currentValue } = this.state;
+  renderRadioButton = proxyComponent<RadioButtonControlledProps<T>>(
+    RadioButton,
+    ({ value, ...props }) => {
+      const { inputProps } = partitionFieldProps<T, RadioButtonControllerProps<T>>(this.props);
+      const { id, value: currentValue } = this.state;
 
-    return (
-      <RadioButton
-        compactSpacing
-        {...props}
-        {...inputProps}
-        hideOptionalLabel
-        id={`${id}-${value}`}
-        value={value}
-        checked={value === currentValue}
-        onChange={this.handleChange}
-      />
-    );
-  });
+      return (
+        <RadioButton<T>
+          compactSpacing
+          {...props}
+          {...inputProps}
+          hideOptionalLabel
+          id={`${id}-${value}`}
+          value={value}
+          checked={value === currentValue}
+          onChange={this.handleChange}
+        />
+      );
+    },
+  );
 
   render() {
-    const { children, fieldProps } = partitionFieldProps(this.props);
+    const { children, fieldProps } = partitionFieldProps<T, RadioButtonControllerProps<T>>(
+      this.props,
+    );
     const { id, value } = this.state;
 
     return (

--- a/packages/core/src/components/Select/index.tsx
+++ b/packages/core/src/components/Select/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { childrenOfType } from 'airbnb-prop-types';
 import uuid from 'uuid/v4';
 import BaseSelect, { BaseSelectProps } from '../private/BaseSelect';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 
-export type SelectProps = Omit<BaseSelectProps, 'id'> &
+export type SelectProps<T extends string> = Omit<BaseSelectProps<T>, 'id'> &
   FormFieldProps & {
     /** Dropdown options. Supports `option` and `optgroup`. */
     children: NonNullable<React.ReactNode>;
@@ -12,34 +12,22 @@ export type SelectProps = Omit<BaseSelectProps, 'id'> &
     placeholder?: string;
   };
 
-export type SelectState = {
-  id: string;
+/** A controlled select field. */
+function Select<T extends string = string>(props: SelectProps<T>) {
+  const { children, fieldProps, inputProps } = partitionFieldProps<T, SelectProps<T>>(props);
+  const [id] = useState(() => uuid());
+
+  return (
+    <FormField {...fieldProps} id={id}>
+      <BaseSelect<T> {...inputProps} id={id}>
+        {children}
+      </BaseSelect>
+    </FormField>
+  );
+}
+
+Select.propTypes = {
+  children: childrenOfType('option', 'optgroup').isRequired,
 };
 
-/** A controlled select field. */
-export default class Select extends React.Component<SelectProps, SelectState> {
-  static propTypes = {
-    children: childrenOfType('option', 'optgroup').isRequired,
-  };
-
-  static defaultProps = {
-    placeholder: '',
-  };
-
-  state = {
-    id: uuid(),
-  };
-
-  render() {
-    const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
-    const { id } = this.state;
-
-    return (
-      <FormField {...fieldProps} id={id}>
-        <BaseSelect {...inputProps} id={id}>
-          {children}
-        </BaseSelect>
-      </FormField>
-    );
-  }
-}
+export default Select;

--- a/packages/core/src/components/Select/index.tsx
+++ b/packages/core/src/components/Select/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { childrenOfType } from 'airbnb-prop-types';
 import uuid from 'uuid/v4';
 import BaseSelect, { BaseSelectProps } from '../private/BaseSelect';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
@@ -13,7 +12,7 @@ export type SelectProps<T extends string> = Omit<BaseSelectProps<T>, 'id'> &
   };
 
 /** A controlled select field. */
-function Select<T extends string = string>(props: SelectProps<T>) {
+export default function Select<T extends string = string>(props: SelectProps<T>) {
   const { children, fieldProps, inputProps } = partitionFieldProps<T, SelectProps<T>>(props);
   const [id] = useState(() => uuid());
 
@@ -25,9 +24,3 @@ function Select<T extends string = string>(props: SelectProps<T>) {
     </FormField>
   );
 }
-
-Select.propTypes = {
-  children: childrenOfType('option', 'optgroup').isRequired,
-};
-
-export default Select;

--- a/packages/core/src/components/SteppedProgressBar/index.tsx
+++ b/packages/core/src/components/SteppedProgressBar/index.tsx
@@ -14,7 +14,6 @@ export type SteppedProgressBarProps = {
 /** A progress bar separated into individual steps. */
 function SteppedProgressBar({ children, styleSheet }: SteppedProgressBarProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetBar);
-
   const steps = React.Children.count(children);
 
   return (

--- a/packages/core/src/components/Switch/index.tsx
+++ b/packages/core/src/components/Switch/index.tsx
@@ -1,32 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'uuid/v4';
 import BaseSwitch, { BaseSwitchProps } from '../private/BaseSwitch';
 import FormField, { FormFieldProps, partitionFieldProps } from '../FormField';
 
-export type SwitchProps = Omit<BaseSwitchProps, 'id'> & FormFieldProps;
-
-export type SwitchState = {
-  id: string;
-};
+export type SwitchProps<T extends string> = Omit<BaseSwitchProps<T>, 'id'> & FormFieldProps;
 
 /** A controlled switch (fancy checkbox) field. */
-export default class Switch extends React.Component<SwitchProps, SwitchState> {
-  static defaultProps = {
-    checked: false,
-  };
+export default function Switch<T extends string = string>(props: SwitchProps<T>) {
+  const { fieldProps, inputProps } = partitionFieldProps<T, SwitchProps<T>>(props);
+  const [id] = useState(() => uuid());
 
-  state = {
-    id: uuid(),
-  };
-
-  render() {
-    const { fieldProps, inputProps } = partitionFieldProps(this.props);
-    const { id } = this.state;
-
-    return (
-      <FormField {...fieldProps} inline stretchLabel id={id}>
-        <BaseSwitch value="1" {...inputProps} id={id} />
-      </FormField>
-    );
-  }
+  return (
+    <FormField {...fieldProps} inline stretchLabel id={id}>
+      <BaseSwitch<T> value="1" {...inputProps} id={id} />
+    </FormField>
+  );
 }

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -6,17 +6,20 @@ import TrackingBoundary from '../TrackingBoundary';
 import { styleSheetTab } from './styles';
 import useStyles, { StyleSheet } from '../../hooks/useStyles';
 
-export type TabProps = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'disabled' | 'href'> & {
+export type TabProps<T extends string> = Pick<
+  ButtonOrLinkProps,
+  'afterIcon' | 'beforeIcon' | 'disabled' | 'href'
+> & {
   /** Hide bottom border of Tab when unselected. */
   borderless?: boolean;
   /** Content to render if the tab is selected. */
   children?: React.ReactNode;
   /** @ignore Unique key name for this tab. */
-  keyName?: string;
+  keyName?: T;
   /** Text to render in the tab. */
   label: NonNullable<React.ReactNode>;
   /** @ignore Callback fired when the tab is clicked. */
-  onClick?: (key: string) => void;
+  onClick?: (key: T) => void;
   /** Callback fired when the tab is selected. */
   onSelected?: () => void;
   /** Secondary tab style, implies borderless. */
@@ -32,7 +35,7 @@ export type TabProps = Pick<ButtonOrLinkProps, 'afterIcon' | 'beforeIcon' | 'dis
 };
 
 /** A single tab button. Usually rendered amongst a collection of tabs. */
-export default function Tab({
+export default function Tab<T extends string = string>({
   afterIcon,
   beforeIcon,
   borderless,
@@ -47,7 +50,7 @@ export default function Tab({
   onClick,
   onSelected,
   styleSheet,
-}: TabProps) {
+}: TabProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetTab);
   const trackingName = upperFirst(camelCase(keyName ?? 'Tab'));
   const noBorder = secondary || borderless;

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 import React, { useState, useEffect, useCallback } from 'react';
-import withBoundary from '../../composers/withBoundary';
+import withBoundary, { WithBoundaryWrapperProps } from '../../composers/withBoundary';
 import GradientScroller from '../GradientScroller';
 import Tab, { TabProps } from './Tab';
 import { styleSheetTabs } from './styles';
@@ -8,15 +8,15 @@ import useStyles, { StyleSheet } from '../../hooks/useStyles';
 
 export { Tab };
 
-export type TabsProps = {
+export type TabsProps<T extends string> = {
   /** Hide bottom border of Tabs. */
   borderless?: boolean;
   /** Tabs and their content. */
   children: NonNullable<React.ReactNode>;
   /** Key of tab selected by default. */
-  defaultKey?: string;
+  defaultKey?: T;
   /** Callback fired when a tab changes. */
-  onChange?: (key: string) => void;
+  onChange?: (key: T) => void;
   /** Persist the selected tab through the defined URL hash. */
   persistWithHash?: string;
   /** Secondary tab style, implies borderless. */
@@ -38,7 +38,7 @@ function getHashQuery(): URLSearchParams {
 }
 
 /** A controller for multiple tabs. */
-function Tabs({
+function Tabs<T extends string = string>({
   borderless,
   children,
   secondary,
@@ -48,7 +48,7 @@ function Tabs({
   defaultKey,
   onChange,
   styleSheet,
-}: TabsProps) {
+}: TabsProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetTabs);
   const [selectedKey, setSelectedKey] = useState(
     () => (persistWithHash && getHashQuery().get(persistWithHash)) || defaultKey || '',
@@ -67,7 +67,7 @@ function Tabs({
     }
   }, [persistWithHash]);
 
-  const handleClick = (key: string) => {
+  const handleClick = (key: T) => {
     setSelectedKey(key);
 
     if (onChange) {
@@ -114,9 +114,9 @@ function Tabs({
           content = props.children;
         }
 
-        return React.cloneElement(child as React.ReactElement<TabProps>, {
+        return React.cloneElement(child as React.ReactElement<TabProps<T>>, {
           borderless,
-          keyName: String(key),
+          keyName: String(key) as T,
           secondary,
           selected,
           stretched,
@@ -145,4 +145,9 @@ function Tabs({
   );
 }
 
-export default withBoundary('Tabs')(Tabs);
+// Required to pass generics around HOCs
+const BoundaryTabs = withBoundary('Tabs')(Tabs) as <T extends string = string>(
+  props: TabsProps<T> & WithBoundaryWrapperProps,
+) => React.ReactElement<TabsProps<T>>;
+
+export default BoundaryTabs;

--- a/packages/core/src/components/TextArea/index.tsx
+++ b/packages/core/src/components/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import uuid from 'uuid/v4';
 import PropTypes from 'prop-types';
 import { requiredBy } from 'airbnb-prop-types';
@@ -21,58 +21,42 @@ export type TextAreaProps = Omit<BaseTextAreaProps, 'id'> &
     proofreadProps?: ExtraProofreadProps;
   };
 
-export type TextAreaState = {
-  id: string;
+/** A controlled textarea field. */
+function TextArea(props: TextAreaProps) {
+  const { fieldProps, inputProps } = partitionFieldProps(props);
+  const { locale, name, proofread, proofreadProps, onCheckText, ...textareaProps } = inputProps;
+  const [id] = useState(() => uuid());
+  const description =
+    fieldProps.labelDescription ||
+    (inputProps.maxLength && (
+      <T
+        k="lunar.form.charsUsed"
+        phrase="%{current}/%{max} characters used"
+        current={inputProps.value!.length.toLocaleString()}
+        max={inputProps.maxLength.toLocaleString()}
+      />
+    ));
+
+  return (
+    <FormField {...fieldProps} id={id} labelDescription={description}>
+      {proofread && onCheckText ? (
+        <Proofreader
+          {...textareaProps}
+          {...proofreadProps}
+          id={id}
+          locale={locale}
+          name={name!}
+          onCheckText={onCheckText}
+        />
+      ) : (
+        <BaseTextArea {...textareaProps} id={id} name={name} />
+      )}
+    </FormField>
+  );
+}
+
+TextArea.propTypes = {
+  onCheckText: requiredBy('proofread', PropTypes.func),
 };
 
-/** A controlled textarea field. */
-export default class TextArea extends React.Component<TextAreaProps, TextAreaState> {
-  static propTypes = {
-    onCheckText: requiredBy('proofread', PropTypes.func),
-  };
-
-  static defaultProps = {
-    locale: 'none',
-    noTranslate: false,
-    proofread: false,
-    proofreadProps: undefined,
-    value: '',
-  };
-
-  state = {
-    id: uuid(),
-  };
-
-  render() {
-    const { fieldProps, inputProps } = partitionFieldProps(this.props);
-    const { locale, name, proofread, proofreadProps, onCheckText, ...textareaProps } = inputProps;
-    const { id } = this.state;
-    const description =
-      fieldProps.labelDescription ||
-      (inputProps.maxLength && (
-        <T
-          k="lunar.form.charsUsed"
-          phrase="%{current}/%{max} characters used"
-          current={inputProps.value!.length.toLocaleString()}
-          max={inputProps.maxLength.toLocaleString()}
-        />
-      ));
-
-    return (
-      <FormField {...fieldProps} id={id} labelDescription={description}>
-        {proofread && onCheckText ? (
-          <Proofreader
-            {...textareaProps}
-            {...proofreadProps}
-            id={id}
-            locale={locale}
-            name={name!}
-            onCheckText={onCheckText}
-          />
-        ) : (
-          <BaseTextArea {...textareaProps} id={id} name={name} />
-        )}
-      </FormField>
-    );
-  }
-}
+export default TextArea;

--- a/packages/core/src/components/ToggleButtonController/index.tsx
+++ b/packages/core/src/components/ToggleButtonController/index.tsx
@@ -9,31 +9,35 @@ import { ButtonOrLinkTypes } from '../private/ButtonOrLink';
 
 export { ButtonGroup };
 
-export type PropsProvided = Partial<ButtonProps> & {
+export type ToggleButtonControlledProps<T extends string> = Partial<ButtonProps> & {
   children: NonNullable<React.ReactNode>;
-  value: string;
+  value: T;
 };
 
-export type ToggleButtonControllerProps = FormFieldProps & {
+export type ToggleButtonControllerProps<T extends string> = FormFieldProps & {
   /** Function children in which Button components can be rendered. */
-  children: (component: React.ComponentType<PropsProvided>, value: string, id: string) => void;
+  children: (
+    component: React.ComponentType<ToggleButtonControlledProps<T>>,
+    value: T,
+    id: string,
+  ) => void;
   /** Unique name of the field. */
   name: string;
   /** Callback that is triggered when a child Button is clicked. */
-  onChange: (value: string, event: React.MouseEvent<HTMLButtonElement>) => void;
+  onChange: (value: T, event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Default value. */
-  value?: string;
+  value?: T;
 };
 
-export type ToggleButtonControllerState = {
+export type ToggleButtonControllerState<T extends string> = {
   id: string;
-  value: string;
+  value: T;
 };
 
 /** Manage a group of buttons with the same input `name`. */
-export default class ToggleButtonController extends React.Component<
-  ToggleButtonControllerProps,
-  ToggleButtonControllerState
+export default class ToggleButtonController<T extends string = string> extends React.Component<
+  ToggleButtonControllerProps<T>,
+  ToggleButtonControllerState<T>
 > {
   static defaultProps = {
     value: '',
@@ -41,19 +45,19 @@ export default class ToggleButtonController extends React.Component<
 
   state = {
     id: uuid(),
-    value: this.props.value || '',
+    value: this.props.value || ('' as T),
   };
 
-  componentDidUpdate(prevProps: ToggleButtonControllerProps) {
+  componentDidUpdate(prevProps: ToggleButtonControllerProps<T>) {
     if (this.props.value !== prevProps.value) {
       this.setState({
-        value: this.props.value || '',
+        value: this.props.value || ('' as T),
       });
     }
   }
 
   private handleClick = (event: React.MouseEvent<ButtonOrLinkTypes>) => {
-    const newValue = event.currentTarget.dataset.value!;
+    const newValue = event.currentTarget.dataset.value! as T;
     const { value } = this.state;
 
     if (newValue === value) {
@@ -67,31 +71,36 @@ export default class ToggleButtonController extends React.Component<
     });
   };
 
-  renderButton = proxyComponent(BaseButton, ({ children, value, ...props }: PropsProvided) => {
-    const { small, disabled, invalid, large } = this.props;
-    const { id, value: selectedValue } = this.state;
-    const selected = value === selectedValue;
+  renderButton = proxyComponent<ToggleButtonControlledProps<T>>(
+    BaseButton,
+    ({ children, value, ...props }) => {
+      const { small, disabled, invalid, large } = this.props;
+      const { id, value: selectedValue } = this.state;
+      const selected = value === selectedValue;
 
-    return (
-      <FormInputButton
-        {...props}
-        data-value={value}
-        id={`${id}-${value}`}
-        name={name}
-        disabled={disabled}
-        inverted={!selected}
-        invalid={invalid}
-        small={small}
-        large={large}
-        onClick={this.handleClick}
-      >
-        {children}
-      </FormInputButton>
-    );
-  });
+      return (
+        <FormInputButton
+          {...props}
+          data-value={value}
+          id={`${id}-${value}`}
+          name={name}
+          disabled={disabled}
+          inverted={!selected}
+          invalid={invalid}
+          small={small}
+          large={large}
+          onClick={this.handleClick}
+        >
+          {children}
+        </FormInputButton>
+      );
+    },
+  );
 
   render() {
-    const { children, fieldProps } = partitionFieldProps(this.props);
+    const { children, fieldProps } = partitionFieldProps<T, ToggleButtonControllerProps<T>>(
+      this.props,
+    );
     const { id, value } = this.state;
 
     return (

--- a/packages/core/src/components/ToggleButtonController/story.tsx
+++ b/packages/core/src/components/ToggleButtonController/story.tsx
@@ -10,9 +10,11 @@ export default {
   },
 };
 
+type Value = 'red' | 'green' | 'blue';
+
 export function aListOfSingleSelectToggleButtons() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       value="red"
       name="button-group-controller"
       label="Favorite color?"
@@ -41,7 +43,7 @@ aListOfSingleSelectToggleButtons.story = {
 
 export function handlesInvalidState() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       invalid
       value="red"
       name="button-group-controller"
@@ -71,7 +73,7 @@ handlesInvalidState.story = {
 
 export function handlesDisabledState() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       disabled
       value="red"
       name="button-group-controller"
@@ -101,7 +103,7 @@ handlesDisabledState.story = {
 
 export function asSmall() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       small
       value="red"
       name="button-group-controller"
@@ -131,7 +133,7 @@ asSmall.story = {
 
 export function asLarge() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       large
       value="red"
       name="button-group-controller"
@@ -161,7 +163,7 @@ asLarge.story = {
 
 export function withInline() {
   return (
-    <ToggleButtonController
+    <ToggleButtonController<Value>
       inline
       value="red"
       name="button-group-controller"

--- a/packages/core/src/components/private/BaseCheckBox.tsx
+++ b/packages/core/src/components/private/BaseCheckBox.tsx
@@ -66,7 +66,7 @@ export const styleSheetCheckbox: StyleSheet = theme => {
   };
 };
 
-export type BaseCheckBoxProps = InputProps & {
+export type BaseCheckBoxProps<T extends string> = InputProps<T> & {
   /** Render the field as a large clickable button. */
   button?: boolean;
   /** Content to display when in button mode. Defaults to the current label bolded followed by the label description. */
@@ -74,14 +74,14 @@ export type BaseCheckBoxProps = InputProps & {
   /** Hide the native checkbox label. */
   hideLabel?: boolean;
   /** Callback fired when the value changes. */
-  onChange: (checked: boolean, value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (checked: boolean, value: T, event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Mark the checkbox as greyed out with a dash to indicate an indeterminate state. */
   indeterminate?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
 
-export default function BaseCheckBox({
+export default function BaseCheckBox<T extends string = string>({
   button,
   checked,
   children,
@@ -94,11 +94,11 @@ export default function BaseCheckBox({
   onChange,
   styleSheet,
   ...restProps
-}: BaseCheckBoxProps) {
+}: BaseCheckBoxProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetCheckbox);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(event.currentTarget.checked, event.currentTarget.value, event);
+    onChange(event.currentTarget.checked, event.currentTarget.value as T, event);
   };
 
   const checkbox = (

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -83,7 +83,7 @@ export type BaseRadioButtonProps<T extends string> = InputProps<T> & {
   styleSheet?: StyleSheet;
 };
 
-export default function BaseRadioButton<T extends string>({
+export default function BaseRadioButton<T extends string = string>({
   button,
   checked,
   children,

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -68,7 +68,7 @@ export const styleSheetRadioButton: StyleSheet = theme => {
   };
 };
 
-export type BaseRadioButtonProps = InputProps & {
+export type BaseRadioButtonProps<T extends string> = InputProps<T> & {
   /** Render the field as a large clickable button. */
   button?: boolean;
   /** Content to display when in button mode. Defaults to the current label bolded followed by the label description. */
@@ -76,14 +76,14 @@ export type BaseRadioButtonProps = InputProps & {
   /** Hide the native radio button label. */
   hideLabel?: boolean;
   /** Callback fired when the value changes. */
-  onChange: (checked: boolean, value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (checked: boolean, value: T, event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Mark the checkbox as greyed out with a dash to indicate an indeterminate state. */
   indeterminate?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
 
-export default function BaseRadioButton({
+export default function BaseRadioButton<T extends string>({
   button,
   checked,
   children,
@@ -96,11 +96,11 @@ export default function BaseRadioButton({
   onChange,
   styleSheet,
   ...restProps
-}: BaseRadioButtonProps) {
+}: BaseRadioButtonProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetRadioButton);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(event.currentTarget.checked, event.currentTarget.value, event);
+    onChange(event.currentTarget.checked, event.currentTarget.value as T, event);
   };
 
   const radioButton = (

--- a/packages/core/src/components/private/BaseSelect.tsx
+++ b/packages/core/src/components/private/BaseSelect.tsx
@@ -36,28 +36,28 @@ export const styleSheetSelect: StyleSheet = ({ pattern, unit }) => ({
   },
 });
 
-export type BaseSelectProps = SelectProps & {
+export type BaseSelectProps<T extends string> = SelectProps<T> & {
   /** List of `option`s to render. */
   children: NonNullable<React.ReactNode>;
   /** An empty `option` to render at the top of the list. */
   placeholder?: string;
   /** Callback fired when the value changes. */
-  onChange: (value: string, event: React.ChangeEvent<HTMLSelectElement>) => void;
+  onChange: (value: T, event: React.ChangeEvent<HTMLSelectElement>) => void;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
 
-export default function BaseSelect({
+export default function BaseSelect<T extends string = string>({
   children,
   placeholder = '',
   onChange,
   styleSheet,
   ...restProps
-}: BaseSelectProps) {
+}: BaseSelectProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetSelect);
 
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange(event.currentTarget.value, event);
+    onChange(event.currentTarget.value as T, event);
   };
 
   return (

--- a/packages/core/src/components/private/BaseSwitch.tsx
+++ b/packages/core/src/components/private/BaseSwitch.tsx
@@ -80,18 +80,18 @@ export const styleSheetSwitch: StyleSheet = theme => {
   };
 };
 
-export type BaseSwitchProps = InputProps & {
+export type BaseSwitchProps<T extends string> = InputProps<T> & {
   /** Whether the switch is checked. */
   checked?: boolean;
   /** Unique identifier. */
   id: string;
   /** Callback fired when the value changes. */
-  onChange: (checked: boolean, value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (checked: boolean, value: T, event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
 
-export default function BaseSwitch({
+export default function BaseSwitch<T extends string = string>({
   checked,
   disabled,
   id,
@@ -99,11 +99,11 @@ export default function BaseSwitch({
   onChange,
   styleSheet,
   ...restProps
-}: BaseSwitchProps) {
+}: BaseSwitchProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetSwitch);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(event.currentTarget.checked, event.currentTarget.value, event);
+    onChange(event.currentTarget.checked, event.currentTarget.value as T, event);
   };
 
   return (

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -26,7 +26,7 @@ export type IgnoreAttributes =
   | 'results'
   | 'security';
 
-export type FormInputProps<T extends string, R = unknown> = {
+export type FormInputProps<T extends string = string, R = unknown> = {
   /** Mark the field as important. */
   important?: boolean;
   /** Mark the field as invalid. */
@@ -47,19 +47,19 @@ export type FormInputProps<T extends string, R = unknown> = {
   styleSheet?: StyleSheet;
 };
 
-export type InputProps<T extends string> = Omit<
+export type InputProps<T extends string = string> = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   IgnoreAttributes
 > &
   FormInputProps<T, HTMLInputElement>;
 
-export type SelectProps<T extends string> = Omit<
+export type SelectProps<T extends string = string> = Omit<
   React.SelectHTMLAttributes<HTMLSelectElement>,
   IgnoreAttributes
 > &
   FormInputProps<T, HTMLSelectElement>;
 
-export type TextAreaProps<T extends string> = Omit<
+export type TextAreaProps<T extends string = string> = Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   IgnoreAttributes
 > &

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -26,7 +26,7 @@ export type IgnoreAttributes =
   | 'results'
   | 'security';
 
-export type FormInputProps<T = unknown> = {
+export type FormInputProps<T extends string, R = unknown> = {
   /** Mark the field as important. */
   important?: boolean;
   /** Mark the field as invalid. */
@@ -38,28 +38,34 @@ export type FormInputProps<T = unknown> = {
   /** Mark the field as optional. */
   optional?: boolean;
   /** Reference to access the underlying input DOM element. */
-  propagateRef?: React.Ref<T>;
+  propagateRef?: React.Ref<R>;
   /** Decrease font size and padding to small. */
   small?: boolean;
   /** Current value. */
-  value?: string;
+  value?: T;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
 
-export type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, IgnoreAttributes> &
-  FormInputProps<HTMLInputElement>;
+export type InputProps<T extends string> = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  IgnoreAttributes
+> &
+  FormInputProps<T, HTMLInputElement>;
 
-export type SelectProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, IgnoreAttributes> &
-  FormInputProps<HTMLSelectElement>;
+export type SelectProps<T extends string> = Omit<
+  React.SelectHTMLAttributes<HTMLSelectElement>,
+  IgnoreAttributes
+> &
+  FormInputProps<T, HTMLSelectElement>;
 
-export type TextAreaProps = Omit<
+export type TextAreaProps<T extends string> = Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   IgnoreAttributes
 > &
-  FormInputProps<HTMLTextAreaElement>;
+  FormInputProps<T, HTMLTextAreaElement>;
 
-export type PrivateProps = FormInputProps & {
+export type PrivateProps<T extends string> = FormInputProps<T> & {
   // Support everything for convenience
   [key: string]: unknown;
   /** @ignore */
@@ -74,7 +80,7 @@ export type PrivateProps = FormInputProps & {
   styleSheet?: StyleSheet;
 };
 
-function FormInput({
+function FormInput<T extends string = string>({
   children,
   disabled,
   hasPrefix,
@@ -91,7 +97,7 @@ function FormInput({
   tagName: Tag,
   styleSheet,
   ...restProps
-}: PrivateProps) {
+}: PrivateProps<T>) {
   const [styles, cx] = useStyles(styleSheet ?? inputStyleSheet);
   const isSelect = Tag === 'select';
 
@@ -144,4 +150,6 @@ FormInput.propTypes = {
 };
 
 // Proofreader crashes in non-latin languages unless this component is memoized
-export default React.memo(FormInput);
+const MemoFormInput = React.memo(FormInput);
+
+export default MemoFormInput;

--- a/packages/core/src/components/private/FormInput.tsx
+++ b/packages/core/src/components/private/FormInput.tsx
@@ -150,6 +150,4 @@ FormInput.propTypes = {
 };
 
 // Proofreader crashes in non-latin languages unless this component is memoized
-const MemoFormInput = React.memo(FormInput);
-
-export default MemoFormInput;
+export default React.memo(FormInput);

--- a/packages/core/src/utils/proxyComponent.ts
+++ b/packages/core/src/utils/proxyComponent.ts
@@ -3,8 +3,8 @@
 import React from 'react';
 
 export default function proxyComponent<T>(
-  Component: React.ComponentType<T>,
-  implementation: (props: any) => React.ReactElement<T>,
+  Component: React.ComponentType<any>,
+  implementation: (props: T) => React.ReactElement<T>,
 ): React.ComponentType<T> {
   function Proxy(props: T) {
     return implementation(props);

--- a/packages/core/src/utils/proxyComponent.ts
+++ b/packages/core/src/utils/proxyComponent.ts
@@ -4,7 +4,7 @@ import React from 'react';
 
 export default function proxyComponent<T>(
   Component: React.ComponentType<any>,
-  implementation: (props: T) => React.ReactElement<T>,
+  implementation: (props: T) => React.ReactElement<any>,
 ): React.ComponentType<T> {
   function Proxy(props: T) {
     return implementation(props);

--- a/packages/core/test/components/CheckBox.test.tsx
+++ b/packages/core/test/components/CheckBox.test.tsx
@@ -37,7 +37,7 @@ describe('<CheckBox />', () => {
   it('can set checked', () => {
     const wrapper = shallow(<CheckBox name="foo" label="Label" value="1" onChange={() => {}} />);
 
-    expect(wrapper.find(BaseCheckBox).prop('checked')).toBe(false);
+    expect(wrapper.find(BaseCheckBox).prop('checked')).toBeUndefined();
 
     wrapper.setProps({
       checked: true,
@@ -49,7 +49,7 @@ describe('<CheckBox />', () => {
   it('can set indeterminate', () => {
     const wrapper = shallow(<CheckBox name="foo" label="Label" value="1" onChange={() => {}} />);
 
-    expect(wrapper.find(BaseCheckBox).prop('indeterminate')).toBe(false);
+    expect(wrapper.find(BaseCheckBox).prop('indeterminate')).toBeUndefined();
 
     wrapper.setProps({
       indeterminate: true,

--- a/packages/core/test/components/CheckBox.test.tsx
+++ b/packages/core/test/components/CheckBox.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
-import CheckBox, { CheckBoxProps, CheckBoxState } from '../../src/components/CheckBox';
+import CheckBox, { CheckBoxProps } from '../../src/components/CheckBox';
 import FormField from '../../src/components/FormField';
 import BaseCheckBox from '../../src/components/private/BaseCheckBox';
 import Text from '../../src/components/Text';
 
 describe('<CheckBox />', () => {
   it('renders a field and input', () => {
-    const wrapper = shallow(<CheckBox name="foo" label="Label" value="1" onChange={() => {}} />);
+    const wrapper = shallow(
+      <CheckBox<'a' | 'b' | 'c'> name="foo" label="Label" value="a" onChange={() => {}} />,
+    );
 
     expect(wrapper.find(FormField)).toHaveLength(1);
     expect(wrapper.find(BaseCheckBox)).toHaveLength(1);
@@ -57,7 +59,7 @@ describe('<CheckBox />', () => {
   });
 
   describe('button mode', () => {
-    let wrapper: Enzyme.ShallowWrapper<CheckBoxProps, CheckBoxState>;
+    let wrapper: Enzyme.ShallowWrapper<CheckBoxProps<string>>;
 
     beforeEach(() => {
       wrapper = shallow(

--- a/packages/core/test/components/CheckBoxController.test.tsx
+++ b/packages/core/test/components/CheckBoxController.test.tsx
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import CheckBoxController from '../../src/components/CheckBoxController';
 
 describe('<CheckBoxController />', () => {
+  type Value = 'foo' | 'bar' | 'baz' | 'qux';
+
   const props = {
     name: 'cb',
     value: ['foo'],
@@ -101,7 +103,7 @@ describe('<CheckBoxController />', () => {
 
   it('handles checked', () => {
     const wrapper = shallow<CheckBoxController>(
-      <CheckBoxController {...props}>
+      <CheckBoxController<Value> {...props} value={['foo']}>
         {CB => (
           <div>
             <CB value="foo" label="Foo" />

--- a/packages/core/test/components/RadioButton.test.tsx
+++ b/packages/core/test/components/RadioButton.test.tsx
@@ -45,7 +45,7 @@ describe('<RadioButton />', () => {
       <RadioButton name="foo" label="Label" value="foo" onChange={() => {}} />,
     );
 
-    expect(wrapper.find(BaseRadioButton).prop('checked')).toBe(false);
+    expect(wrapper.find(BaseRadioButton).prop('checked')).toBeUndefined();
 
     wrapper.setProps({
       checked: true,
@@ -59,7 +59,7 @@ describe('<RadioButton />', () => {
       <RadioButton name="foo" label="Label" value="foo" onChange={() => {}} />,
     );
 
-    expect(wrapper.find(BaseRadioButton).prop('indeterminate')).toBe(false);
+    expect(wrapper.find(BaseRadioButton).prop('indeterminate')).toBeUndefined();
 
     wrapper.setProps({
       indeterminate: true,

--- a/packages/core/test/components/RadioButton.test.tsx
+++ b/packages/core/test/components/RadioButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
-import RadioButton, { RadioButtonProps, RadioButtonState } from '../../src/components/RadioButton';
+import RadioButton, { RadioButtonProps } from '../../src/components/RadioButton';
 import FormField from '../../src/components/FormField';
 import BaseRadioButton from '../../src/components/private/BaseRadioButton';
 import Text from '../../src/components/Text';
@@ -69,7 +69,7 @@ describe('<RadioButton />', () => {
   });
 
   describe('button mode', () => {
-    let wrapper: Enzyme.ShallowWrapper<RadioButtonProps, RadioButtonState>;
+    let wrapper: Enzyme.ShallowWrapper<RadioButtonProps<string>>;
 
     beforeEach(() => {
       wrapper = shallow(

--- a/packages/core/test/components/RadioButtonController.test.tsx
+++ b/packages/core/test/components/RadioButtonController.test.tsx
@@ -108,7 +108,11 @@ describe('<RadioButtonController />', () => {
 
   it('handles checked', () => {
     const wrapper = shallow<RadioButtonController>(
-      <RadioButtonController {...props} onChange={() => {}}>
+      <RadioButtonController<'foo' | 'bar' | 'baz' | 'qux'>
+        {...props}
+        value="foo"
+        onChange={() => {}}
+      >
         {RB => (
           <div>
             <RB value="foo" label="Foo" />

--- a/packages/core/test/components/Select.test.tsx
+++ b/packages/core/test/components/Select.test.tsx
@@ -5,9 +5,11 @@ import FormField from '../../src/components/FormField';
 import BaseSelect from '../../src/components/private/BaseSelect';
 
 describe('<Select />', () => {
+  type Value = 'foo' | 'bar' | 'baz';
+
   it('renders a field and input', () => {
     const wrapper = shallow(
-      <Select name="foo" label="Label" onChange={() => {}}>
+      <Select<Value> name="foo" label="Label" onChange={() => {}}>
         <option value="">Option</option>
       </Select>,
     );

--- a/packages/core/test/components/Switch.test.tsx
+++ b/packages/core/test/components/Switch.test.tsx
@@ -34,7 +34,7 @@ describe('<Switch />', () => {
   it('can set checked', () => {
     const wrapper = shallow(<Switch name="foo" label="Label" onChange={() => {}} />);
 
-    expect(wrapper.find(BaseSwitch).prop('checked')).toBe(false);
+    expect(wrapper.find(BaseSwitch).prop('checked')).toBeUndefined();
 
     wrapper.setProps({
       checked: true,

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -202,9 +202,12 @@ describe('<Tabs/>', () => {
       </Tabs>,
     );
 
-    wrapper.find(ButtonOrLink).simulate('click');
+    wrapper
+      .find(ButtonOrLink)
+      .at(1)
+      .simulate('click');
 
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('b');
   });
 
   it('wraps in scroller when using `scrollable`', () => {

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -195,8 +195,10 @@ describe('<Tabs/>', () => {
   it('triggers `onChange` when clicking', () => {
     const spy = jest.fn();
     const wrapper = mountUseStyles(
-      <Tabs onChange={spy}>
+      <Tabs<'a' | 'b' | 'c'> onChange={spy}>
         <Tab key="a" label="Label" />
+        <Tab key="b" label="Label" />
+        <Tab key="c" label="Label" />
       </Tabs>,
     );
 

--- a/packages/core/test/components/ToggleButtonController.test.tsx
+++ b/packages/core/test/components/ToggleButtonController.test.tsx
@@ -10,6 +10,8 @@ function clickButton(wrapper: Enzyme.ShallowWrapper, value: unknown): Enzyme.Sha
 }
 
 describe('<ToggleButtonController />', () => {
+  type Value = '1' | '2' | '3';
+
   const props = {
     id: 'foo',
     name: 'bg',
@@ -54,7 +56,7 @@ describe('<ToggleButtonController />', () => {
   it('does not notify of click that does not cause change', () => {
     const onChange = jest.fn();
     const wrapper = shallow(
-      <ToggleButtonController {...props} value="1" onChange={onChange}>
+      <ToggleButtonController<Value> {...props} value="1" onChange={onChange}>
         {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
@@ -96,7 +98,7 @@ describe('<ToggleButtonController />', () => {
 
   it('inverts inactive buttons', () => {
     const wrapper = shallow(
-      <ToggleButtonController {...props} value="1">
+      <ToggleButtonController<Value> {...props} value="1">
         {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>
@@ -131,7 +133,7 @@ describe('<ToggleButtonController />', () => {
 
   it('renders `small` buttons', () => {
     const wrapper = shallow(
-      <ToggleButtonController {...props} small value="1">
+      <ToggleButtonController<Value> {...props} small value="1">
         {ProxyButton => (
           <div>
             <ProxyButton value="1">1</ProxyButton>

--- a/packages/forms/src/components/FeedbackForm/index.tsx
+++ b/packages/forms/src/components/FeedbackForm/index.tsx
@@ -82,7 +82,7 @@ export default class FeedbackForm extends React.PureComponent<
     return (
       <Form onSubmit={this.handleSubmit} onStateUpdate={this.handleStateUpdate}>
         {!disableBugReporting && (
-          <RadioButtonController
+          <RadioButtonController<'bug' | 'feedback'>
             name="type"
             label={
               <T

--- a/packages/forms/src/components/Form/CheckBox.tsx
+++ b/packages/forms/src/components/Form/CheckBox.tsx
@@ -4,12 +4,14 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `CheckBox` automatically connected to the parent `Form`.  */
-export default function FormCheckBox(props: FieldProps<boolean, CheckBoxProps>) {
+export default function FormCheckBox<T extends string = string>(
+  props: FieldProps<boolean, CheckBoxProps<T>>,
+) {
   const fieldProps = useFormField(props, {
     initialValue: false,
     parse: toBool,
     valueProp: 'checked',
   });
 
-  return <CheckBox {...fieldProps} />;
+  return <CheckBox<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/CheckBoxController.tsx
+++ b/packages/forms/src/components/Form/CheckBoxController.tsx
@@ -6,8 +6,8 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `CheckBoxController` automatically connected to the parent `Form`.  */
-export default function FormCheckBoxController(
-  props: FieldProps<string[], CheckBoxControllerProps>,
+export default function FormCheckBoxController<T extends string = string>(
+  props: FieldProps<T[], CheckBoxControllerProps<T>>,
 ) {
   const fieldProps = useFormField(props, {
     initialValue: [],
@@ -15,5 +15,5 @@ export default function FormCheckBoxController(
     parse: toString,
   });
 
-  return <CheckBoxController {...fieldProps} />;
+  return <CheckBoxController<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/RadioButtonController.tsx
+++ b/packages/forms/src/components/Form/RadioButtonController.tsx
@@ -6,13 +6,13 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `RadioButtonController` automatically connected to the parent `Form`.  */
-export default function FormRadioButtonController(
-  props: FieldProps<string, RadioButtonControllerProps>,
+export default function FormRadioButtonController<T extends string = string>(
+  props: FieldProps<T, RadioButtonControllerProps<T>>,
 ) {
   const fieldProps = useFormField(props, {
-    initialValue: '',
+    initialValue: '' as T,
     parse: toString,
   });
 
-  return <RadioButtonController {...fieldProps} />;
+  return <RadioButtonController<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Select.tsx
+++ b/packages/forms/src/components/Form/Select.tsx
@@ -4,11 +4,13 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `Select` automatically connected to the parent `Form`.  */
-export default function FormSelect(props: FieldProps<string, SelectProps>) {
+export default function FormSelect<T extends string = string>(
+  props: FieldProps<T, SelectProps<T>>,
+) {
   const fieldProps = useFormField(props, {
-    initialValue: '',
+    initialValue: '' as T,
     parse: toString,
   });
 
-  return <Select {...fieldProps} />;
+  return <Select<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/Switch.tsx
+++ b/packages/forms/src/components/Form/Switch.tsx
@@ -4,12 +4,14 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toBool } from '../../helpers';
 
 /** `Switch` automatically connected to the parent `Form`.  */
-export default function FormSwitch(props: FieldProps<boolean, SwitchProps>) {
+export default function FormSwitch<T extends string = string>(
+  props: FieldProps<boolean, SwitchProps<T>>,
+) {
   const fieldProps = useFormField(props, {
     initialValue: false,
     parse: toBool,
     valueProp: 'checked',
   });
 
-  return <Switch {...fieldProps} />;
+  return <Switch<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/ToggleButtonController.tsx
+++ b/packages/forms/src/components/Form/ToggleButtonController.tsx
@@ -6,13 +6,13 @@ import useFormField, { FieldProps } from '../../hooks/useFormField';
 import { toString } from '../../helpers';
 
 /** `ToggleButtonController` automatically connected to the parent `Form`.  */
-export default function FormToggleButtonController(
-  props: FieldProps<string, ToggleButtonControllerProps>,
+export default function FormToggleButtonController<T extends string = string>(
+  props: FieldProps<T, ToggleButtonControllerProps<T>>,
 ) {
   const fieldProps = useFormField(props, {
-    initialValue: '',
+    initialValue: '' as T,
     parse: toString,
   });
 
-  return <ToggleButtonController {...fieldProps} />;
+  return <ToggleButtonController<T> {...fieldProps} />;
 }

--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -237,7 +237,7 @@ export function withAllFields() {
         onChange={action('onChange')}
       />
 
-      <CheckBoxController
+      <CheckBoxController<'foo' | 'bar' | 'baz'>
         unregisterOnUnmount
         label="Checkboxes"
         name="multiple_checkbox"
@@ -283,7 +283,7 @@ export function withAllFields() {
         )}
       </CheckBoxController>
 
-      <RadioButtonController
+      <RadioButtonController<'foo' | 'bar' | 'baz'>
         unregisterOnUnmount
         label="Radio buttons (in button mode)"
         name="multiple_radio"
@@ -300,7 +300,7 @@ export function withAllFields() {
         )}
       </RadioButtonController>
 
-      <ToggleButtonController
+      <ToggleButtonController<'foo' | 'bar' | 'baz'>
         unregisterOnUnmount
         label="Toggle buttons"
         name="mutliple_buttons"

--- a/packages/forms/src/composers/connectToForm.tsx
+++ b/packages/forms/src/composers/connectToForm.tsx
@@ -8,13 +8,6 @@ import useFormField, {
   FieldProvidedProps,
 } from '../hooks/useFormField';
 
-if (process.env.NODE_ENV === 'development') {
-  // eslint-disable-next-line no-console
-  console.warn(
-    '`connectToForm` composer is deprecated. Please migrate to the `useFormField` hook.',
-  );
-}
-
 export type Options<T> = BaseOptions<T>;
 export type ConnectToFormProps<T> = FieldProvidedProps<T>;
 export type ConnectToFormWrapperProps<T> = FieldInternalProps<T>;

--- a/packages/forms/src/helpers.ts
+++ b/packages/forms/src/helpers.ts
@@ -18,8 +18,8 @@ export function isPrimitive(value: unknown): boolean {
 /**
  * Return an empty string for non-primitives, otherwise cast to a string.
  */
-export function toString(value: unknown): string {
-  return isPrimitive(value) ? String(value) : '';
+export function toString<T extends string = string>(value: unknown): T {
+  return (isPrimitive(value) ? String(value) : '') as T;
 }
 
 /**

--- a/packages/forms/test/components/Form/CheckBoxController.test.tsx
+++ b/packages/forms/test/components/Form/CheckBoxController.test.tsx
@@ -13,9 +13,16 @@ describe('<CheckBoxController />', () => {
     context = createFormContext();
   });
 
+  type Value = 'foo' | 'bar' | 'baz';
+
   it('connects to the form', () => {
     const wrapper = mount(
-      <CheckBoxController label="Label" name="foo" defaultValue={['bar']} validator={() => {}}>
+      <CheckBoxController<Value>
+        label="Label"
+        name="foo"
+        defaultValue={['bar']}
+        validator={() => {}}
+      >
         {CB => (
           <div>
             <CB value="foo" label="Foo" />
@@ -40,7 +47,12 @@ describe('<CheckBoxController />', () => {
 
   it('passes value as an array', () => {
     const wrapper = mount(
-      <CheckBoxController label="Label" name="foo" defaultValue={['bar']} validator={() => {}}>
+      <CheckBoxController<Value>
+        label="Label"
+        name="foo"
+        defaultValue={['bar']}
+        validator={() => {}}
+      >
         {CB => (
           <div>
             <CB value="foo" label="Foo" />

--- a/packages/forms/test/components/Form/RadioButtonController.test.tsx
+++ b/packages/forms/test/components/Form/RadioButtonController.test.tsx
@@ -13,9 +13,16 @@ describe('<RadioButtonController />', () => {
     context = createFormContext();
   });
 
+  type Value = 'foo' | 'bar' | 'baz';
+
   it('connects to the form', () => {
     const wrapper = mount(
-      <RadioButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+      <RadioButtonController<Value>
+        label="Label"
+        name="foo"
+        defaultValue="bar"
+        validator={() => {}}
+      >
         {RB => (
           <div>
             <RB value="foo" label="Foo" />

--- a/packages/forms/test/components/Form/ToggleButtonController.test.tsx
+++ b/packages/forms/test/components/Form/ToggleButtonController.test.tsx
@@ -13,9 +13,16 @@ describe('<ToggleButtonController />', () => {
     context = createFormContext();
   });
 
+  type Value = 'foo' | 'bar' | 'baz';
+
   it('connects to the form', () => {
     const wrapper = mount(
-      <ToggleButtonController label="Label" name="foo" defaultValue="bar" validator={() => {}}>
+      <ToggleButtonController<Value>
+        label="Label"
+        name="foo"
+        defaultValue="bar"
+        validator={() => {}}
+      >
         {ProxyButton => (
           <div>
             <ProxyButton value="foo">Foo</ProxyButton>

--- a/packages/layouts/src/components/Layout/story.tsx
+++ b/packages/layouts/src/components/Layout/story.tsx
@@ -31,7 +31,7 @@ export function standardLayoutCentered() {
 }
 
 standardLayoutCentered.story = {
-  name: 'Wtih `centerAlign`.',
+  name: 'With `centerAlign`.',
 };
 
 export function withMinHeight() {

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -21,6 +21,7 @@
     "target": "es2015",
     "useDefineForClassFields": false,
     "composite": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "noErrorTruncation": false
   }
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds a generic to all form components that accept a list (controllers, select, etc), and other components that have a defined list (tab). 

Also rewrote some components to function components.

## Motivation and Context

This is so handlers can be strictly typed.

## Testing

Yes.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
