### PR TITLE
breaking(CardContent): Consolidate before/after props. Remove afterImageSrc, beforeImageSrc, small, and large props. Generalize other props.

### DIFF
--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -31,9 +31,9 @@ export type CardContentProps = {
   top?: React.ReactNode;
   /** To use with text truncation; overflow is hidden. */
   truncated?: boolean;
-  /** If provided, makes the after image clickable, firing this callback. */
+  /** If provided, makes the after content clickable, firing this callback. */
   onAfterClick?: () => void;
-  /** If provided, makes the before image clickable, firing this callback. */
+  /** If provided, makes the before content clickable, firing this callback. */
   onBeforeClick?: () => void;
   /** If provided, makes the entire content clickable, firing this callback. */
   onClick?: () => void;

--- a/packages/core/src/components/Card/Content.tsx
+++ b/packages/core/src/components/Card/Content.tsx
@@ -1,56 +1,40 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { mutuallyExclusiveProps } from 'airbnb-prop-types';
 import useStyles, { StyleSheet } from '../../hooks/useStyles';
-import Image from '../Image';
 import Row from '../Row';
 import Spacing from '../Spacing';
 import { styleSheetContent } from './styles';
 import ButtonOrLink from '../private/ButtonOrLink';
-
-function getSideImageWidth({ large, small }: { large?: boolean; small?: boolean }): number {
-  if (small) {
-    return 80;
-  }
-
-  if (large) {
-    return 195;
-  }
-
-  return 152;
-}
+import CardSide from './private/Side';
 
 export type CardContentProps = {
-  /** Content to display following the primary content. Takes priority over `afterImageSrc`. */
+  /** Content to display following the primary content. */
   after?: React.ReactNode;
-  /** Right image URL. */
-  afterImageSrc?: string;
-  /** Content to display before the primary content. Takes priority over `beforeImageSrc`. */
+  /** Content to display before the primary content. */
   before?: React.ReactNode;
-  /** Left image URL. */
-  beforeImageSrc?: string;
   /** Content to display. */
   children: NonNullable<React.ReactNode>;
   /** Decrease padding. */
   compact?: boolean;
-  /** Whether the image content is large. */
-  large?: boolean;
   /** Max height of content. */
   maxHeight?: number | string;
   /** Align contents in the middle vertically. */
   middleAlign?: boolean;
   /** Min height of content. */
   minHeight?: number | string;
-  /** Whether the image content is small. */
-  small?: boolean;
-  /** Top image URL. */
-  topImageSrc?: string;
+  /** Remove padding around after content. */
+  noPaddingAfter?: boolean;
+  /** Remove padding around before content. */
+  noPaddingBefore?: boolean;
+  /** Remove padding around top content. */
+  noPaddingTop?: boolean;
+  /** Content to display above the primary content. */
+  top?: React.ReactNode;
   /** To use with text truncation; overflow is hidden. */
   truncated?: boolean;
   /** If provided, makes the after image clickable, firing this callback. */
-  onAfterImageClick?: () => void;
+  onAfterClick?: () => void;
   /** If provided, makes the before image clickable, firing this callback. */
-  onBeforeImageClick?: () => void;
+  onBeforeClick?: () => void;
   /** If provided, makes the entire content clickable, firing this callback. */
   onClick?: () => void;
   /** Custom style sheet. */
@@ -58,107 +42,69 @@ export type CardContentProps = {
 };
 
 /** Content block within a card. */
-function CardContent({
+export default function CardContent({
   after,
-  afterImageSrc,
   before,
-  beforeImageSrc,
   children,
   compact,
-  large,
   maxHeight,
   middleAlign,
   minHeight,
+  noPaddingAfter,
+  noPaddingBefore,
+  noPaddingTop,
   onClick,
-  small,
-  topImageSrc,
+  top,
   truncated,
-  onAfterImageClick,
-  onBeforeImageClick,
+  onAfterClick,
+  onBeforeClick,
   styleSheet,
 }: CardContentProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetContent);
 
   const ContainerTag = onClick ? 'button' : 'div';
-  const props = onClick ? { type: 'button', onClick } : {};
+  const containerProps = onClick ? { type: 'button', onClick } : {};
   const spacing = compact ? 1.5 : 3;
   const horizontalSpacing = compact ? 0 : 1;
 
   let afterContent = after ? (
-    <div
-      className={cx(
-        styles.side,
-        compact && styles.side_compact,
-        styles.after,
-        compact && styles.after_compact,
-      )}
-    >
+    <CardSide type="after" compact={compact} middleAlign={middleAlign} noPadding={noPaddingAfter}>
       {after}
-    </div>
+    </CardSide>
   ) : null;
 
-  if (!afterContent && afterImageSrc) {
+  if (afterContent && onAfterClick) {
     afterContent = (
-      <Image
-        background
-        cover
-        alt=""
-        height="100%"
-        width={getSideImageWidth({ large, small })}
-        src={afterImageSrc}
-      />
+      <ButtonOrLink className={cx(styles.sideButton)} onClick={onAfterClick}>
+        {afterContent}
+      </ButtonOrLink>
     );
-
-    if (onAfterImageClick) {
-      afterContent = (
-        <ButtonOrLink className={cx(styles.sideButton)} onClick={onAfterImageClick}>
-          {afterContent}
-        </ButtonOrLink>
-      );
-    }
   }
 
   let beforeContent = before ? (
-    <div
-      className={cx(
-        styles.side,
-        compact && styles.side_compact,
-        styles.before,
-        compact && styles.before_compact,
-      )}
-    >
+    <CardSide type="before" compact={compact} middleAlign={middleAlign} noPadding={noPaddingBefore}>
       {before}
-    </div>
+    </CardSide>
   ) : null;
 
-  if (!beforeContent && beforeImageSrc) {
+  if (beforeContent && onBeforeClick) {
     beforeContent = (
-      <Image
-        background
-        cover
-        alt=""
-        height="100%"
-        width={getSideImageWidth({ large, small })}
-        src={beforeImageSrc}
-      />
+      <ButtonOrLink className={cx(styles.sideButton)} onClick={onBeforeClick}>
+        {beforeContent}
+      </ButtonOrLink>
     );
-
-    if (onBeforeImageClick) {
-      beforeContent = (
-        <ButtonOrLink className={cx(styles.sideButton)} onClick={onBeforeImageClick}>
-          {beforeContent}
-        </ButtonOrLink>
-      );
-    }
   }
 
   return (
     // @ts-ignore [ts] JSX element type 'ContainerTag' does not have any construct or call signatures. [2604]
-    <ContainerTag {...props} className={cx(styles.container, onClick && styles.container_button)}>
-      {topImageSrc && (
-        <div className={cx(styles.topImage, large && styles.topImage_large)}>
-          <img className={cx(styles.image)} alt="" height="100%" src={topImageSrc} width="100%" />
-        </div>
+    <ContainerTag
+      {...containerProps}
+      className={cx(styles.container, onClick && styles.container_button)}
+    >
+      {top && (
+        <Spacing inner horizontal={noPaddingTop ? 0 : spacing} top={noPaddingTop ? 0 : spacing}>
+          {top}
+        </Spacing>
       )}
 
       <Row
@@ -181,36 +127,3 @@ function CardContent({
     </ContainerTag>
   );
 }
-
-const imageUrlTypePropType = mutuallyExclusiveProps(
-  PropTypes.string,
-  'beforeImageSrc',
-  'afterImageSrc',
-  'topImageSrc',
-);
-
-const afterPropType = mutuallyExclusiveProps(
-  PropTypes.oneOfType([PropTypes.node, imageUrlTypePropType]),
-  'after',
-  'afterImageSrc',
-);
-
-const beforePropType = mutuallyExclusiveProps(
-  PropTypes.oneOfType([PropTypes.node, imageUrlTypePropType]),
-  'before',
-  'beforeImageSrc',
-);
-
-const imageSizePropType = mutuallyExclusiveProps(PropTypes.bool, 'small', 'large');
-
-CardContent.propTypes = {
-  after: afterPropType,
-  afterImageSrc: imageUrlTypePropType,
-  before: beforePropType,
-  beforeImageSrc: imageUrlTypePropType,
-  large: imageSizePropType,
-  small: imageSizePropType,
-  topImageSrc: imageUrlTypePropType,
-};
-
-export default CardContent;

--- a/packages/core/src/components/Card/private/Side.tsx
+++ b/packages/core/src/components/Card/private/Side.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import useStyles from '../../../hooks/useStyles';
+import { styleSheetContent } from '../styles';
+import { CardContentProps } from '../Content';
+
+type CardSideProps = Partial<Pick<CardContentProps, 'children' | 'compact' | 'middleAlign'>> & {
+  noPadding?: boolean;
+  type: 'before' | 'after';
+};
+
+export default function CardSide({ children, compact, middleAlign, noPadding, type }: CardSideProps) {
+  const [styles, cx] = useStyles(styleSheetContent);
+  const isAfter = type === 'after';
+  const isBefore = type === 'before';
+
+  return (
+    <div
+      className={cx(
+        styles.side,
+        middleAlign && styles.side_middleAlign,
+        compact && styles.side_compact,
+        isAfter && styles.after,
+        compact && isAfter && styles.after_compact,
+        isBefore && styles.before,
+        compact && isBefore && styles.before_compact,
+        noPadding && styles.side_noPadding,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/core/src/components/Card/private/Side.tsx
+++ b/packages/core/src/components/Card/private/Side.tsx
@@ -8,7 +8,13 @@ type CardSideProps = Partial<Pick<CardContentProps, 'children' | 'compact' | 'mi
   type: 'before' | 'after';
 };
 
-export default function CardSide({ children, compact, middleAlign, noPadding, type }: CardSideProps) {
+export default function CardSide({
+  children,
+  compact,
+  middleAlign,
+  noPadding,
+  type,
+}: CardSideProps) {
   const [styles, cx] = useStyles(styleSheetContent);
   const isAfter = type === 'after';
   const isBefore = type === 'before';

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -427,7 +427,6 @@ export function aCardWithAllTheExtraContentAndAlignMents() {
           <Text>Middle alignment</Text>
         </Content>
       </Card>
-
     </>
   );
 }

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -408,12 +408,10 @@ export function aCardWithAllTheExtraContentAndAlignMents() {
       <Card>
         <Content
           after={<Text>After</Text>}
-          before={<Text>Before</Text>}
+          before={<Image background cover alt="" height={80} width={80} src={moon} />}
           top={<Text centerAlign>Top</Text>}
         >
-          <Text>
-            <LoremIpsum />
-          </Text>
+          <Text>Default alignment</Text>
         </Content>
       </Card>
 
@@ -423,14 +421,13 @@ export function aCardWithAllTheExtraContentAndAlignMents() {
         <Content
           middleAlign
           after={<Text>After</Text>}
-          before={<Text>Before</Text>}
+          before={<Image background cover alt="" height={80} width={80} src={moon} />}
           top={<Text centerAlign>Top</Text>}
         >
-          <Text>
-            <LoremIpsum />
-          </Text>
+          <Text>Middle alignment</Text>
         </Content>
       </Card>
+
     </>
   );
 }

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -6,6 +6,7 @@ import stars from ':storybook/images/stars.jpg';
 import moon from ':storybook/images/moon.png';
 import Text from '../Text';
 import ResponsiveImage from '../ResponsiveImage';
+import Image from '../Image';
 import Card, { Content } from '.';
 
 export default {
@@ -116,7 +117,10 @@ withAMinHeight.story = {
 export function aCardWithATopFeaturedImage() {
   return (
     <Card>
-      <Content topImageSrc={stars}>
+      <Content
+        noPaddingTop
+        top={<Image background cover alt="" height={105} width="100%" src={stars} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -132,7 +136,10 @@ aCardWithATopFeaturedImage.story = {
 export function aCardWithALargeTopFeaturedImage() {
   return (
     <Card>
-      <Content large topImageSrc={stars}>
+      <Content
+        noPaddingTop
+        top={<Image background cover alt="" height={195} width="100%" src={stars} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -148,7 +155,10 @@ aCardWithALargeTopFeaturedImage.story = {
 export function aCardWithASmallLeftFeaturedImage() {
   return (
     <Card>
-      <Content small beforeImageSrc={moon}>
+      <Content
+        noPaddingBefore
+        before={<Image background cover alt="" height="100%" width={80} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -164,7 +174,10 @@ aCardWithASmallLeftFeaturedImage.story = {
 export function aCardWithALeftFeaturedImage() {
   return (
     <Card>
-      <Content beforeImageSrc={moon}>
+      <Content
+        noPaddingBefore
+        before={<Image background cover alt="" height="100%" width={152} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -180,7 +193,10 @@ aCardWithALeftFeaturedImage.story = {
 export function aCardWithALargeLeftFeaturedImage() {
   return (
     <Card>
-      <Content large beforeImageSrc={moon}>
+      <Content
+        noPaddingBefore
+        before={<Image background cover alt="" height="100%" width={195} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -196,7 +212,10 @@ aCardWithALargeLeftFeaturedImage.story = {
 export function aCardWithASmallRightFeaturedImage() {
   return (
     <Card>
-      <Content small afterImageSrc={moon}>
+      <Content
+        noPaddingAfter
+        after={<Image background cover alt="" height="100%" width={80} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -212,7 +231,10 @@ aCardWithASmallRightFeaturedImage.story = {
 export function aCardWithARightFeaturedImage() {
   return (
     <Card>
-      <Content afterImageSrc={moon}>
+      <Content
+        noPaddingAfter
+        after={<Image background cover alt="" height="100%" width={152} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -228,7 +250,10 @@ aCardWithARightFeaturedImage.story = {
 export function aCardWithALargeRightFeaturedImage() {
   return (
     <Card>
-      <Content large afterImageSrc={moon}>
+      <Content
+        noPaddingAfter
+        after={<Image background cover alt="" height="100%" width={195} src={moon} />}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -244,7 +269,11 @@ aCardWithALargeRightFeaturedImage.story = {
 export function aCardWithTextTruncation() {
   return (
     <Card>
-      <Content truncated beforeImageSrc={stars}>
+      <Content
+        truncated
+        noPaddingBefore
+        before={<Image background cover alt="" height="100%" width={152} src={moon} />}
+      >
         <Text truncated>
           <LoremIpsum />
         </Text>
@@ -261,7 +290,7 @@ aCardWithTextTruncation.story = {
   name: 'A card with text truncation.',
 };
 
-export function clickAble() {
+export function clickableCard() {
   return (
     <Card>
       <Content
@@ -277,7 +306,7 @@ export function clickAble() {
   );
 }
 
-clickAble.story = {
+clickableCard.story = {
   name: 'Click-able.',
 };
 
@@ -336,7 +365,11 @@ cardAsAButtonWithMiddleAlignment.story = {
 export function asClickableBeforeImage() {
   return (
     <Card>
-      <Content large beforeImageSrc={moon} onBeforeImageClick={action('onClick before')}>
+      <Content
+        noPaddingBefore
+        before={<Image background cover alt="" height="100%" width={152} src={moon} />}
+        onBeforeClick={action('onClick before')}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -352,7 +385,11 @@ asClickableBeforeImage.story = {
 export function asClickableAfterImage() {
   return (
     <Card>
-      <Content large afterImageSrc={moon} onAfterImageClick={action('onClick after')}>
+      <Content
+        noPaddingAfter
+        after={<Image background cover alt="" height="100%" width={152} src={moon} />}
+        onAfterClick={action('onClick after')}
+      >
         <Text>
           <LoremIpsum />
         </Text>
@@ -363,4 +400,41 @@ export function asClickableAfterImage() {
 
 asClickableAfterImage.story = {
   name: 'A card with a clickable after image.',
+};
+
+export function aCardWithAllTheExtraContentAndAlignMents() {
+  return (
+    <>
+      <Card>
+        <Content
+          after={<Text>After</Text>}
+          before={<Text>Before</Text>}
+          top={<Text centerAlign>Top</Text>}
+        >
+          <Text>
+            <LoremIpsum />
+          </Text>
+        </Content>
+      </Card>
+
+      <br />
+
+      <Card>
+        <Content
+          middleAlign
+          after={<Text>After</Text>}
+          before={<Text>Before</Text>}
+          top={<Text centerAlign>Top</Text>}
+        >
+          <Text>
+            <LoremIpsum />
+          </Text>
+        </Content>
+      </Card>
+    </>
+  );
+}
+
+aCardWithAllTheExtraContentAndAlignMents.story = {
+  name: 'Cards with before, after, and top content showing different alignments.',
 };

--- a/packages/core/src/components/Card/styles.ts
+++ b/packages/core/src/components/Card/styles.ts
@@ -38,26 +38,39 @@ export const styleSheetContent: StyleSheet = ({ color, pattern, ui, unit }) => (
 
   side: {
     display: 'flex',
-    alignItems: 'center',
     height: '100%',
+    alignItems: 'flex-start',
     paddingTop: unit * 3,
     paddingBottom: unit * 3,
   },
 
-  sideButton: {
-    ...pattern.resetButton,
-    height: '100%',
-    '@selectors': {
-      '> span': {
-        height: '100%',
-        display: 'block',
-      },
-    },
+  side_middleAlign: {
+    alignItems: 'center',
   },
 
   side_compact: {
     paddingTop: unit * 1.5,
     paddingBottom: unit * 1.5,
+  },
+
+  side_noPadding: {
+    padding: 0,
+  },
+
+  sideButton: {
+    ...pattern.resetButton,
+    height: '100%',
+
+    '@selectors': {
+      ':hover, :focus': {
+        outline: 'none',
+      },
+
+      '> span': {
+        height: '100%',
+        display: 'block',
+      },
+    },
   },
 
   after: {
@@ -74,18 +87,5 @@ export const styleSheetContent: StyleSheet = ({ color, pattern, ui, unit }) => (
 
   before_compact: {
     paddingLeft: unit * 1.5,
-  },
-
-  image: {
-    display: 'block',
-    objectFit: 'cover',
-  },
-
-  topImage: {
-    height: 105,
-  },
-
-  topImage_large: {
-    height: 195,
   },
 });

--- a/packages/core/test/components/Card/Content.test.tsx
+++ b/packages/core/test/components/Card/Content.test.tsx
@@ -33,9 +33,9 @@ describe('<Card />', () => {
       true,
     );
 
-    expect(shallow(wrapper.find(Row).prop('after') as React.ReactElement).hasClass('side_noPadding')).toBe(
-      true,
-    );
+    expect(
+      shallow(wrapper.find(Row).prop('after') as React.ReactElement).hasClass('side_noPadding'),
+    ).toBe(true);
   });
 
   it('renders before content', () => {
@@ -59,9 +59,9 @@ describe('<Card />', () => {
       true,
     );
 
-    expect(shallow(wrapper.find(Row).prop('before') as React.ReactElement).hasClass('side_noPadding')).toBe(
-      true,
-    );
+    expect(
+      shallow(wrapper.find(Row).prop('before') as React.ReactElement).hasClass('side_noPadding'),
+    ).toBe(true);
   });
 
   it('renders top content', () => {
@@ -71,8 +71,6 @@ describe('<Card />', () => {
     expect(wrapper.contains(top)).toBe(true);
   });
 
-
-
   it('renders top content with no padding', () => {
     const top = '~~Top~~';
     const wrapper = shallow(
@@ -81,13 +79,19 @@ describe('<Card />', () => {
       </Content>,
     );
 
-    expect(wrapper.find(Spacing).at(0).prop('horizontal')).toBe(
-      0,
-    );
+    expect(
+      wrapper
+        .find(Spacing)
+        .at(0)
+        .prop('horizontal'),
+    ).toBe(0);
 
-    expect(wrapper.find(Spacing).at(0).prop('top')).toBe(
-      0,
-    );
+    expect(
+      wrapper
+        .find(Spacing)
+        .at(0)
+        .prop('top'),
+    ).toBe(0);
   });
 
   it('renders before content as clickable', () => {

--- a/packages/core/test/components/Card/Content.test.tsx
+++ b/packages/core/test/components/Card/Content.test.tsx
@@ -2,33 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Content from '../../../src/components/Card/Content';
 import Row from '../../../src/components/Row';
+import Spacing from '../../../src/components/Spacing';
 
 describe('<Card />', () => {
-  it('renders a top image', () => {
-    const imageUrl = 'TopFoo.jpg';
-    const wrapper = shallow(<Content topImageSrc={imageUrl}>Sup</Content>);
-
-    expect(wrapper.find('img').prop('src')).toBe(imageUrl);
-  });
-
-  it('renders a left image', () => {
-    const imageUrl = 'LeftFoo.jpg';
-    const wrapper = shallow(<Content beforeImageSrc={imageUrl}>Sup</Content>);
-
-    expect(
-      (wrapper.find(Row).prop('before')! as React.ReactElement<{ src: string }>).props.src,
-    ).toBe(imageUrl);
-  });
-
-  it('renders a right image', () => {
-    const imageUrl = 'RightFoo.jpg';
-    const wrapper = shallow(<Content afterImageSrc={imageUrl}>Sup</Content>);
-
-    expect(
-      (wrapper.find(Row).prop('after') as React.ReactElement<{ src: string }>)!.props.src,
-    ).toBe(imageUrl);
-  });
-
   it('renders a button if `onClick` is provided', () => {
     const onClick = () => {};
     const wrapper = shallow(<Content onClick={onClick}>Sup</Content>);
@@ -45,6 +21,23 @@ describe('<Card />', () => {
     );
   });
 
+  it('renders after content with no padding', () => {
+    const after = '~~After~~';
+    const wrapper = shallow(
+      <Content noPaddingAfter after={after}>
+        Sup
+      </Content>,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('after') as React.ReactElement).hasClass('after')).toBe(
+      true,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('after') as React.ReactElement).hasClass('side_noPadding')).toBe(
+      true,
+    );
+  });
+
   it('renders before content', () => {
     const before = '~*Before*~';
     const wrapper = shallow(<Content before={before}>Sup</Content>);
@@ -54,11 +47,54 @@ describe('<Card />', () => {
     );
   });
 
+  it('renders before content with no padding', () => {
+    const before = '~~Before~~';
+    const wrapper = shallow(
+      <Content noPaddingBefore before={before}>
+        Sup
+      </Content>,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('before') as React.ReactElement).hasClass('before')).toBe(
+      true,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('before') as React.ReactElement).hasClass('side_noPadding')).toBe(
+      true,
+    );
+  });
+
+  it('renders top content', () => {
+    const top = '~*Top*~';
+    const wrapper = shallow(<Content top={top}>Sup</Content>);
+
+    expect(wrapper.contains(top)).toBe(true);
+  });
+
+
+
+  it('renders top content with no padding', () => {
+    const top = '~~Top~~';
+    const wrapper = shallow(
+      <Content noPaddingTop top={top}>
+        Sup
+      </Content>,
+    );
+
+    expect(wrapper.find(Spacing).at(0).prop('horizontal')).toBe(
+      0,
+    );
+
+    expect(wrapper.find(Spacing).at(0).prop('top')).toBe(
+      0,
+    );
+  });
+
   it('renders before content as clickable', () => {
-    const imageUrl = 'LeftFoo.jpg';
+    const before = '~*Before*~';
     const handleClick = jest.fn();
     const wrapper = shallow(
-      <Content beforeImageSrc={imageUrl} onBeforeImageClick={handleClick}>
+      <Content before={before} onBeforeClick={handleClick}>
         Sup
       </Content>,
     );
@@ -70,10 +106,10 @@ describe('<Card />', () => {
   });
 
   it('renders after content as clickable', () => {
-    const imageUrl = 'RightFoo.jpg';
+    const after = '~~After~~';
     const handleClick = jest.fn();
     const wrapper = shallow(
-      <Content afterImageSrc={imageUrl} onAfterImageClick={handleClick}>
+      <Content after={after} onAfterClick={handleClick}>
         Sup
       </Content>,
     );
@@ -96,8 +132,36 @@ describe('<Card />', () => {
     expect(shallow(wrapper.find(Row).prop('after') as React.ReactElement).contains(after)).toBe(
       true,
     );
+
     expect(shallow(wrapper.find(Row).prop('before') as React.ReactElement).contains(before)).toBe(
       true,
     );
+  });
+
+  it('renders before, after, and top content', () => {
+    const after = '~~After~~';
+    const before = '~*Before*~';
+    const top = '~*Top*~';
+    const wrapper = shallow(
+      <Content noPaddingAfter after={after} before={before} top={top}>
+        Sup
+      </Content>,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('after') as React.ReactElement).contains(after)).toBe(
+      true,
+    );
+
+    expect(shallow(wrapper.find(Row).prop('before') as React.ReactElement).contains(before)).toBe(
+      true,
+    );
+
+    expect(wrapper.contains(top)).toBe(true);
+  });
+
+  it('renders middleAlign content', () => {
+    const wrapper = shallow(<Content middleAlign>Sup</Content>);
+
+    expect(wrapper.find(Row).prop('middleAlign')).toBe(true);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

making the card content more flexible and generalized.

updated examples to show how images can be used in before/after/top props.

- Removed:
  - `afterImageSrc`
  - `beforeImageSrc`
  - `small`
  - `large`
- New:
  - `noPaddingAfter` to do full cover after content
  - `noPaddingBefore` to do full cover before content
  - `noPaddingTop` to do full cover top content
- Generalized:
  - `topImageSrc` -> `top` (string to node)
  - `onAfterImageClick` -> `onAfterClick`
  - `onBeforeImageClick` -> `onBeforeClick`

## changelog

small before image
```jsx
// before
<Card>
  <Content small beforeImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingBefore
    before={<Image background cover alt="" height="100%" width={80} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

before image
```jsx
// before
<Card>
  <Content beforeImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingBefore
    before={<Image background cover alt="" height="100%" width={152} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

large before image
```jsx
// before
<Card>
  <Content large beforeImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingBefore
    before={<Image background cover alt="" height="100%" width={195} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

small after image
```jsx
// before
<Card>
  <Content small afterImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingAfter
    after={<Image background cover alt="" height="100%" width={80} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

after image
```jsx
// before
<Card>
  <Content afterImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingAfter
    after={<Image background cover alt="" height="100%" width={152} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

large after image
```jsx
// before
<Card>
  <Content large afterImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingAfter
    after={<Image background cover alt="" height="100%" width={195} src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

top image
```jsx
// before
<Card>
  <Content topImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingTop
    top={<Image background cover alt="" height={105} width="100%" src=}moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

large top image
```jsx
// before
<Card>
  <Content large topImageSrc="moon.jpg">
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingTop
    top={<Image background cover alt="" height={195} width="100%" src="moon.jpg" />}
  >
    Moon
  </Content>
</Card>
```

onBeforeImageClick -> onBeforeClick
```jsx
// before
<Card>
  <Content beforeImageSrc="moon.jpg" onBeforeImageClick={action('onClick before')}>
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingBefore
    before={<Image background cover alt="" height="100%" width={152} src="moon.jpg" />}
    onBeforeClick={action('onClick before')}
  >
    Moon
  </Content>
</Card>
```

onAfterImageClick -> onAfterClick
```jsx
// before
<Card>
  <Content beforeImageSrc="moon.jpg" onAfterImageClick={action('onClick after')}>
    Moon
  </Content>
</Card>

// after
<Card>
  <Content
    noPaddingBefore
    before={<Image background cover alt="" height="100%" width={152} src="moon.jpg" />}
    onAfterClick={action('onClick after')}
  >
    Moon
  </Content>
</Card>
```

## Motivation and Context

card was getting really overloaded and BUs needed more than just images. so, making things more generalized.

## Testing

- storybook
- tests

## Screenshots

<img width="1341" alt="Core : Card - A card with a top featured image   ⋅ Storybook 2020-02-17 05-41-12" src="https://user-images.githubusercontent.com/306275/74660863-cb188400-514b-11ea-8f27-10ffa13371b3.png">
<img width="1341" alt="Core : Card - A card with a left featured image   ⋅ Storybook 2020-02-17 05-41-28" src="https://user-images.githubusercontent.com/306275/74660878-cf44a180-514b-11ea-8011-35ac3883ca14.png">
<img width="1341" alt="Core : Card - A card with a right featured image   ⋅ Storybook 2020-02-17 05-41-52" src="https://user-images.githubusercontent.com/306275/74660880-d075ce80-514b-11ea-9f19-26845ec7718c.png">
<img width="981" alt="Core : Card - A card with a right featured image   ⋅ Storybook 2020-02-17 05-42-55" src="https://user-images.githubusercontent.com/306275/74660881-d10e6500-514b-11ea-8971-9a7b06fb0570.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
