### PR TITLE
fix(GradientScroller): Initially hide gradient end.

### DIFF
--- a/packages/core/src/components/GradientScroller/index.tsx
+++ b/packages/core/src/components/GradientScroller/index.tsx
@@ -46,7 +46,7 @@ export class GradientScroller extends React.Component<
 
   state = {
     showStartGradient: false,
-    showEndGradient: true,
+    showEndGradient: false,
   };
 
   componentWillUnmount() {

--- a/packages/core/src/components/GradientScroller/index.tsx
+++ b/packages/core/src/components/GradientScroller/index.tsx
@@ -44,7 +44,7 @@ export class GradientScroller extends React.Component<
 
   scrollerRef: HTMLDivElement | null = null;
 
-  state = {
+  state: GradientScrollerState = {
     showStartGradient: false,
     showEndGradient: false,
   };

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -33,7 +33,7 @@ export default {
   title: 'Core/GradientScroller',
   parameters: {
     inspectComponents: [GradientScroller],
-    happo: { delay: 1000 },
+    happo: { delay: 500 },
   },
 };
 

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -33,7 +33,7 @@ export default {
   title: 'Core/GradientScroller',
   parameters: {
     inspectComponents: [GradientScroller],
-    happo: { delay: 500 },
+    happo: { delay: 1000 },
   },
 };
 

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -74,7 +74,9 @@ withLeftAndRightArrows.story = {
 export function withArrowsButNotShown() {
   return (
     <GradientScroller showArrows hideScrollbar>
-      <Text><LoremIpsum short /></Text>
+      <Text>
+        <LoremIpsum short />
+      </Text>
     </GradientScroller>
   );
 }

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -74,7 +74,7 @@ withLeftAndRightArrows.story = {
 export function withArrowsButNotShown() {
   return (
     <GradientScroller showArrows hideScrollbar>
-      <Text>{"Hello"}</Text>
+      <Text><LoremIpsum short /></Text>
     </GradientScroller>
   );
 }

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -33,7 +33,7 @@ export default {
   title: 'Core/GradientScroller',
   parameters: {
     inspectComponents: [GradientScroller],
-    happo: { delay: 100 },
+    happo: { delay: 500 },
   },
 };
 

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -33,6 +33,7 @@ export default {
   title: 'Core/GradientScroller',
   parameters: {
     inspectComponents: [GradientScroller],
+    happo: { delay: 100 },
   },
 };
 

--- a/packages/core/src/components/GradientScroller/story.tsx
+++ b/packages/core/src/components/GradientScroller/story.tsx
@@ -70,6 +70,18 @@ withLeftAndRightArrows.story = {
   name: 'With left and right arrows.',
 };
 
+export function withArrowsButNotShown() {
+  return (
+    <GradientScroller showArrows hideScrollbar>
+      <Text>{"Hello"}</Text>
+    </GradientScroller>
+  );
+}
+
+withArrowsButNotShown.story = {
+  name: 'With arrows but not shown.',
+};
+
 export function withNoScrollbarAndVariableWidthChildren() {
   return (
     <GradientScroller hideScrollbar>

--- a/packages/core/src/components/Tabs/story.tsx
+++ b/packages/core/src/components/Tabs/story.tsx
@@ -9,6 +9,7 @@ export default {
   title: 'Core/Tabs',
   parameters: {
     inspectComponents: [Tabs, Tab],
+    happo: { delay: 500 },
   },
 };
 

--- a/packages/core/test/components/__snapshots__/GradientScroller.test.tsx.snap
+++ b/packages/core/test/components/__snapshots__/GradientScroller.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<GradientScroller /> has the correct default sizing 1`] = `
     />
   </div>
   <div
-    className="rightGradient gradient_reveal"
+    className="rightGradient"
   >
     <span
       className="scrollTrigger"


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

## Motivation and Context

When using `<GradientScrollbar showArrows />`, if the content does _not_ overflow, we would see a flash of the arrow before the ResizeObserver does it's thing.

## Testing

StyleBook

## Screenshots

before this change, in nova usage of `<Tabs scrollable />` :

![demo](https://user-images.githubusercontent.com/205004/77122491-fa483c80-69fa-11ea-950f-4a6a57f0cc62.gif)


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
