### PR TITLE
breaking(CheckBox, FormField, RadioButton): Remove topAlign and default to top alignment. Add middleAlign option.

### DIFF
--- a/packages/core/src/components/CheckBox/index.tsx
+++ b/packages/core/src/components/CheckBox/index.tsx
@@ -6,14 +6,14 @@ import Text from '../Text';
 
 export type CheckBoxProps<T extends string> = BaseCheckBoxProps<T> &
   FormFieldProps & {
-    /** Top align content. */
-    topAlign?: boolean;
+    /** Middle align content. */
+    middleAlign?: boolean;
   };
 
 /** A controlled checkbox field. */
 export default function CheckBox<T extends string = string>(props: CheckBoxProps<T>) {
   const { children, fieldProps, inputProps } = partitionFieldProps<T, CheckBoxProps<T>>(props);
-  const { topAlign, ...restProps } = inputProps;
+  const { middleAlign, ...restProps } = inputProps;
   const [id] = useState(() => uuid());
 
   return (
@@ -26,7 +26,7 @@ export default function CheckBox<T extends string = string>(props: CheckBoxProps
       id={props.id || id}
       hideLabel={fieldProps.hideLabel || inputProps.button}
       renderFullWidth={inputProps.button}
-      topAlign={topAlign}
+      middleAlign={middleAlign}
     >
       <BaseCheckBox<T>
         value="1"

--- a/packages/core/src/components/CheckBox/index.tsx
+++ b/packages/core/src/components/CheckBox/index.tsx
@@ -26,7 +26,7 @@ export default function CheckBox<T extends string = string>(props: CheckBoxProps
       id={props.id || id}
       hideLabel={fieldProps.hideLabel || inputProps.button}
       renderFullWidth={inputProps.button}
-      middleAlign={middleAlign}
+      topAlign={!middleAlign}
     >
       <BaseCheckBox<T>
         value="1"

--- a/packages/core/src/components/CheckBox/story.tsx
+++ b/packages/core/src/components/CheckBox/story.tsx
@@ -19,9 +19,9 @@ aStandardCheckboxField.story = {
 export function inDifferentSizes() {
   return (
     <>
-      <CheckBox small name="cb-small" label="Small" onChange={action('onChange')} />
-      <CheckBox name="cb-regular" label="Regular" onChange={action('onChange')} />
-      <CheckBox large name="cb-large" label="Large" onChange={action('onChange')} />
+      <CheckBox small middleAlign name="cb-small" label="Small" onChange={action('onChange')} />
+      <CheckBox middleAlign name="cb-regular" label="Regular" onChange={action('onChange')} />
+      <CheckBox large middleAlign name="cb-large" label="Large" onChange={action('onChange')} />
     </>
   );
 }

--- a/packages/core/src/components/CheckBox/story.tsx
+++ b/packages/core/src/components/CheckBox/story.tsx
@@ -78,12 +78,12 @@ withALabelDescriptionInAnIndeterminateState.story = {
   name: 'With a label description in an indeterminate state.',
 };
 
-export function withATopAlignment() {
+export function withAMiddleAlignment() {
   return (
     <>
-      <CheckBox checked topAlign name="cb-topalign" label="Label" onChange={action('onChange')} />
+      <CheckBox checked middleAlign name="cb-topalign" label="Label" onChange={action('onChange')} />
       <CheckBox
-        topAlign
+        middleAlign
         name="cb-topalign"
         label="Label"
         labelDescription="This is a small label description."
@@ -93,8 +93,8 @@ export function withATopAlignment() {
   );
 }
 
-withATopAlignment.story = {
-  name: 'With a top alignment.',
+withAMiddleAlignment.story = {
+  name: 'With a middle alignment.',
 };
 
 export function markedAsOptional() {

--- a/packages/core/src/components/CheckBox/story.tsx
+++ b/packages/core/src/components/CheckBox/story.tsx
@@ -81,7 +81,13 @@ withALabelDescriptionInAnIndeterminateState.story = {
 export function withAMiddleAlignment() {
   return (
     <>
-      <CheckBox checked middleAlign name="cb-topalign" label="Label" onChange={action('onChange')} />
+      <CheckBox
+        checked
+        middleAlign
+        name="cb-topalign"
+        label="Label"
+        onChange={action('onChange')}
+      />
       <CheckBox
         middleAlign
         name="cb-topalign"

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -44,6 +44,8 @@ export type FormFieldProps = {
   suffix?: React.ReactNode;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
+  /** @ignore Top align. (Internal use only) */
+  topAlign?: boolean;
 };
 
 export type PrivateProps = FormFieldProps & {
@@ -92,6 +94,7 @@ export default function FormField({
   suffix,
   middleAlign,
   styleSheet,
+  topAlign,
 }: PrivateProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetFormField);
 
@@ -121,9 +124,7 @@ export default function FormField({
         noSpacing && styles.field_noSpacing,
       )}
     >
-      <div
-        className={cx(inline && styles.content_inline, middleAlign && styles.content_middleAlign)}
-      >
+      <div className={cx(inline && styles.content_inline, topAlign && styles.content_topAlign)}>
         {renderBeforeLabel && content}
 
         <label

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -59,7 +59,7 @@ export type PrivateProps = FormFieldProps & {
   renderLargeLabel?: boolean;
   /** @ignore Stretches the label to 100%. */
   stretchLabel?: boolean;
-  /** @ignore Top align content. */
+  /** @ignore Middle align content. */
   middleAlign?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -121,7 +121,9 @@ export default function FormField({
         noSpacing && styles.field_noSpacing,
       )}
     >
-      <div className={cx(inline && styles.content_inline, middleAlign && styles.content_middleAlign)}>
+      <div
+        className={cx(inline && styles.content_inline, middleAlign && styles.content_middleAlign)}
+      >
         {renderBeforeLabel && content}
 
         <label

--- a/packages/core/src/components/FormField/index.tsx
+++ b/packages/core/src/components/FormField/index.tsx
@@ -60,7 +60,7 @@ export type PrivateProps = FormFieldProps & {
   /** @ignore Stretches the label to 100%. */
   stretchLabel?: boolean;
   /** @ignore Top align content. */
-  topAlign?: boolean;
+  middleAlign?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
@@ -90,7 +90,7 @@ export default function FormField({
   prefix,
   small,
   suffix,
-  topAlign,
+  middleAlign,
   styleSheet,
 }: PrivateProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetFormField);
@@ -121,7 +121,7 @@ export default function FormField({
         noSpacing && styles.field_noSpacing,
       )}
     >
-      <div className={cx(inline && styles.content_inline, topAlign && styles.content_topAlign)}>
+      <div className={cx(inline && styles.content_inline, middleAlign && styles.content_middleAlign)}>
         {renderBeforeLabel && content}
 
         <label

--- a/packages/core/src/components/FormField/styles.ts
+++ b/packages/core/src/components/FormField/styles.ts
@@ -21,11 +21,11 @@ export const styleSheetFormField: StyleSheet = ({ unit }) => ({
 
   content_inline: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
   },
 
-  content_middleAlign: {
-    alignItems: 'center',
+  content_topAlign: {
+    alignItems: 'flex-start',
   },
 
   label: {

--- a/packages/core/src/components/FormField/styles.ts
+++ b/packages/core/src/components/FormField/styles.ts
@@ -21,11 +21,11 @@ export const styleSheetFormField: StyleSheet = ({ unit }) => ({
 
   content_inline: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
   },
 
-  content_topAlign: {
-    alignItems: 'flex-start',
+  content_middleAlign: {
+    alignItems: 'center',
   },
 
   label: {

--- a/packages/core/src/components/RadioButton/index.tsx
+++ b/packages/core/src/components/RadioButton/index.tsx
@@ -9,8 +9,8 @@ const stateProp = mutuallyExclusiveTrueProps('checked', 'indeterminate');
 
 export type RadioButtonProps<T extends string> = Omit<BaseRadioButtonProps<T>, 'value'> &
   FormFieldProps & {
-    /** Top align content. */
-    topAlign?: boolean;
+    /** Middle align content. */
+    middleAlign?: boolean;
     /** Unique value for this radio. */
     value: string;
   };
@@ -18,7 +18,7 @@ export type RadioButtonProps<T extends string> = Omit<BaseRadioButtonProps<T>, '
 /** A controlled radio button field. */
 function RadioButton<T extends string = string>(props: RadioButtonProps<T>) {
   const { children, fieldProps, inputProps } = partitionFieldProps<T, RadioButtonProps<T>>(props);
-  const { topAlign, ...restProps } = inputProps;
+  const { middleAlign, ...restProps } = inputProps;
   const [id] = useState(() => uuid());
 
   return (
@@ -31,7 +31,7 @@ function RadioButton<T extends string = string>(props: RadioButtonProps<T>) {
       id={props.id || id}
       hideLabel={fieldProps.hideLabel || inputProps.button}
       renderFullWidth={inputProps.button}
-      topAlign={topAlign}
+      middleAlign={middleAlign}
     >
       <BaseRadioButton {...restProps} id={props.id || id} hideLabel={fieldProps.hideLabel}>
         {children || (

--- a/packages/core/src/components/RadioButton/index.tsx
+++ b/packages/core/src/components/RadioButton/index.tsx
@@ -31,7 +31,7 @@ function RadioButton<T extends string = string>(props: RadioButtonProps<T>) {
       id={props.id || id}
       hideLabel={fieldProps.hideLabel || inputProps.button}
       renderFullWidth={inputProps.button}
-      middleAlign={middleAlign}
+      topAlign={!middleAlign}
     >
       <BaseRadioButton {...restProps} id={props.id || id} hideLabel={fieldProps.hideLabel}>
         {children || (

--- a/packages/core/src/components/RadioButton/story.tsx
+++ b/packages/core/src/components/RadioButton/story.tsx
@@ -24,14 +24,22 @@ export function inDifferentSizes() {
     <>
       <RadioButton
         small
+        middleAlign
         name="radio-small"
         label="Small"
         value="foo"
         onChange={action('onChange')}
       />
-      <RadioButton name="radio-regular" label="Regular" value="foo" onChange={action('onChange')} />
+      <RadioButton
+        middleAlign
+        name="radio-regular"
+        label="Regular"
+        value="foo"
+        onChange={action('onChange')}
+      />
       <RadioButton
         large
+        middleAlign
         name="radio-large"
         label="Large"
         value="foo"

--- a/packages/core/src/components/RadioButton/story.tsx
+++ b/packages/core/src/components/RadioButton/story.tsx
@@ -96,19 +96,19 @@ withALabelDescriptionInAIndeterminateState.story = {
   name: 'With a label description in a indeterminate state.',
 };
 
-export function withATopAlignment() {
+export function withAMiddleAlignment() {
   return (
     <>
       <RadioButton
         checked
-        topAlign
+        middleAlign
         name="radio-topalign"
         label="Label"
         value="foo"
         onChange={action('onChange')}
       />
       <RadioButton
-        topAlign
+        middleAlign
         name="radio-topalign"
         label="Label"
         value="foo"
@@ -119,8 +119,8 @@ export function withATopAlignment() {
   );
 }
 
-withATopAlignment.story = {
-  name: 'With a top alignment.',
+withAMiddleAlignment.story = {
+  name: 'With a middle alignment.',
 };
 
 export function markedAsOptional() {
@@ -177,7 +177,7 @@ export function asAClickableButton() {
   return (
     <RadioButton
       button
-      topAlign
+      middleAlign
       name="radio-basic"
       label="Label"
       labelDescription="This is a label description."

--- a/packages/core/src/components/private/BaseCheckBox.tsx
+++ b/packages/core/src/components/private/BaseCheckBox.tsx
@@ -13,8 +13,7 @@ export const styleSheetCheckbox: StyleSheet = theme => {
 
     checkbox: {
       padding: 0,
-      margin: 0,
-      marginTop: 2,
+      margin: '2px 0px',
       width: 18,
       height: 18,
       display: 'block',

--- a/packages/core/src/components/private/BaseRadioButton.tsx
+++ b/packages/core/src/components/private/BaseRadioButton.tsx
@@ -13,8 +13,7 @@ export const styleSheetRadioButton: StyleSheet = theme => {
 
     radio: {
       padding: 0,
-      margin: 0,
-      marginTop: 2,
+      margin: '2px 0px',
       width: 18,
       height: 18,
       display: 'block',

--- a/packages/forms/src/components/Form/story.tsx
+++ b/packages/forms/src/components/Form/story.tsx
@@ -248,7 +248,6 @@ export function withAllFields() {
         {CB => (
           <div>
             <CB
-              topAlign
               value="foo"
               label="Foo"
               labelDescription={
@@ -259,7 +258,6 @@ export function withAllFields() {
             />
 
             <CB
-              topAlign
               value="bar"
               label="Bar"
               labelDescription={
@@ -270,7 +268,6 @@ export function withAllFields() {
             />
 
             <CB
-              topAlign
               value="baz"
               label="Baz"
               labelDescription={


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- For `CheckBox` and `RadioButton`, default to top alignment instead of middle alignment
  - [x] remove `topAlign` prop
  - [x] add `middleAlign` prop

## Motivation and Context

new ui default

## Testing

storybook

## Screenshots

<img width="850" alt="Core : RadioButton - With a middle alignment   ⋅ Storybook 2020-02-17 08-05-42" src="https://user-images.githubusercontent.com/306275/74669632-6c0f3b00-515c-11ea-8e1f-1e1247297633.png">

<img width="850" alt="Core : CheckBox - With a middle alignment   ⋅ Storybook 2020-02-17 08-06-12" src="https://user-images.githubusercontent.com/306275/74669637-6dd8fe80-515c-11ea-980b-c7e62096bc8c.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
