### PR TITLE
update(Proofreader): Add max height prop for locale menu.

### DIFF
--- a/packages/core/src/components/Proofreader/ControlBar.tsx
+++ b/packages/core/src/components/Proofreader/ControlBar.tsx
@@ -17,6 +17,7 @@ export type ControlBarProps = {
   errors: ProofreadRuleMatch[];
   loading?: boolean;
   locale?: string;
+  localeMenuMaxHeight?: number;
   top?: string;
   onSelectLocale: (locale: string) => void;
 };
@@ -26,6 +27,7 @@ export default function ControlBar({
   errors,
   loading,
   locale,
+  localeMenuMaxHeight,
   top = '80%',
   onSelectLocale,
 }: ControlBarProps) {
@@ -60,6 +62,7 @@ export default function ControlBar({
           >
             <LocaleMenu
               autoDefinition={autoDetect ? getLocaleDefinition(AUTO_DETECT_LOCALE) : undefined}
+              maxHeight={localeMenuMaxHeight}
               noneDefinition={getLocaleDefinition(NO_LOCALE)}
               selectedLocale={selectedLocale}
               onSelectLocale={nextLocale => {

--- a/packages/core/src/components/Proofreader/LocaleMenu.tsx
+++ b/packages/core/src/components/Proofreader/LocaleMenu.tsx
@@ -8,6 +8,7 @@ import { DefinitionShape } from './types';
 
 export type LocaleMenuProps = {
   autoDefinition?: DefinitionShape;
+  maxHeight?: number;
   noneDefinition?: DefinitionShape;
   selectedLocale: string | null;
   onSelectLocale: (locale: string) => void;
@@ -19,7 +20,7 @@ export default class LocaleMenu extends React.Component<LocaleMenuProps> {
   };
 
   render() {
-    const { autoDefinition, noneDefinition, selectedLocale } = this.props;
+    const { autoDefinition, maxHeight, noneDefinition, selectedLocale } = this.props;
     const locales = [...LT_LOCALES];
 
     locales.sort((a, b) => a.label.localeCompare(b.label));
@@ -28,6 +29,7 @@ export default class LocaleMenu extends React.Component<LocaleMenuProps> {
       <TrackingBoundary name="Proofreader/LocaleMenu">
         <Menu
           accessibilityLabel={T.phrase('lunar.proofreader.languageSelector', 'Language selector')}
+          maxHeight={maxHeight}
         >
           <Row>
             <Text small muted bold>

--- a/packages/core/src/components/Proofreader/index.tsx
+++ b/packages/core/src/components/Proofreader/index.tsx
@@ -30,12 +30,11 @@ export type Position = {
   top: number;
 };
 
-export type ProofreaderProps = Pick<FormInputProps, 'important'> &
+export type ProofreaderProps = Pick<FormInputProps, 'important' | 'noTranslate'> &
   ExtraProofreadProps & {
+    id: string;
     locale?: string;
     name: string;
-    id: string;
-    noTranslate?: boolean;
     onChange: (value: string, event: React.ChangeEvent<HTMLTextAreaElement>) => void;
     onCheckText: (params: ProofreaderParams) => Promise<ProofreaderResponse>;
     value: string;
@@ -439,15 +438,16 @@ export class Proofreader extends React.Component<
 
   render() {
     const {
-      cx,
       children,
-      styles,
-      onCheckText,
-      theme,
+      cx,
       important,
       isRuleHighlighted,
       isRuleSecondary,
+      localeMenuMaxHeight,
       onChange,
+      onCheckText,
+      styles,
+      theme,
       ...props
     } = this.props;
     const { position, errors, loading, selectedError, selectedLocale, text } = this.state;
@@ -511,6 +511,7 @@ export class Proofreader extends React.Component<
           <ControlBar
             loading={loading}
             locale={selectedLocale!}
+            localeMenuMaxHeight={localeMenuMaxHeight}
             errors={errors}
             onSelectLocale={this.handleSelectLocale}
           />

--- a/packages/core/src/components/Proofreader/types.ts
+++ b/packages/core/src/components/Proofreader/types.ts
@@ -30,4 +30,5 @@ export type DefinitionShape = {
 export type ExtraProofreadProps = {
   isRuleHighlighted?: (rule: ProofreadRuleMatch) => boolean;
   isRuleSecondary?: (rule: ProofreadRuleMatch) => boolean;
+  localeMenuMaxHeight?: number;
 };

--- a/packages/core/src/components/TextArea/story.tsx
+++ b/packages/core/src/components/TextArea/story.tsx
@@ -88,6 +88,9 @@ class ProofreaderDemo extends React.Component<{}, { value: string }> {
         label="Proofread"
         rows={5}
         maxLength={10000}
+        proofreadProps={{
+          localeMenuMaxHeight: 220,
+        }}
         value={this.state.value}
         onChange={this.handleChange}
         onCheckText={onCheckText}


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

the language list can be long, and sometimes flow off screen

## Motivation and Context

helpful to be able to set a max height on the menu and make it scrollable

## Testing

local storybook

## Screenshots

<img width="446" alt="Storybook 2020-03-17 10-39-36" src="https://user-images.githubusercontent.com/306275/76885766-fbcc0600-683c-11ea-8769-19715190fa2f.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
