### PR TITLE
fix(TrackingBoundary): Update element to a `div`.

### DIFF
--- a/packages/core/src/components/TrackingBoundary/index.tsx
+++ b/packages/core/src/components/TrackingBoundary/index.tsx
@@ -26,13 +26,15 @@ function TrackingBoundary({ children, name }: TrackingBoundaryProps) {
   };
 
   return (
-    <tracking-boundary
+    <div
+      data-tracking-boundary
       data-tracking-name={name}
+      role="none"
       onClick={handleTrackContext}
       onKeyDown={handleTrackContext}
     >
       {children}
-    </tracking-boundary>
+    </div>
   );
 }
 

--- a/packages/core/src/themes/global.ts
+++ b/packages/core/src/themes/global.ts
@@ -40,9 +40,6 @@ export default (fontFaces: { [fontFamily: string]: FontFace[] }) => ({ color, fo
         display: 'inline-block',
         verticalAlign: 'middle',
       },
-      'tracking-boundary': {
-        display: 'block',
-      },
     },
     '@font-face': fontFaces,
   } as GlobalSheet);

--- a/packages/core/test/components/TrackingBoundary.test.tsx
+++ b/packages/core/test/components/TrackingBoundary.test.tsx
@@ -3,10 +3,10 @@ import { shallow } from 'enzyme';
 import TrackingBoundary from '../../src/components/TrackingBoundary';
 
 describe('<TrackingBoundary />', () => {
-  it('renders a spy HTML tag', () => {
+  it('renders a div', () => {
     const wrapper = shallow(<TrackingBoundary name="Foo">Foo</TrackingBoundary>);
 
-    expect(wrapper.type()).toBe('tracking-boundary');
+    expect(wrapper.type()).toBe('div');
   });
 
   it('adds data tag to HTML tag', () => {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -53,15 +53,6 @@ interface WindowEventMap {
   paste: ClipboardEvent;
 }
 
-declare namespace JSX {
-  interface IntrinsicElements {
-    'tracking-boundary': React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLDivElement>,
-      HTMLDivElement
-    >;
-  }
-}
-
 interface MouseEvent {
   trackingContext?: string[];
 }


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Migrates from a custom element to a `div`, as the former does not work in SSR. This shouldn't break anything as the former was also display block.

<img width="448" alt="Screen Shot 2020-03-25 at 1 31 20 PM" src="https://user-images.githubusercontent.com/143744/77587233-bb0b6700-6ea4-11ea-8562-5cfed3402c08.png">

## Motivation and Context

Support SSR.

## Testing

N/A

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
