### PR TITLE
fix(HierarchyPicker): Scale weights to sum to 1

### DIFF
--- a/packages/core/src/components/HierarchyPicker/Search/index.tsx
+++ b/packages/core/src/components/HierarchyPicker/Search/index.tsx
@@ -45,15 +45,15 @@ type FuseKey = { name: keyof SearchItemShape; weight: number };
 const defaultFuseKeys: FuseKey[] = [
   {
     name: 'label',
-    weight: 0.8,
+    weight: 0.35,
   },
   {
     name: 'keywords',
-    weight: 0.7,
+    weight: 0.3,
   },
   {
     name: 'description',
-    weight: 0.5,
+    weight: 0.25,
   },
 ];
 
@@ -107,7 +107,7 @@ export class Search extends React.Component<SearchProps & WithStylesProps> {
     if (this.props.indexParentPath) {
       fuseKeys.push({
         name: 'formattedParents',
-        weight: 0.2,
+        weight: 0.1,
       });
     }
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
In Torch we are hitting this issue: https://github.com/krisk/Fuse/issues/357  via `Search` in `HierarchyPicker` . Apparently this breaking change was added as part of a minor upgrade to Fuse, and was fixed here: https://github.com/krisk/Fuse/commit/1b921e29a78fdaae5524b27c36b3b702ff19d7d7 .  Rather than attempting to upgrade the package, this PR scales the key weights such that they sum to 1. I rounded the numbers a bit to make things more clear, but can add some more precision if necessary.

## Motivation and Context
Problem outlined above.

## Testing
Locally

## Screenshots
N / A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
