### PR TITLE
fix(TextArea, Proofreader): Fix double link render.

### DIFF
--- a/packages/core/src/components/Proofreader/Renderer.tsx
+++ b/packages/core/src/components/Proofreader/Renderer.tsx
@@ -26,7 +26,7 @@ export default function Renderer({
   if (errors.length === 0) {
     return (
       <div>
-        <Interweave content={value} />
+        <Interweave disableMatchers content={value} />
       </div>
     );
   }
@@ -47,7 +47,11 @@ export default function Renderer({
 
     // Extract previous string
     content.push(
-      <Interweave key={`${lastIndex}-${offset}`} content={value.slice(lastIndex, offset)} />,
+      <Interweave
+        key={`${lastIndex}-${offset}`}
+        disableMatchers
+        content={value.slice(lastIndex, offset)}
+      />,
     );
 
     // Set new last index
@@ -74,7 +78,9 @@ export default function Renderer({
   // Extract any remaining value
   const final = value.slice(lastIndex);
 
-  content.push(<Interweave key={`${lastIndex}-${lastIndex + final.length}`} content={final} />);
+  content.push(
+    <Interweave key={`${lastIndex}-${lastIndex + final.length}`} disableMatchers content={final} />,
+  );
 
   // Add a fake character to the end of the text when a shadow. This solves a handful of bugs
   // in which trailing new lines in combination with scroll position do not work correctly.


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

when pasting large text that included matchers like links, pressing enter, expanding the height of the textarea, this weirdness would happen:

<img width="1244" alt="Core : TextArea - A textarea with built - in grammar and spelling checks , as well as a max character limit   ⋅ Storybook 2020-03-13 14-55-17" src="https://user-images.githubusercontent.com/306275/76662344-f029c800-653a-11ea-9d98-92c68e178be7.png">

fix:

<img width="1216" alt="Storybook 2020-03-13 14-55-56" src="https://user-images.githubusercontent.com/306275/76662388-09cb0f80-653b-11ea-8240-0ec6dfdefac0.png">


## Motivation and Context

broken experience for our proofreader and consumers

## Testing

storybook

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
