### PR TITLE
fix(Timeline): Correctly import IconRecord and export Timeline/Item

### DIFF
--- a/packages/core/src/components/Timeline/Item.tsx
+++ b/packages/core/src/components/Timeline/Item.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import IconRecord from '@airbnb/lunar-icons/src/interface/IconRecord';
+import IconRecord from '@airbnb/lunar-icons/lib/interface/IconRecord';
 import useStyles from '../../hooks/useStyles';
 import { styleSheetItem } from './styles';
 import Text from '../Text';

--- a/packages/core/src/components/Timeline/index.tsx
+++ b/packages/core/src/components/Timeline/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import List from '../List';
+import Item from './Item';
+
+export { Item }; // This confuses Storybook and causes Timeline's props to be Timeline/Item's.
 
 export type TimelineProps = {
   /** Collection of timeline items. */

--- a/packages/core/src/components/Timeline/story.tsx
+++ b/packages/core/src/components/Timeline/story.tsx
@@ -62,4 +62,7 @@ export function basicFunctionality() {
 
 basicFunctionality.story = {
   name: 'Basic functionality',
+
+  // Since Timeline uses relative datetime, this will _always_ render a happo visual diff.
+  parameters: { happo: false },
 };


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- Import path for `IconRecord` was incorrect - works locally and in storybook but not when consuming the npm package
- Exported `Timeline/Item` from index. This seems to confuse Storybook and the props for `Timeline/Item` are shown when viewing `Timeline` itself.
- **Disable happo for `Timeline` component**, see: https://github.com/airbnb/lunar/pull/327#issuecomment-591682052

## Motivation and Context

Can't use `Timeline` without `IconRecord` import change

## Testing

Local storybook

## Screenshots

No visual change

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
