### PR TITLE
update(Tabs) add customPushState prop

### DIFF
--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -19,6 +19,8 @@ export type TabsProps<T extends string = string> = {
   onChange?: (key: T) => void;
   /** Persist the selected tab through the defined URL hash. */
   persistWithHash?: string;
+  /** A function to use in lieu of the native pushState. */
+  customPushState?: typeof history.pushState;
   /** Secondary tab style, implies borderless. */
   secondary?: boolean;
   /** Wrap tabs in a scrollable region. */
@@ -45,6 +47,7 @@ function Tabs<T extends string = string>({
   scrollable,
   stretched,
   persistWithHash,
+  customPushState,
   defaultKey,
   onChange,
   styleSheet,
@@ -79,7 +82,11 @@ function Tabs<T extends string = string>({
 
       query.set(persistWithHash, key);
 
-      history.pushState(null, '', `#${String(query)}`);
+      if (customPushState) {
+        customPushState(null, '', `#${String(query)}`);
+      } else {
+        history.pushState(null, '', `#${String(query)}`);
+      }
     }
   };
 

--- a/packages/core/src/components/Tabs/index.tsx
+++ b/packages/core/src/components/Tabs/index.tsx
@@ -20,7 +20,7 @@ export type TabsProps<T extends string = string> = {
   /** Persist the selected tab through the defined URL hash. */
   persistWithHash?: string;
   /** A function to use in lieu of the native pushState. */
-  customPushState?: typeof history.pushState;
+  onPushState?: typeof history.pushState;
   /** Secondary tab style, implies borderless. */
   secondary?: boolean;
   /** Wrap tabs in a scrollable region. */
@@ -47,7 +47,7 @@ function Tabs<T extends string = string>({
   scrollable,
   stretched,
   persistWithHash,
-  customPushState,
+  onPushState,
   defaultKey,
   onChange,
   styleSheet,
@@ -82,8 +82,8 @@ function Tabs<T extends string = string>({
 
       query.set(persistWithHash, key);
 
-      if (customPushState) {
-        customPushState(null, '', `#${String(query)}`);
+      if (onPushState) {
+        onPushState(null, '', `#${String(query)}`);
       } else {
         history.pushState(null, '', `#${String(query)}`);
       }

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -188,6 +188,29 @@ persistWithHashAndBackButton.story = {
   name: 'Persist with hash and back button.',
 };
 
+export function customPushState() {
+  return (
+    // eslint-disable-next-line no-console
+    <Tabs persistWithHash="tab" customPushState={(...args) => console.log(args)}>
+      <Tab key="a" label="Bruce W.">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Tab>
+
+      <Tab key="b" label="Clark K.">
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Tab>
+    </Tabs>
+  );
+}
+
+customPushState.story = {
+  name: 'Custom pushState function.',
+};
+
 export function withScrollableVariableHeightTabs() {
   return (
     <div style={{ width: '325px' }}>

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -188,10 +188,11 @@ persistWithHashAndBackButton.story = {
   name: 'Persist with hash and back button.',
 };
 
-export function customPushState() {
+const customPushState = (...args: Array<unknown>) => action('customPushState')(args);
+
+export function persistWithHashAndCustomPushState() {
   return (
-    // eslint-disable-next-line no-console
-    <Tabs persistWithHash="tab" customPushState={(...args) => console.log(args)}>
+    <Tabs persistWithHash="tab" customPushState={customPushState}>
       <Tab key="a" label="Bruce W.">
         <Text>
           <LoremIpsum />
@@ -207,7 +208,7 @@ export function customPushState() {
   );
 }
 
-customPushState.story = {
+persistWithHashAndCustomPushState.story = {
   name: 'Custom pushState function.',
 };
 

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -188,11 +188,11 @@ persistWithHashAndBackButton.story = {
   name: 'Persist with hash and back button.',
 };
 
-const customPushState = (...args: Array<unknown>) => action('customPushState')(args);
+const onPushState = (...args: Array<unknown>) => action('onPushState')(args);
 
-export function persistWithHashAndCustomPushState() {
+export function persistWithHashAndonPushState() {
   return (
-    <Tabs persistWithHash="tab" customPushState={customPushState}>
+    <Tabs persistWithHash="tab" onPushState={onPushState}>
       <Tab key="a" label="Bruce W.">
         <Text>
           <LoremIpsum />
@@ -208,7 +208,7 @@ export function persistWithHashAndCustomPushState() {
   );
 }
 
-persistWithHashAndCustomPushState.story = {
+persistWithHashAndonPushState.story = {
   name: 'Custom pushState function.',
 };
 

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -273,8 +273,10 @@ describe('<Tabs/>', () => {
     const addSpy = jest.spyOn(window, 'addEventListener');
     const rmSpy = jest.spyOn(window, 'removeEventListener');
 
+    const pushFn = jest.fn((a, b, url) => history.pushState(null, '', url));
+
     const wrapper = mountUseStyles(
-      <Tabs persistWithHash="tab">
+      <Tabs persistWithHash="tab" customPushState={pushFn}>
         <Tab key="a" label="One" />
         <Tab key="b" label="Two" />
       </Tabs>,
@@ -282,12 +284,15 @@ describe('<Tabs/>', () => {
 
     expect(addSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
 
+    expect(pushFn).not.toHaveBeenCalled();
+
     wrapper
       .find(ButtonOrLink)
       .at(1)
       .simulate('click', 'b');
 
     expect(location.hash).toBe('#tab=b');
+    expect(pushFn).toHaveBeenCalledWith(null, '', '#tab=b');
 
     // eslint-disable-next-line rut/no-act
     act(() => {

--- a/packages/core/test/components/Tabs.test.tsx
+++ b/packages/core/test/components/Tabs.test.tsx
@@ -276,7 +276,7 @@ describe('<Tabs/>', () => {
     const pushFn = jest.fn((a, b, url) => history.pushState(null, '', url));
 
     const wrapper = mountUseStyles(
-      <Tabs persistWithHash="tab" customPushState={pushFn}>
+      <Tabs persistWithHash="tab" onPushState={pushFn}>
         <Tab key="a" label="One" />
         <Tab key="b" label="Two" />
       </Tabs>,


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

add a new optional `customPushState` prop to `<Tabs />` to be used in conjunction with `persistWithHash`.

## Motivation and Context

One may want to use _react-router_'s `pushState` instead of the native one.

## Testing

Added to existing spec

## Screenshots

n/a

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
