### PR TITLE
fix(crosstab): Create one channel per instance

### DIFF
--- a/packages/core/src/crosstab.ts
+++ b/packages/core/src/crosstab.ts
@@ -18,6 +18,10 @@ export class Crosstab {
       return undefined;
     }
 
+    if (this.channel) {
+      return this.channel;
+    }
+
     this.channel = new BroadcastChannel('crosstab');
     this.channel.addEventListener('message', this.handleMessage);
 

--- a/packages/core/test/crosstab.test.ts
+++ b/packages/core/test/crosstab.test.ts
@@ -87,8 +87,8 @@ describe('crosstab', () => {
   });
 
   it('creates only one channel', () => {
-    const channel = crosstab.getChannel()
-    expect(channel).toBeDefined()
-    expect(crosstab.getChannel()).toBe(channel)
-  })
+    const channel = crosstab.getChannel();
+    expect(channel).toBeDefined();
+    expect(crosstab.getChannel()).toBe(channel);
+  });
 });

--- a/packages/core/test/crosstab.test.ts
+++ b/packages/core/test/crosstab.test.ts
@@ -86,7 +86,7 @@ describe('crosstab', () => {
     crosstab.emit('selfEmit', 'yep', true);
   });
 
-  it('creates only on channel', () => {
+  it('creates only one channel', () => {
     const channel = crosstab.getChannel()
     expect(channel).toBeDefined()
     expect(crosstab.getChannel()).toBe(channel)

--- a/packages/core/test/crosstab.test.ts
+++ b/packages/core/test/crosstab.test.ts
@@ -85,4 +85,10 @@ describe('crosstab', () => {
 
     crosstab.emit('selfEmit', 'yep', true);
   });
+
+  it('creates only on channel', () => {
+    const channel = crosstab.getChannel()
+    expect(channel).toBeDefined()
+    expect(crosstab.getChannel()).toBe(channel)
+  })
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

`crosstab` was creating new BroadcastChannels at each `on`, `off`, and `emit` method call. 

## Motivation and Context

Crosstab wasn't working as expected after the previous change. 

## Testing

Added test

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
