### PR TITLE
fix: Lazy-load `BroadcastChannel`.

### DIFF
--- a/packages/core/src/components/BrowserNotification/index.tsx
+++ b/packages/core/src/components/BrowserNotification/index.tsx
@@ -45,6 +45,10 @@ export default class BrowserNotification extends React.PureComponent<BrowserNoti
   }
 
   showNotification() {
+    if (typeof Notification === 'undefined') {
+      return;
+    }
+
     Notification.requestPermission().then(permission => {
       if (permission === 'granted') {
         const { title, tag, body, icon, timeout, onClick } = this.props;

--- a/packages/core/src/components/ScrollSection/ScrollWrapper.tsx
+++ b/packages/core/src/components/ScrollSection/ScrollWrapper.tsx
@@ -46,6 +46,10 @@ export class ScrollWrapper extends React.Component<ScrollWrapperProps & WithStyl
   }
 
   setupObserver() {
+    if (typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
     if (this.observer) {
       this.observer.disconnect();
       this.observer = null;


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Lazy-loads `BroadcastChannel` as crosstab is a side-effect and the channel does not exist in some browsers, nor in SSR, so it crashes. This turns it into a no-op in those cases.

Also added checks in some other locations.

## Motivation and Context

More SSR work.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
