### PR TITLE
update(Tooltip): Add `horizontalAlign` and `verticalAlign` props.

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -18,22 +18,24 @@ const EMPTY_TARGET_RECT: ClientRect = {
 };
 
 export type TooltipProps = {
-  /** Width of the tooltip in units. */
-  width?: number;
-  /** What to show in the tooltip. */
-  content: NonNullable<React.ReactNode>;
+  /** Manually override calculated align */
+  align?: 'center' | 'left' | 'right';
   /** Inline content to hover. */
   children: NonNullable<React.ReactNode>;
+  /** What to show in the tooltip. */
+  content: NonNullable<React.ReactNode>;
   /** True to disable tooltip but still show children. */
   disabled?: boolean;
   /** True to use a light background with dark text. */
   inverted?: boolean;
+  /** Callback fired when the tooltip is shown. */
+  onShow?: () => void;
   /** True to prevent dismissmal on mouse down. */
   remainOnMouseDown?: boolean;
   /** True to add a dotted bottom border. */
   underlined?: boolean;
-  /** Callback fired when the tooltip is shown. */
-  onShow?: () => void;
+  /** Width of the tooltip in units. */
+  width?: number;
 };
 
 export type TooltipState = {
@@ -186,7 +188,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   };
 
   private renderPopUp() {
-    const { cx, styles, theme, width: widthProp, content, inverted } = this.props;
+    const { align: alignProp, cx, styles, theme, width: widthProp, content, inverted } = this.props;
     const { open, targetRect, tooltipHeight, targetRectReady } = this.state;
 
     // render null until targetRect is initialized by cDM
@@ -214,9 +216,9 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
           role="tooltip"
           className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
             width,
-            marginLeft: marginLeft[align as keyof StyleStruct],
+            marginLeft: marginLeft[(alignProp ?? align) as keyof StyleStruct],
             marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
-            textAlign: align,
+            textAlign: alignProp ?? align,
           })}
         >
           <div className={cx(styles.content, invert && styles.content_inverted)}>

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -18,14 +18,14 @@ const EMPTY_TARGET_RECT: ClientRect = {
 };
 
 export type TooltipProps = {
-  /** Manually override calculated align */
-  align?: 'center' | 'left' | 'right';
   /** Inline content to hover. */
   children: NonNullable<React.ReactNode>;
   /** What to show in the tooltip. */
   content: NonNullable<React.ReactNode>;
   /** True to disable tooltip but still show children. */
   disabled?: boolean;
+  /** Manually override calculated horizontal align */
+  horizontalAlign?: 'center' | 'left' | 'right';
   /** True to use a light background with dark text. */
   inverted?: boolean;
   /** Callback fired when the tooltip is shown. */
@@ -34,6 +34,8 @@ export type TooltipProps = {
   remainOnMouseDown?: boolean;
   /** True to add a dotted bottom border. */
   underlined?: boolean;
+  /** Manually override calculated vertical align */
+  verticalAlign?: 'above' | 'below';
   /** Width of the tooltip in units. */
   width?: number;
 };
@@ -188,7 +190,16 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   };
 
   private renderPopUp() {
-    const { align: alignProp, cx, styles, theme, width: widthProp, content, inverted } = this.props;
+    const {
+      horizontalAlign,
+      cx,
+      styles,
+      theme,
+      width: widthProp,
+      content,
+      inverted,
+      verticalAlign,
+    } = this.props;
     const { open, targetRect, tooltipHeight, targetRectReady } = this.state;
 
     // render null until targetRect is initialized by cDM
@@ -200,7 +211,9 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     const width = widthProp! * unit;
 
     // bestPosition will cause a reflow as will `targetRect.width`
-    const { align, above } = this.bestPosition(targetRect);
+    const { align: bestAlign, above: bestAbove } = this.bestPosition(targetRect);
+    const align = horizontalAlign ?? bestAlign;
+    const above = verticalAlign ? verticalAlign === 'above' : bestAbove;
     const targetWidth = targetRect.width;
     const marginLeft: StyleStruct = {
       center: -width / 2 + targetWidth / 2,
@@ -216,9 +229,9 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
           role="tooltip"
           className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
             width,
-            marginLeft: marginLeft[(alignProp ?? align) as keyof StyleStruct],
+            marginLeft: marginLeft[align as keyof StyleStruct],
             marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
-            textAlign: alignProp ?? align,
+            textAlign: align,
           })}
         >
           <div className={cx(styles.content, invert && styles.content_inverted)}>

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -67,7 +67,10 @@ export default {
 export function displaysWhenAnElementIsHovered() {
   return (
     <div>
-      <Tooltip content="Tooltips are an anti-pattern! Please think carefully about accessibility before using them. Do not use tooltips for content that cannot be discovered by other means.">
+      <Tooltip
+        width={16}
+        content="Tooltips are an anti-pattern! Please think carefully about accessibility before using them. Do not use tooltips for content that cannot be discovered by other means."
+      >
         <Button>Hover Me</Button>
       </Tooltip>
 
@@ -166,28 +169,31 @@ callbackFiredWhenTheTooltipIsShown.story = {
 export function overrideAlign() {
   return (
     <div style={{ textAlign: 'center' }}>
-      <Tooltip
-        align="right"
-        content="This is an example of a tooltip that manually overrides the align prop with the value right"
-        width={40}
-      >
-        <Button>Right align value</Button>
-      </Tooltip>
-      <Spacing inline horizontal={5}>
+      <Spacing top={10}>
         <Tooltip
-          content="This is an example of a tooltip that does not manually override the align value"
+          horizontalAlign="right"
+          content="This is an example of a tooltip that manually overrides the align prop with the value right"
           width={40}
         >
-          <Button>No override</Button>
+          <Button>Right align value</Button>
+        </Tooltip>
+        <Spacing inline horizontal={5}>
+          <Tooltip
+            content="This is an example of a tooltip that overrides the verticalAlign value"
+            verticalAlign="above"
+            width={40}
+          >
+            <Button>Vertical override</Button>
+          </Tooltip>
+        </Spacing>
+        <Tooltip
+          horizontalAlign="left"
+          content="This is an example of a tooltip that manually overrides the align prop with the value left"
+          width={40}
+        >
+          <Button>Left align value</Button>
         </Tooltip>
       </Spacing>
-      <Tooltip
-        align="left"
-        content="This is an example of a tooltip that manually overrides the align prop with the value left"
-        width={40}
-      >
-        <Button>Left align value</Button>
-      </Tooltip>
     </div>
   );
 }

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import Button from '../Button';
 import Text from '../Text';
+import Spacing from '../Spacing';
 import Tooltip from '.';
 
 class TooltipDemo extends React.Component<{}, { text: string; clicked: boolean }> {
@@ -160,4 +161,37 @@ export function callbackFiredWhenTheTooltipIsShown() {
 
 callbackFiredWhenTheTooltipIsShown.story = {
   name: 'Callback fired when the tooltip is shown.',
+};
+
+export function overrideAlign() {
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <Tooltip
+        align="right"
+        content="This is an example of a tooltip that manually overrides the align prop with the value right"
+        width={40}
+      >
+        <Button>Right align value</Button>
+      </Tooltip>
+      <Spacing inline horizontal={5}>
+        <Tooltip
+          content="This is an example of a tooltip that does not manually override the align value"
+          width={40}
+        >
+          <Button>No override</Button>
+        </Tooltip>
+      </Spacing>
+      <Tooltip
+        align="left"
+        content="This is an example of a tooltip that manually overrides the align prop with the value left"
+        width={40}
+      >
+        <Button>Left align value</Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+overrideAlign.story = {
+  name: 'Manually override the align of the tooltip',
 };

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -67,10 +67,7 @@ export default {
 export function displaysWhenAnElementIsHovered() {
   return (
     <div>
-      <Tooltip
-        width={16}
-        content="Tooltips are an anti-pattern! Please think carefully about accessibility before using them. Do not use tooltips for content that cannot be discovered by other means."
-      >
+      <Tooltip content="Tooltips are an anti-pattern! Please think carefully about accessibility before using them. Do not use tooltips for content that cannot be discovered by other means.">
         <Button>Hover Me</Button>
       </Tooltip>
 

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -172,7 +172,7 @@ export function overrideAlign() {
           content="This is an example of a tooltip that manually overrides the align prop with the value right"
           width={40}
         >
-          <Button>Right align value</Button>
+          <Button>Horizontal align right</Button>
         </Tooltip>
         <Spacing inline horizontal={5}>
           <Tooltip
@@ -180,7 +180,7 @@ export function overrideAlign() {
             verticalAlign="above"
             width={40}
           >
-            <Button>Vertical override</Button>
+            <Button>Vertical align above</Button>
           </Tooltip>
         </Spacing>
         <Tooltip
@@ -188,7 +188,7 @@ export function overrideAlign() {
           content="This is an example of a tooltip that manually overrides the align prop with the value left"
           width={40}
         >
-          <Button>Left align value</Button>
+          <Button>Horizontal align left</Button>
         </Tooltip>
       </Spacing>
     </div>


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Add an `align` prop that allows overriding the default calculated align value.
Also organized the props alphabetically.

## Motivation and Context
Request from design for Torch app.

## Testing
Local

## Screenshots
![image](https://user-images.githubusercontent.com/17676991/76116092-3365c300-5f9e-11ea-88e8-f8c4d9ab90d7.png)

![image](https://user-images.githubusercontent.com/17676991/76259180-500a3100-6212-11ea-9f35-29471e569bc5.png)



## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
