### PR TITLE
new(Tooltip): Add optional accessibilityLabel for perf

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -18,7 +18,7 @@ const EMPTY_TARGET_RECT: ClientRect = {
 };
 
 export type TooltipProps = {
-  /** Accessibility label. If not specified, all tooltip content is duplicated in an accessibility portal rendered at all times. */
+  /** Accessibility label. If not specified, all tooltip content is duplicated, rendered in an off-screen element with a separate layer. */
   accessibilityLabel?: string;
   /** Inline content to hover. */
   children: NonNullable<React.ReactNode>;

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -18,6 +18,8 @@ const EMPTY_TARGET_RECT: ClientRect = {
 };
 
 export type TooltipProps = {
+  /** Accessibility label. If not specified, all tooltip content is duplicated in an accessibility portal rendered at all times. */
+  accessibilityLabel?: string;
   /** Inline content to hover. */
   children: NonNullable<React.ReactNode>;
   /** What to show in the tooltip. */
@@ -265,13 +267,14 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   }
 
   render() {
-    const { cx, styles, children, content, disabled, underlined } = this.props;
+    const { accessibilityLabel, cx, styles, children, content, disabled, underlined } = this.props;
     const { open, labelID } = this.state;
 
     return (
       <span ref={this.containerRef} className={cx(styles.container)}>
         <div
-          aria-labelledby={labelID}
+          aria-labelledby={accessibilityLabel ? undefined : labelID}
+          aria-label={accessibilityLabel}
           className={cx(!disabled && underlined && styles.underlined)}
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
@@ -281,11 +284,13 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
         </div>
 
         {/* render off-screen element in a separate layer */}
-        <Portal>
-          <div id={labelID} className={cx(styles.offscreen)}>
-            {content}
-          </div>
-        </Portal>
+        {!accessibilityLabel && (
+          <Portal>
+            <div id={labelID} className={cx(styles.offscreen)}>
+              {content}
+            </div>
+          </Portal>
+        )}
 
         {open ? this.renderPopUp() : null}
       </span>

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -221,21 +221,21 @@ export function withAccessibilityLabel() {
       <Spacing bottom={1}>
         <Tooltip
           accessibilityLabel="Override accessibility content"
-          content="I have an aria-labelledby instead of aria-label"
+          content="I have an aria-label instead of an aria-labelledby"
         >
           I have an{' '}
           <Text bold inline>
             aria-label
           </Text>{' '}
-          instead of aria-labelledby
+          instead of an aria-labelledby
         </Tooltip>
       </Spacing>
-      <Tooltip content="I have an aria-label instead of aria-labelledby">
+      <Tooltip content="I have an aria-labelledby instead of an aria-label">
         I have an{' '}
         <Text bold inline>
           aria-labelledby
         </Text>{' '}
-        instead of aria-label
+        instead of an aria-label
       </Tooltip>
     </>
   );

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -214,3 +214,33 @@ export function toggleWithClick() {
 toggleWithClick.story = {
   name: 'Toggle tooltip on click',
 };
+
+export function withAccessibilityLabel() {
+  return (
+    <>
+      <Spacing bottom={1}>
+        <Tooltip
+          accessibilityLabel="Override accessibility content"
+          content="I have an aria-labelledby instead of aria-label"
+        >
+          I have an{' '}
+          <Text bold inline>
+            aria-label
+          </Text>{' '}
+          instead of aria-labelledby
+        </Tooltip>
+      </Spacing>
+      <Tooltip content="I have an aria-label instead of aria-labelledby">
+        I have an{' '}
+        <Text bold inline>
+          aria-labelledby
+        </Text>{' '}
+        instead of aria-label
+      </Tooltip>
+    </>
+  );
+}
+
+withAccessibilityLabel.story = {
+  name: 'With accessibility label',
+};


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
cc @avand @stopachka

## Description

This PR adds an optional `accessibilityLabel` prop to the `Tooltip`, mostly to enable an opt-in (non-breaking) perf improvement. 

## Motivation and Context

Currently the `content` prop of `Tooltip` is rendered in an invisible `Portal` for a11y, to serve as an `aria-labeledby` element that is rendered whether or not the `Tooltip` popup is visible. This can lead to performance issues on pages with 100s of `Tooltips` as `content` is rendered at all times.

We discussed that one solution to ensure accessibility but allow for optimization is to override this behavior by specifying an `aria-label` (`accessibilityLabel` prop) to be used instead. 

Note: there was some discussion about whether omission of `aria-labelledby`/duplication of content should be conditional on whether `props.toggleOnClick === false` as you could potentially have functionality in `content` that would not be captured with a simple label. After thinking about this more I think it could be confusing to the developer but am still open to adding it if you want.

## Testing

- [x] CI
- [x] functional – `aria-label` and `aria-labelledby` work in new story

## Screenshots

New example
![image](https://user-images.githubusercontent.com/4496521/79624472-9c307700-80d6-11ea-842b-ad60a83f2784.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
