### PR TITLE
fix(Term): Fix `large` prop conflicting with `small` default. Update stories.

### DIFF
--- a/packages/core/src/components/TermList/Term.tsx
+++ b/packages/core/src/components/TermList/Term.tsx
@@ -35,9 +35,10 @@ export default function Term({
     <div>
       <dt>
         <Row after={endAlign && after}>
-          <Text inline small uppercased={uppercased} {...textProps}>
+          <Text inline small={!textProps.large} uppercased={uppercased} {...textProps}>
             {label}
           </Text>
+
           {!endAlign && after && (
             <Spacing inline left={1}>
               {after!}
@@ -45,6 +46,7 @@ export default function Term({
           )}
         </Row>
       </dt>
+
       <dd className={cx(styles.dd)}>
         <Text>{children}</Text>
       </dd>

--- a/packages/core/src/components/TermList/story.tsx
+++ b/packages/core/src/components/TermList/story.tsx
@@ -28,16 +28,16 @@ export function termsUsingTextProperties() {
   return (
     <TermList>
       <Term bold label="Bold term">
-        16
+        with &quot;bold&quot; prop
       </Term>
       <Term muted label="Muted term">
-        4
+        with &quot;muted&quot; prop
       </Term>
       <Term small={false} label="Regular term">
-        8
+        {'with "small={false}" prop'}
       </Term>
       <Term large label="Large term">
-        12
+        with &quot;large&quot; prop
       </Term>
     </TermList>
   );

--- a/packages/core/src/components/TermList/story.tsx
+++ b/packages/core/src/components/TermList/story.tsx
@@ -13,40 +13,61 @@ export default {
 };
 
 export function standaloneTerm() {
-  return <Term label="Clusters">8</Term>;
+  return (
+    <TermList>
+      <Term label="Clusters">8</Term>
+    </TermList>
+  );
 }
 
 standaloneTerm.story = {
   name: 'Standalone term.',
 };
 
-export function standaloneTermWithRegularLabel() {
-  return <Term label="Clusters">8</Term>;
+export function termsUsingTextProperties() {
+  return (
+    <TermList>
+      <Term bold label="Bold term">
+        16
+      </Term>
+      <Term muted label="Muted term">
+        4
+      </Term>
+      <Term small={false} label="Regular term">
+        8
+      </Term>
+      <Term large label="Large term">
+        12
+      </Term>
+    </TermList>
+  );
 }
 
-standaloneTermWithRegularLabel.story = {
-  name: 'Standalone Term with regular sized label.',
+termsUsingTextProperties.story = {
+  name: 'Examples of Term using Text properties.',
 };
 
 export function standaloneTermWithAfterContent() {
   return (
-    <Term
-      label="Clusters"
-      after={
-        <>
-          <Link small href="https://github.com/airbnb/lunar">
-            Details
-          </Link>
-          <Spacing inline left={1}>
+    <TermList>
+      <Term
+        label="Clusters"
+        after={
+          <>
             <Link small href="https://github.com/airbnb/lunar">
-              Git
+              Details
             </Link>
-          </Spacing>
-        </>
-      }
-    >
-      8
-    </Term>
+            <Spacing inline left={1}>
+              <Link small href="https://github.com/airbnb/lunar">
+                Git
+              </Link>
+            </Spacing>
+          </>
+        }
+      >
+        8
+      </Term>
+    </TermList>
   );
 }
 
@@ -86,20 +107,16 @@ export function standaloneTermWithAfterContentEndAligned() {
 }
 
 standaloneTermWithAfterContentEndAligned.story = {
-  name: 'Standalone Term in a card with after content end aligned.',
+  name: 'Standalone Term in a Card with after content end-aligned.',
 };
 
 export function listOfTerms() {
   return (
-    <Card>
-      <Content>
-        <TermList>
-          <Term label="Total Clusters">16</Term>
-          <Term label="Active Clusters">4</Term>
-          <Term label="Inactive Clusters">12</Term>
-        </TermList>
-      </Content>
-    </Card>
+    <TermList>
+      <Term label="Total Clusters">16</Term>
+      <Term label="Active Clusters">4</Term>
+      <Term label="Inactive Clusters">12</Term>
+    </TermList>
   );
 }
 
@@ -109,20 +126,14 @@ listOfTerms.story = {
 
 export function horizontalListOfTerms() {
   return (
-    <div style={{ width: '50%' }}>
-      <Card>
-        <Content>
-          <TermList horizontal>
-            <Term label="Total Clusters">16</Term>
-            <Term label="Inactive Clusters">12</Term>
-            <Term label="Active">123456789</Term>
-          </TermList>
-        </Content>
-      </Card>
-    </div>
+    <TermList horizontal>
+      <Term label="Total Clusters">16</Term>
+      <Term label="Inactive Clusters">12</Term>
+      <Term label="Active">123456789</Term>
+    </TermList>
   );
 }
 
 horizontalListOfTerms.story = {
-  name: 'Horizontal list of terms wrapped in List.',
+  name: 'Horizontal list of terms.',
 };


### PR DESCRIPTION
to: @milesj @schillerk 

## Description

noticed the `large` text prop wasn't working. fix for that. updated the stories to show usage of text properties!

## Motivation and Context

more people are starting to use this, seeing key/value pair lists in designs more.

## Testing

- storybook

## Screenshots

<img width="702" alt="Core : TermList - Examples of Term using Text properties   ⋅ Storybook 2020-04-20 11-45-02" src="https://user-images.githubusercontent.com/306275/79787787-653baa80-82fc-11ea-952f-bb898272766b.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
