### PR TITLE
update(Tooltip): Add `toggleOnClick`  prop.

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -32,6 +32,8 @@ export type TooltipProps = {
   onShow?: () => void;
   /** True to prevent dismissmal on mouse down. */
   remainOnMouseDown?: boolean;
+  /** True to toggle tooltip display on click.  */
+  toggleOnClick?: boolean;
   /** True to add a dotted bottom border. */
   underlined?: boolean;
   /** Manually override calculated vertical align */
@@ -67,6 +69,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     inverted: false,
     onShow() {},
     remainOnMouseDown: false,
+    toggleOnClick: false,
     underlined: false,
     width: 35,
   };
@@ -162,7 +165,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     this.updateTooltipHeight();
   };
 
-  private handleEnter = () => {
+  private handleOpen = () => {
     /* istanbul ignore next: refs are hard */
     this.rafHandle = requestAnimationFrame(() => {
       const { current } = this.containerRef;
@@ -179,14 +182,33 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     }
   };
 
-  private handleMouseDown = () => {
-    if (!this.props.remainOnMouseDown) {
-      this.handleClose();
+  private handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  private handleMouseEnter = () => {
+    if (!this.props.toggleOnClick) {
+      this.handleOpen();
     }
   };
 
-  private handleClose = () => {
-    this.setState({ open: false });
+  private handleMouseDown = () => {
+    if (!this.props.remainOnMouseDown && !this.props.toggleOnClick) {
+      this.handleClose();
+    }
+    if (this.props.toggleOnClick) {
+      if (this.state.open) {
+        this.handleClose();
+      } else {
+        this.handleOpen();
+      }
+    }
+  };
+
+  private handleMouseLeave = () => {
+    if (!this.props.toggleOnClick) {
+      this.handleClose();
+    }
   };
 
   private renderPopUp() {
@@ -251,8 +273,8 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
         <div
           aria-labelledby={labelID}
           className={cx(!disabled && underlined && styles.underlined)}
-          onMouseEnter={this.handleEnter}
-          onMouseLeave={this.handleClose}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
           onMouseDown={this.handleMouseDown}
         >
           {children}

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -198,3 +198,19 @@ export function overrideAlign() {
 overrideAlign.story = {
   name: 'Manually override the align of the tooltip',
 };
+
+export function toggleWithClick() {
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <Spacing top={10}>
+        <Tooltip toggleOnClick content="This tooltip's display is toggled on click.">
+          <Button>Toggle on click</Button>
+        </Tooltip>
+      </Spacing>
+    </div>
+  );
+}
+
+toggleWithClick.story = {
+  name: 'Toggle tooltip on click',
+};


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Add `toggleOnClick` prop that toggles the display of the tooltip content on user click when true.

## Motivation and Context
Request from design

## Testing
Local

## Screenshots

![toggleonclick](https://user-images.githubusercontent.com/17676991/76453473-2d9e2200-6390-11ea-9aed-a3b2417fbb0b.gif)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
