### PR TITLE
fix: Add index file to resolve imports.

### DIFF
--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,0 +1,1 @@
+// We need a fake index so that bundles can resolve imports correctly.


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This crashes some bundlers as the `main` field in `package.json` is pointing to a non-existent file.

## Motivation and Context

Fix the bundlers.

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
