### PR TITLE
update(ErrorMessage): Handle error object props more robustly.

### DIFF
--- a/packages/core/src/components/ErrorMessage/index.tsx
+++ b/packages/core/src/components/ErrorMessage/index.tsx
@@ -12,15 +12,11 @@ export function getErrorMessage(error: string | ErrorType, includeCode: boolean 
     return error;
   }
 
-  if (error instanceof Error) {
-    return error.message;
-  }
-
   const debug = error.debug_info;
 
   const message = debug
     ? `${debug.error_class} - ${debug.error_message || debug.response_message}`
-    : error.user_message || error.error_details || error.error_message;
+    : error.user_message || error.error_details || error.error_message || (error as Error).message;
 
   if (includeCode && error.error_code) {
     return `${error.error_code} - ${message}`;
@@ -60,9 +56,9 @@ export default function ErrorMessage({
   }
 
   const message = subtitle || getErrorMessage(error);
-  const code = error instanceof Error ? null : error.error_code;
-  const id = error instanceof Error ? null : error.error_id;
-  const url = error instanceof Error ? '' : error.error_url;
+  const code = error.error_code || '';
+  const id = error.error_id || '';
+  const url = error.error_url || '';
 
   if (inline) {
     return <StatusText danger>{message}</StatusText>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,17 +13,17 @@ export type Translator = (
   options?: TranslateOptions,
 ) => string;
 
-export type ErrorType =
-  | {
-      error_id?: string;
-      error_code?: number | string;
-      error_message?: string;
-      error_details?: string;
-      error_url?: string;
-      debug_info?: { [key: string]: string };
-      user_message?: string;
-    }
-  | Error;
+export type ErrorObject = {
+  error_id?: string;
+  error_code?: number | string;
+  error_message?: string;
+  error_details?: string;
+  error_url?: string;
+  debug_info?: { [key: string]: string };
+  user_message?: string;
+};
+
+export type ErrorType = ErrorObject | (Error & ErrorObject);
 
 export type StatusType = 'notice' | 'info' | 'success' | 'warning' | 'danger' | 'muted';
 

--- a/packages/core/test/components/ErrorMessage.test.tsx
+++ b/packages/core/test/components/ErrorMessage.test.tsx
@@ -5,6 +5,7 @@ import Alert from '../../src/components/Alert';
 import MutedButton from '../../src/components/MutedButton';
 import ErrorMessage, { getErrorMessage } from '../../src/components/ErrorMessage';
 import StatusText from '../../src/components/StatusText';
+import { ErrorObject } from '../../src/types';
 
 describe('getErrorMessage()', () => {
   it('returns empty string for no message', () => {
@@ -74,8 +75,14 @@ describe('getErrorMessage()', () => {
     ).toBe('404 - FooBar - Systems are offline!');
   });
 
-  it('supports Error objects', () => {
+  it('supports Error instances', () => {
     expect(getErrorMessage(new Error('Danger Will Robinson!'))).toBe('Danger Will Robinson!');
+  });
+
+  it('supports Error instances with additional properties', () => {
+    const error = new Error('Not useful message') as ErrorObject; // Satisfy TS.
+    error.error_message = 'Very useful message';
+    expect(getErrorMessage(error)).toBe('Very useful message');
   });
 });
 
@@ -168,6 +175,34 @@ describe('<ErrorMessage />', () => {
         error_message: 'Failure',
         error_id: 'ABC',
       },
+    });
+
+    expect(
+      wrapper
+        .find(Alert)
+        .find(MutedButton)
+        .contains(<T k="lunar.error.viewDetails" phrase="View error details" />),
+    ).toBe(true);
+    expect(typeof wrapper.find(Alert).find(MutedButton).prop('onClick')).toBe('function');
+  });
+
+  it('renders a button if an error instance containing an error ID is passed', () => {
+    const error = new Error('Whatever') as ErrorObject; // Satisfy TS.
+
+    const wrapper = shallow(<ErrorMessage error={error} />);
+
+    expect(
+      wrapper
+        .find(Alert)
+        .find(MutedButton)
+        .contains(<T k="lunar.error.viewDetails" phrase="View error details" />),
+    ).toBe(false);
+
+    error.error_message = 'Failure';
+    error.error_id = 'ABC';
+
+    wrapper.setProps({
+      error,
     });
 
     expect(


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Check for the presence of properties on `Error` objects instead of gating by type (`instanceof Error`).

## Motivation and Context

`APIError` instances (`error instanceof Error === true`) _do_ have additional properties on them which can be used to render more information in the `ErrorMessage` component. Let's use them.

## Testing

Added/updated tests. Ran storybook locally.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
