### PR TITLE
Adding centerAlign as a property for column headers

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -67,6 +67,11 @@ export default function ColumnLabels({
       width: '100%',
     };
 
+    const centerAlignmentStyle: React.CSSProperties = {
+      justifyContent: 'center',
+      width: '100%',
+    };
+
     const newColumns = columns.map((col, idx) => {
       if (!React.isValidElement<ColumnChildrenProps>(col)) {
         return col;
@@ -89,11 +94,14 @@ export default function ColumnLabels({
       const sortable =
         !columnMetadata || !columnMetadata[key] || columnMetadata[key].disableSorting !== 1;
 
+      const alignStyle = columnMetadata?.[key]?.rightAlign ? rightAlignmentStyle : 
+        columnMetadata?.[key]?.centerAlign ? centerAlignmentStyle : {};
+
       const newHeader = (
         <Spacing left={indent && !isLeftmost ? 2 : 0}>
           <div style={heightStyle} className={cx(showDivider && styles && styles.column_divider)}>
             <div
-              style={columnMetadata?.[key]?.rightAlign ? rightAlignmentStyle : {}}
+              style={alignStyle}
               className={cx(styles?.headerRow)}
             >
               <Text micro muted>

--- a/packages/core/src/components/DataTable/story.tsx
+++ b/packages/core/src/components/DataTable/story.tsx
@@ -520,3 +520,27 @@ export function ATableWithDynamicSortKey() {
     </>
   );
 }
+
+export function aTableWithCenterAndRightAlignColumnHeaders() {
+  return (
+    <DataTable
+      showColumnDividers
+      data={getData()}
+      keys={['name', 'jobTitle', 'tenureDays']}
+      columnMetadata={{
+        name: {
+        },
+        jobTitle: {
+          centerAlign: 1,
+        },
+        tenureDays: {
+          rightAlign: 1,
+        },
+      }}
+    />
+  );
+}
+
+aTableWithCenterAndRightAlignColumnHeaders.story = {
+  name: 'A table with center align and right align column headers.',
+};


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Added a `centerAlign` option to the `ColumnMetadata` section of `<DataTable>` to allow the column headers to be center aligned.

## Motivation and Context
Some content looks best center aligned.

## Testing
Verified it looks correct with a new story in storyboard.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->
![image](https://user-images.githubusercontent.com/63325204/78732710-3aaf2200-78f8-11ea-9de5-fd2cddf7a22d.png)

## Checklist
- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
