### PR TITLE
update(TermList): Label muted by default.

### DIFF
--- a/packages/core/src/components/TermList/Term.tsx
+++ b/packages/core/src/components/TermList/Term.tsx
@@ -14,6 +14,8 @@ export type TermProps = TextProps & {
   endAlign?: boolean;
   /** Term label describing the value displayed. */
   label: string | React.ReactNode;
+  /** Mark the label as muted. */
+  muted?: boolean;
   /** If enabled, term label is uppercased. */
   uppercased?: boolean;
   /** Custom style sheet. */
@@ -25,6 +27,7 @@ export default function Term({
   after,
   endAlign,
   uppercased,
+  muted = true,
   children,
   styleSheet,
   ...textProps
@@ -35,7 +38,7 @@ export default function Term({
     <div>
       <dt>
         <Row after={endAlign && after}>
-          <Text inline small uppercased={uppercased} {...textProps}>
+          <Text inline small muted={muted} uppercased={uppercased} {...textProps}>
             {label}
           </Text>
           {!endAlign && after && (


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
@kenchendesign Wants increased contrast between label and value.

I was a little bit unclear on technical implementation since `muted` is part of `textProps`, but this approach seems to work.
<!--- Describe your change in detail. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Testing

<!--- Please describe in detail how you tested your change. -->

## Screenshots
Previously:
<img width="83" alt="Screen Shot 2020-03-30 at 4 19 18 PM" src="https://user-images.githubusercontent.com/8676510/77970898-3d7b9880-72a2-11ea-9c95-d57b1f916824.png">

Now:
<img width="81" alt="Screen Shot 2020-03-30 at 4 19 11 PM" src="https://user-images.githubusercontent.com/8676510/77970901-40768900-72a2-11ea-8d35-6227ffa942ff.png">

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
