### PR TITLE
new(Modal): Add `topBar` and `topBarCentered` support.

### DIFF
--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -89,6 +89,8 @@ export class ModalInner extends React.Component<ModalInnerProps & WithStylesProp
       styles,
       subtitle,
       title,
+      topBar,
+      topBarCentered,
     } = this.props;
 
     const showLargeContent = large || !!image;
@@ -101,6 +103,8 @@ export class ModalInner extends React.Component<ModalInnerProps & WithStylesProp
         scrollable={scrollable}
         subtitle={subtitle}
         title={title}
+        topBar={topBar}
+        topBarCentered={topBarCentered}
         onClose={this.handleClose}
       >
         {children}

--- a/packages/core/src/components/Modal/private/InnerContent.tsx
+++ b/packages/core/src/components/Modal/private/InnerContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import IconClose from '@airbnb/lunar-icons/lib/interface/IconClose';
+import Row from '../../Row';
 import Text from '../../Text';
 import Title from '../../Title';
 import IconButton from '../../IconButton';
@@ -23,6 +24,10 @@ export type ModalInnerContentProps = {
   subtitle?: React.ReactNode;
   /** Dialog header title. */
   title?: React.ReactNode;
+  /** Top bar, above dialog header. */
+  topBar?: React.ReactNode;
+  /** Whether the top bar content is centered. */
+  topBarCentered?: boolean;
   /** Callback for when the Dialog should be closed.  */
   onClose: (event: React.MouseEvent | React.KeyboardEvent) => void;
   /** Custom style sheet. */
@@ -39,6 +44,8 @@ export default function ModalInnerContent({
   scrollable,
   subtitle,
   title,
+  topBar,
+  topBarCentered,
   styleSheet,
 }: ModalInnerContentProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetInnerContent);
@@ -46,24 +53,38 @@ export default function ModalInnerContent({
   const withHeader = Boolean(title || subtitle);
   const withFooter = Boolean(footer);
 
+  const closeButton = (
+    <IconButton onClick={onClose}>
+      <IconClose
+        accessibilityLabel={T.phrase('lunar.common.close', 'Close')}
+        color={theme.color.muted}
+        size={theme.unit * 3}
+      />
+    </IconButton>
+  );
+
   return (
     <div className={cx(styles.wrapper)}>
+      {topBar && (
+        <div className={cx(styles.header, styles.topBar, topBarCentered && styles.topBar_centered)}>
+          <Row middleAlign after={closeButton}>
+            {topBar}
+          </Row>
+        </div>
+      )}
+
       {withHeader && (
         <header className={cx(styles.header, scrollable && styles.header_scrollable)}>
-          {title && <Title level={3}>{title}</Title>}
-          {subtitle && <Text muted>{subtitle}</Text>}
+          <Row after={topBar ? null : closeButton}>
+            <div className={cx(styles.headerInner)}>
+              {title && <Title level={3}>{title}</Title>}
+              {subtitle && <Text muted>{subtitle}</Text>}
+            </div>
+          </Row>
         </header>
       )}
 
-      <div className={cx(styles.close, !withHeader && styles.close_float)}>
-        <IconButton onClick={onClose}>
-          <IconClose
-            accessibilityLabel={T.phrase('lunar.common.close', 'Close')}
-            color={theme.color.muted}
-            size={theme.unit * 3}
-          />
-        </IconButton>
-      </div>
+      {!withHeader && !topBar && <div className={cx(styles.close_float)}>{closeButton}</div>}
 
       <div
         className={cx(
@@ -71,6 +92,7 @@ export default function ModalInnerContent({
           !withHeader && styles.body_paddingTop,
           !withFooter && styles.body_paddingBottom,
           scrollable && styles.body_scrollable,
+          scrollable && !withHeader && styles.body_scrollable_noHeader,
           small && scrollable && styles.body_scrollableSmall,
           large && scrollable && styles.body_scrollableLarge,
         )}

--- a/packages/core/src/components/Modal/story.tsx
+++ b/packages/core/src/components/Modal/story.tsx
@@ -16,12 +16,14 @@ class ModalDemo extends React.Component<
     showScrollable?: boolean;
     showSubtitle?: boolean;
     showTitle?: boolean;
+    showTopBar?: boolean;
+    showTopBarCentered?: boolean;
   },
   { visible: boolean }
 > {
   state = { visible: true };
 
-  handleToggle = () => this.setState((prevState) => ({ visible: !prevState.visible }));
+  handleToggle = () => this.setState(prevState => ({ visible: !prevState.visible }));
 
   handleClose = () => this.setState({ visible: false });
 
@@ -36,6 +38,8 @@ class ModalDemo extends React.Component<
       showScrollable,
       showSubtitle,
       showTitle,
+      showTopBar,
+      showTopBarCentered,
     } = this.props;
 
     return (
@@ -71,6 +75,8 @@ class ModalDemo extends React.Component<
             small={showSmall}
             subtitle={showSubtitle ? 'Modal Sub-Title' : undefined}
             title={showTitle ? <LoremIpsum short /> : undefined}
+            topBar={showTopBar ? <Text bold>Top bar</Text> : undefined}
+            topBarCentered={showTopBarCentered}
             onClose={this.handleClose}
           >
             <Text>
@@ -151,12 +157,44 @@ withTitleAndFooter.story = {
   name: 'With title and footer',
 };
 
+export function withTopBar() {
+  return <ModalDemo showTopBar />;
+}
+
+withTopBar.story = {
+  name: 'With top bar, not centered',
+};
+
+export function withTopBarCentered() {
+  return <ModalDemo showTopBar showTopBarCentered />;
+}
+
+withTopBarCentered.story = {
+  name: 'With top bar, centered',
+};
+
 export function scrollableContent() {
   return <ModalDemo showFooter showTitle showScrollable />;
 }
 
 scrollableContent.story = {
   name: 'Scrollable content',
+};
+
+export function withTopBarAndFooter() {
+  return <ModalDemo showFooter showTopBar showTopBarCentered showScrollable />;
+}
+
+withTopBarAndFooter.story = {
+  name: 'With top bar, topBarCentered, footer, and scrollable',
+};
+
+export function withTitleTopBarAndFooter() {
+  return <ModalDemo showTitle showFooter showTopBar showScrollable />;
+}
+
+withTitleTopBarAndFooter.story = {
+  name: 'With top bar, title, footer, and scrollable',
 };
 
 export function scrollableContentWithoutFooter() {

--- a/packages/core/src/components/Modal/story.tsx
+++ b/packages/core/src/components/Modal/story.tsx
@@ -23,7 +23,7 @@ class ModalDemo extends React.Component<
 > {
   state = { visible: true };
 
-  handleToggle = () => this.setState(prevState => ({ visible: !prevState.visible }));
+  handleToggle = () => this.setState((prevState) => ({ visible: !prevState.visible }));
 
   handleClose = () => this.setState({ visible: false });
 

--- a/packages/core/src/components/Modal/styles.ts
+++ b/packages/core/src/components/Modal/styles.ts
@@ -107,7 +107,11 @@ export const styleSheetInnerContent: StyleSheet = ({ color, ui, unit }) => ({
   },
 
   header: {
-    padding: `${unit * 3}px ${unit * 4}px ${unit * 3}px ${unit * 3}px`,
+    padding: `${unit * 2}px ${unit * 2}px ${unit * 3}px ${unit * 3}px`,
+  },
+
+  headerInner: {
+    paddingTop: unit,
   },
 
   header_scrollable: {
@@ -127,18 +131,18 @@ export const styleSheetInnerContent: StyleSheet = ({ color, ui, unit }) => ({
     },
   },
 
-  close: {
-    position: 'absolute',
-    top: unit * 2,
-    right: unit * 2,
-    zIndex: Z_INDEX_MODAL,
+  topBar: {
+    borderBottom: ui.border,
+    paddingBottom: unit * 2,
+  },
+
+  topBar_centered: {
+    textAlign: 'center',
+    paddingLeft: unit * 8, // width of close button + padding around to offset top bar content
   },
 
   close_float: {
     float: 'right',
-    position: 'relative',
-    top: 0,
-    right: 0,
     margin: `${unit * 2}px ${unit * 2}px ${unit / 2}px ${unit / 2}px`,
   },
 
@@ -167,6 +171,12 @@ export const styleSheetInnerContent: StyleSheet = ({ color, ui, unit }) => ({
       marginLeft: -unit * 3,
       height: unit / 2,
       background: color.accent.bg,
+    },
+  },
+
+  body_scrollable_noHeader: {
+    ':before': {
+      display: 'none',
     },
   },
 

--- a/packages/core/test/components/Modal.test.tsx
+++ b/packages/core/test/components/Modal.test.tsx
@@ -315,6 +315,21 @@ describe('<Modal />', () => {
     expect(wrapper.find('header').find(Text).prop('children')).toBe('Subtitle');
   });
 
+  it('renders a top bar', () => {
+    const { wrapper } = setup(
+      {
+        title: null,
+        topBar: 'Top bar',
+      },
+      false /* isShallow */,
+    );
+
+    expect(wrapper.find('header')).toHaveLength(0);
+
+    const div = wrapper.find(ModalInnerContent).find('div').at(1);
+    expect(div.text()).toContain('Top bar');
+  });
+
   it('no header if no title is provided', () => {
     const { wrapper } = setup(
       {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

new top bar request from design. can put whatever in it! has a border on the bottom with an option to center align (through text-align) the content. works independent of title/subtitle/header.

## Motivation and Context

design needs

## Testing

storybook

## Screenshots

<img width="1342" alt="Core : Modal - With top bar , not centered ⋅ Storybook 2020-04-20 15-24-16" src="https://user-images.githubusercontent.com/306275/79807502-ebb5b380-831f-11ea-891b-1dda621345a7.png">

<img width="1342" alt="Core : Modal - With top bar , centered ⋅ Storybook 2020-04-20 15-25-02" src="https://user-images.githubusercontent.com/306275/79807504-ee180d80-831f-11ea-8dbe-33d433e6cc03.png">

<img width="1342" alt="Core : Modal - With top bar , topBarCentered , footer , and scrollable ⋅ Storybook 2020-04-20 15-25-35" src="https://user-images.githubusercontent.com/306275/79807507-eeb0a400-831f-11ea-87c5-61d2b23a4fcd.png">

<img width="1342" alt="Core : Modal - With top bar , title , footer , and scrollable ⋅ Storybook 2020-04-20 15-26-23" src="https://user-images.githubusercontent.com/306275/79807509-ef493a80-831f-11ea-93ca-3fd12904aa92.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
