### PR TITLE
update(Aside): Add external expanded support.

### DIFF
--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import useStyles, { StyleSheet } from '@airbnb/lunar/lib/hooks/useStyles';
 import Tab from './private/Tab';
 
@@ -53,6 +53,8 @@ export type Props = {
   collapsible?: boolean;
   /** Content within the column. */
   children: NonNullable<React.ReactNode>;
+  /** Externally control the expanded state. Typically not required. */
+  expanded?: boolean;
   /** Remove padding from column. */
   noPadding?: boolean;
   /** Convert column to a scrollable container. */
@@ -69,23 +71,34 @@ export default function Aside({
   before,
   children,
   collapsible,
+  expanded,
   noPadding,
   scrollable,
   width,
   onCollapseToggle,
 }: Props) {
   const [styles, cx] = useStyles(styleSheet);
-  const [expanded, setExpanded] = useState(true);
+  const [isExpanded, setExpanded] = useState(true);
 
   const handleCollapseToggle: React.DOMAttributes<HTMLButtonElement>['onClick'] = collapsible
     ? () => {
         setExpanded(prev => !prev);
 
         if (onCollapseToggle) {
-          onCollapseToggle(!expanded);
+          onCollapseToggle(!isExpanded);
         }
       }
     : undefined;
+
+  useEffect(() => {
+    if (expanded !== undefined && expanded !== isExpanded) {
+      setExpanded(expanded);
+
+      if (onCollapseToggle) {
+        onCollapseToggle(expanded);
+      }
+    }
+  }, [expanded, isExpanded, onCollapseToggle]);
 
   return (
     <aside
@@ -96,14 +109,14 @@ export default function Aside({
         collapsible && styles.aside_collapsible,
         scrollable && styles.aside_scrollable,
         {
-          width: collapsible && !expanded ? 0 : width,
+          width: collapsible && !isExpanded ? 0 : width,
         },
       )}
     >
       {collapsible && (
         <Tab
           bordered={!!before || !!after}
-          expanded={expanded}
+          expanded={isExpanded}
           position={before || (!before && !after) ? 'after' : 'before'}
           onCollapseToggle={handleCollapseToggle}
         />
@@ -113,7 +126,7 @@ export default function Aside({
         className={cx(
           styles.wrapper,
           noPadding && styles.wrapper_noPadding,
-          collapsible && !expanded && styles.wrapper_collapsed,
+          collapsible && !isExpanded && styles.wrapper_collapsed,
           scrollable && styles.wrapper_scrollable,
         )}
       >

--- a/packages/layouts/src/components/Aside/index.tsx
+++ b/packages/layouts/src/components/Aside/index.tsx
@@ -91,14 +91,20 @@ export default function Aside({
     : undefined;
 
   useEffect(() => {
-    if (expanded !== undefined && expanded !== isExpanded) {
-      setExpanded(expanded);
+    if (expanded !== undefined) {
+      setExpanded(prev => {
+        if (expanded === prev) {
+          return !expanded;
+        }
+
+        return expanded;
+      });
 
       if (onCollapseToggle) {
         onCollapseToggle(expanded);
       }
     }
-  }, [expanded, isExpanded, onCollapseToggle]);
+  }, [expanded, onCollapseToggle]);
 
   return (
     <aside

--- a/packages/layouts/src/components/Aside/story.tsx
+++ b/packages/layouts/src/components/Aside/story.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Button from '@airbnb/lunar/lib/components/Button';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import Aside from '.';
 
@@ -131,4 +132,33 @@ export function asAScrollableContainerWithCollapsibleTab() {
 
 asAScrollableContainerWithCollapsibleTab.story = {
   name: 'As a scrollable container with a collapsible tab.',
+};
+
+export function CanExternallyControlExpandedState() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <Button
+        onClick={() => {
+          setExpanded(prev => !prev);
+        }}
+      >
+        Toggle
+      </Button>
+
+      <div style={{ height: 500 }}>
+        <Aside before collapsible scrollable expanded={expanded} width={300}>
+          <LoremIpsum />
+          <LoremIpsum />
+          <LoremIpsum />
+          <LoremIpsum />
+        </Aside>
+      </div>
+    </div>
+  );
+}
+
+CanExternallyControlExpandedState.story = {
+  name: 'Can externally control expanded state.',
 };

--- a/packages/layouts/test/components/Aside.test.tsx
+++ b/packages/layouts/test/components/Aside.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Aside from '../../src/components/Aside';
+import { render } from 'rut-dom';
+import Aside, { Props } from '../../src/components/Aside';
 import Tab from '../../src/components/Aside/private/Tab';
 
 describe('<Aside />', () => {
@@ -38,5 +39,21 @@ describe('<Aside />', () => {
     );
 
     expect(wrapper.find(Tab)).toHaveLength(1);
+  });
+
+  it('can externally change expanded state', () => {
+    const { root, update } = render<Props>(
+      <Aside after collapsible>
+        Child
+      </Aside>,
+    );
+
+    expect(root.findOne(Tab)).toHaveProp('expanded', true);
+
+    update({
+      expanded: false,
+    });
+
+    expect(root.findOne(Tab)).toHaveProp('expanded', false);
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Adds an `expanded` prop.

## Motivation and Context

We need to be able to control the expanded state externally, so this provides a hook to.

## Testing

Yes, jest and storybook.

## Screenshots

Happo.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
