### PR TITLE
perf(datatable): remove unnecessary <Spacing> wrappers

### DIFF
--- a/.storybook/components/DataTable/DataTableData.jsx
+++ b/.storybook/components/DataTable/DataTableData.jsx
@@ -1,15 +1,15 @@
 import { STATUS_OPTIONS } from '@airbnb/lunar/src/components/DataTable/constants';
 
-export function generateRandomData() {
-  return new Array(50).fill(0).map((x, i) => ({
+export function generateRandomData(n = 500) {
+  return new Array(n).fill(0).map((x, i) => ({
     data: {
-      number: `${i + 1} `.repeat(i + 1),
+      number: `${i + 1} `.repeat(Math.round(Math.random() * 100)),
       zero: x,
     },
     metadata: {
       children: new Array(2).fill(0).map((x, j) => ({
         data: {
-          number: `${j + 1} `.repeat(i + 1),
+          number: `${j + 1} `.repeat(Math.round(Math.random() * i) + 1),
           zero: x,
         },
       })),
@@ -88,6 +88,24 @@ export default function getData() {
               tenureDays: 1095,
               menu: '',
               cats: 3,
+            },
+          },
+          {
+            data: {
+              name: 'Random Staff',
+              jobTitle: 'Sales',
+              tenureDays: 105,
+              menu: '',
+              cats: 3,
+            },
+          },
+          {
+            data: {
+              name: 'Joe Doe',
+              jobTitle: 'Operational',
+              tenureDays: 183,
+              menu: '',
+              cats: 50,
             },
           },
         ],

--- a/.storybook/components/DataTable/DataTableData.jsx
+++ b/.storybook/components/DataTable/DataTableData.jsx
@@ -1,6 +1,6 @@
 import { STATUS_OPTIONS } from '@airbnb/lunar/src/components/DataTable/constants';
 
-export function generateRandomData(n = 500) {
+export function generateRandomData(n = 800) {
   return new Array(n).fill(0).map((x, i) => ({
     data: {
       number: `${i + 1} `.repeat(Math.round(Math.random() * 100)),

--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -24,6 +24,8 @@ type ColumnLabelsProps = {
   style: React.CSSProperties;
 };
 
+const { ASC, DESC } = SortDirection;
+
 /** See https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultHeaderRowRenderer.js.
     In order to overwrite the existing labels and carets in defaultHeaderRowRenderer,
     we clone them from props (children[0] = label, children[1] = carets), build around their data. */
@@ -57,67 +59,56 @@ export default function ColumnLabels({
       height: getHeight(rowHeight, columnHeaderHeight),
     };
 
-    const rightAlignmentStyle: React.CSSProperties = {
-      justifyContent: 'flex-end',
-      width: '100%',
-    };
-
     const newColumns = columns.map((col, idx) => {
       if (!React.isValidElement(col)) {
         return col;
       }
 
       const { children } = col.props;
+      const isLeftmost = idx === leftmostIdx;
+      const isRightmost = idx === columns.length - 1;
       const key = children[0].props.children;
       const label = columnToLabel[key]
         ? columnToLabel[key]
         : key && caseColumnLabel(key, columnLabelCase!);
-      const sort = children[1] && children[1].props.sortDirection;
-
-      const isLeftmost = idx === leftmostIdx;
-      const isRightmost = idx === columns.length - 1;
+      const sortDirection = children[1] && children[1].props.sortDirection;
       const indent = !((expandable || selectable) && isLeftmost);
-
       const showDivider = showColumnDividers && !!label && !isRightmost;
-
       const sortable =
         !columnMetadata || !columnMetadata[key] || columnMetadata[key].disableSorting !== 1;
 
       const newHeader = (
-        <Spacing left={indent ? 2 : 0}>
-          <div style={heightStyle} className={cx(showDivider && styles && styles.column_divider)}>
-            <div
-              style={
-                columnMetadata && columnMetadata[key] && columnMetadata[key].rightAlign
-                  ? rightAlignmentStyle
-                  : {}
-              }
-              className={cx(styles && styles.headerRow)}
-            >
-              <Text micro muted>
-                {label}
-              </Text>
+        <div
+          style={heightStyle}
+          className={cx(
+            styles?.headerRow,
+            !!columnMetadata?.[key]?.rightAlign && styles?.columnLabelRightAligned,
+            indent && styles?.columnLabelIndented,
+            showDivider && styles?.columnDivider,
+          )}
+        >
+          <Text micro muted>
+            {label}
+          </Text>
 
-              {label && sortable && (
-                <Spacing inline left={0.5}>
-                  <SortCarets
-                    down
-                    up
-                    enableDown={sort === SortDirection.DESC}
-                    enableUp={sort === SortDirection.ASC}
-                  />
-                </Spacing>
-              )}
-            </div>
-          </div>
-        </Spacing>
+          {label && sortable && (
+            <Spacing inline left={0.5}>
+              <SortCarets
+                down
+                up
+                enableDown={sortDirection === DESC}
+                enableUp={sortDirection === ASC}
+              />
+            </Spacing>
+          )}
+        </div>
       );
 
       return React.cloneElement(col, col.props, newHeader);
     });
 
     return (
-      <div role="row" style={style} className={cx(className, styles && styles.column_header)}>
+      <div role="row" style={style} className={cx(className, styles?.columnHeader)}>
         {newColumns}
       </div>
     );

--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -104,7 +104,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     background: getRowColor(
       expandedDataList[index],
       index,
-      this.props.zebra || false,
+      this.props.zebra ?? false,
       this.props.theme,
     ),
     display: 'flex',
@@ -501,7 +501,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     return (
       <>
         {this.shouldRenderTableHeader() && this.renderTableHeader(width!)}
-        <div className={cx(styles.table_container, { width })}>
+        <div className={cx(styles.tableContainer, { width })}>
           <Table
             ref={propagateRef}
             height={tableHeight}

--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -82,7 +82,7 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     changeLog: {},
     expandedRows: new Set(),
     selectedRows: {},
-    sortBy: this.props.sortByOverride || '',
+    sortBy: this.props.sortByOverride ?? '',
     sortDirection: this.props.sortDirectionOverride!,
     editMode: false,
   };

--- a/packages/core/src/components/DataTable/DefaultRenderer.tsx
+++ b/packages/core/src/components/DataTable/DefaultRenderer.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import Text from '../Text';
 import { RendererProps } from './types';
 
 export default function DefaultRenderer({ row, keyName }: RendererProps) {
   const content = row.rowData.data[keyName];
-
-  return <Text>{typeof content === 'string' || typeof content === 'number' ? content : null}</Text>;
+  return <div>{typeof content === 'string' || typeof content === 'number' ? content : null}</div>;
 }

--- a/packages/core/src/components/DataTable/TableHeader.tsx
+++ b/packages/core/src/components/DataTable/TableHeader.tsx
@@ -122,7 +122,7 @@ export function TableHeader({
 
   return (
     <div style={dimensionStyles}>
-      <div className={cx(styles.tableHeader_inner)}>
+      <div className={cx(styles.tableHeaderInner)}>
         {label}
         {headerButtons}
       </div>

--- a/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
+++ b/packages/core/src/components/DataTable/columns/renderDataColumns.tsx
@@ -47,7 +47,7 @@ export default function renderDataColumns<T>(
   const renderCell = (key: string, columnIndex: number, row: VirtualRow<T>) => {
     const { metadata } = row.rowData;
     const { isChild } = metadata;
-    const customRenderer = renderers && renderers[key];
+    const customRenderer = renderers?.[key];
     const isLeftmost = columnIndex === 0;
     const indentSize = !expandable || !isLeftmost ? 2 : 2.5;
     const spacing = isChild || !((expandable || selectable) && isLeftmost) ? indentSize : 0;
@@ -55,12 +55,12 @@ export default function renderDataColumns<T>(
       row,
       keyName: key as keyof T,
       onEdit,
-      zebra: zebra || false,
+      zebra: zebra ?? false,
       editMode,
       theme,
     };
 
-    if (metadata && metadata.colSpanKey && renderers) {
+    if (metadata?.colSpanKey && renderers) {
       if (isLeftmost) {
         const colSpanRenderer = renderers[metadata.colSpanKey];
 
@@ -70,7 +70,7 @@ export default function renderDataColumns<T>(
       }
     }
 
-    const contents = React.createElement(customRenderer || DefaultRenderer, rendererArguments);
+    const contents = React.createElement(customRenderer ?? DefaultRenderer, rendererArguments);
 
     return (
       <Spacing left={spacing} right={2}>
@@ -113,11 +113,9 @@ export default function renderDataColumns<T>(
     const widthProperties: WidthProperties = {};
     widthPropertiesOptions.forEach(property => {
       widthProperties[property] =
-        columnMetadata &&
-        columnMetadata[key] !== undefined &&
-        columnMetadata[key][property] !== undefined
-          ? columnMetadata[key][property]
-          : DEFAULT_WIDTH_PROPERTIES[property];
+        columnMetadata?.[key]?.[property] === undefined
+          ? DEFAULT_WIDTH_PROPERTIES[property]
+          : columnMetadata[key][property];
     });
 
     const isRightmost = idx === keys.length - 1;
@@ -133,10 +131,7 @@ export default function renderDataColumns<T>(
         maxWidth={widthProperties.maxWidth}
         minWidth={widthProperties.minWidth}
         cellRenderer={columnCellRenderer(idx)}
-        className={cx(
-          styles && styles.column,
-          showColumnDividers && !isRightmost && styles && styles.column_divider,
-        )}
+        className={cx(styles?.column, showColumnDividers && !isRightmost && styles?.columnDivider)}
       />
     );
   });

--- a/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
+++ b/packages/core/src/components/DataTable/columns/renderExpandableColumn.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Column } from 'react-virtualized';
-import Spacing from '../../Spacing';
 import ExpandableIcon from '../../ExpandableIcon';
 import { WithStylesProps } from '../../../composers/withStyles';
 import { EXPANDABLE_COLUMN_WIDTH } from '../constants';
@@ -18,15 +17,13 @@ export default function renderExpandableColumn(
     if (children && children.length > 0) {
       return (
         <div
-          className={cx(styles.expand_caret)}
+          className={cx(styles.expandCaret)}
           role="button"
           tabIndex={0}
           onClick={expandRow(originalIndex)}
           onKeyPress={expandRow(originalIndex)}
         >
-          <Spacing left={1.5}>
-            <ExpandableIcon expanded={expandedRows.has(originalIndex)} size="1.6em" />
-          </Spacing>
+          <ExpandableIcon expanded={expandedRows.has(originalIndex)} />
         </div>
       );
     }

--- a/packages/core/src/components/DataTable/styles.ts
+++ b/packages/core/src/components/DataTable/styles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from '../../hooks/useStyles';
 
-export const styleSheetDataTable: StyleSheet = ({ ui }) => ({
-  table_container: {
+export const styleSheetDataTable: StyleSheet = ({ ui, unit }) => ({
+  tableContainer: {
     overflowX: 'auto',
   },
   headerRow: {
@@ -10,15 +10,22 @@ export const styleSheetDataTable: StyleSheet = ({ ui }) => ({
     height: '100%',
     textTransform: 'none',
   },
-  column_header: {
+  columnHeader: {
     borderBottom: ui.border,
     cursor: 'pointer',
   },
   column: {
     height: 'inherit',
   },
-  column_divider: {
+  columnDivider: {
     borderRight: ui.border,
+  },
+  columnLabelIndented: {
+    marginLeft: 2 * unit,
+  },
+  columnLabelRightAligned: {
+    justifyContent: 'flex-end',
+    width: '100%',
   },
   rowContainer: {
     height: '100%',
@@ -29,13 +36,20 @@ export const styleSheetDataTable: StyleSheet = ({ ui }) => ({
     whiteSpace: 'normal',
     width: '100%', // this is important for consumers who need full-width cells
   },
-  expand_caret: {
+  expandCaret: {
     cursor: 'pointer',
+    marginLeft: 1.5 * unit,
+    '@selectors': {
+      '> svg': {
+        width: '1.6em',
+        height: '1.6em',
+      },
+    },
   },
 });
 
 export const styleSheetTableHeader: StyleSheet = ({ unit, color, ui }) => ({
-  tableHeader_inner: {
+  tableHeaderInner: {
     background: color.accent.bg,
     display: 'flex',
     alignItems: 'center',

--- a/packages/core/src/components/Timeline/story.tsx
+++ b/packages/core/src/components/Timeline/story.tsx
@@ -14,15 +14,15 @@ export default {
 };
 
 export function basicFunctionality() {
-  const now = new Date();
+  const now = new Date(2020, 2, 2, 10, 15);
 
-  const nextMonth = new Date();
+  const nextMonth = new Date(now);
   nextMonth.setMonth(now.getMonth() + 1);
 
-  const lastMonth = new Date();
+  const lastMonth = new Date(now);
   lastMonth.setMonth(now.getMonth() - 1);
 
-  const lastYear = new Date();
+  const lastYear = new Date(now);
   lastYear.setFullYear(now.getFullYear() - 1);
 
   return (


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf @schillerk @kristw 

## Description

This replaces some `<Spacing>` and `<Text>` wrappers in DataTable with native HTML elements or CSS rules in `DataTable/styles`.

Also fixed a bunch of ESLint warnings.

## Motivation and Context

Too many nested components may have negative impact on rendering
performance. Especially for `<Spacing>` and `<Text>` that utilizes [useStyles](https://github.com/milesj/aesthetic/blob/f65749f77908fefc8ab2d22b11734a7823e6c628/packages/react-legacy/src/useStyles.ts#L19) in `aesthetics`, there is certain overhead in parsing JSS stylesheets. Each call of [createStyleSheet](https://github.com/milesj/aesthetic/blob/f65749f77908fefc8ab2d22b11734a7823e6c628/packages/core-legacy/src/Adapter.tsx#L71) takes about 1ms and it adds up for big tables.

## Testing

1. When in master branch, change `[generateRandomData](https://github.com/airbnb/lunar/blob/a6b8d55c2e71c636a28e7291fe6c1767966b62f3/.storybook/components/DataTable/DataTableData.jsx#L3)` in `DataTableData.jsx` and generate 800 rows instead of 50.
2. Go to [core/datatable/a table with a search box](http://localhost:6006/?path=/story/core-datatable--a-table-with-a-search-box-and-parent-height), switch back and forth between stories, feel the difference in loading speed.

## Screenshots

Before:
![Snip20200221_12](https://user-images.githubusercontent.com/335541/75063711-4b1b5280-549a-11ea-915a-f3da55ef60a8.png)

After:
![Snip20200221_16](https://user-images.githubusercontent.com/335541/75063715-4d7dac80-549a-11ea-9108-562de2a59ba6.png)

It saves about 1.3s of rendering time for an 800-record simple text table.

## Checklist

- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
