### PR TITLE
update(ErrorMessage): Add trace ID link

### DIFF
--- a/packages/core/src/components/ErrorMessage/index.tsx
+++ b/packages/core/src/components/ErrorMessage/index.tsx
@@ -25,11 +25,6 @@ export function getErrorMessage(error: string | ErrorType, includeCode: boolean 
   return message || '';
 }
 
-// istanbul ignore next
-function createRedirectURL(id: string, url?: string) {
-  return () => window.open(url || Core.settings.errorURL.replace('{{id}}', id), '_blank');
-}
-
 export type ErrorMessageProps = {
   /** An `Error` instance or an API endpoint response. */
   error?: ErrorType;
@@ -57,8 +52,8 @@ export default function ErrorMessage({
 
   const message = subtitle || getErrorMessage(error);
   const code = error.error_code || '';
-  const id = error.error_id || '';
-  const url = error.error_url || '';
+  const errorID = error.error_id || '';
+  const traceID = error.trace_id || '';
 
   if (inline) {
     return <StatusText danger>{message}</StatusText>;
@@ -72,10 +67,26 @@ export default function ErrorMessage({
     >
       {message}
 
-      {id && (
+      {errorID && (
         <Spacing top={1}>
-          <MutedButton inverted onClick={createRedirectURL(id, url)}>
+          <MutedButton
+            inverted
+            openInNewWindow
+            href={error.error_url || Core.settings.errorURL.replace('{{id}}', errorID)}
+          >
             <T k="lunar.error.viewDetails" phrase="View error details" />
+          </MutedButton>
+        </Spacing>
+      )}
+
+      {traceID && (
+        <Spacing top={1}>
+          <MutedButton
+            inverted
+            openInNewWindow
+            href={Core.settings.traceURL.replace('{{id}}', traceID)}
+          >
+            <T k="lunar.trace.viewDetails" phrase="View trace details" />
           </MutedButton>
         </Spacing>
       )}

--- a/packages/core/src/components/ErrorMessage/index.tsx
+++ b/packages/core/src/components/ErrorMessage/index.tsx
@@ -6,6 +6,7 @@ import Spacing from '../Spacing';
 import StatusText from '../StatusText';
 import { ErrorType } from '../../types';
 import Core from '../..';
+import ButtonGroup from '../ButtonGroup';
 
 export function getErrorMessage(error: string | ErrorType, includeCode: boolean = false): string {
   if (typeof error === 'string') {
@@ -67,27 +68,31 @@ export default function ErrorMessage({
     >
       {message}
 
-      {errorID && (
+      {(errorID || traceID) && (
         <Spacing top={1}>
-          <MutedButton
-            inverted
-            openInNewWindow
-            href={error.error_url || Core.settings.errorURL.replace('{{id}}', errorID)}
-          >
-            <T k="lunar.error.viewDetails" phrase="View error details" />
-          </MutedButton>
-        </Spacing>
-      )}
+          <ButtonGroup>
+            {errorID && (
+              <MutedButton
+                inverted
+                small
+                openInNewWindow
+                href={error.error_url || Core.settings.errorURL.replace('{{id}}', errorID)}
+              >
+                <T k="lunar.error.viewDetails" phrase="View error details" />
+              </MutedButton>
+            )}
 
-      {traceID && (
-        <Spacing top={1}>
-          <MutedButton
-            inverted
-            openInNewWindow
-            href={Core.settings.traceURL.replace('{{id}}', traceID)}
-          >
-            <T k="lunar.trace.viewDetails" phrase="View trace details" />
-          </MutedButton>
+            {traceID && (
+              <MutedButton
+                inverted
+                small
+                openInNewWindow
+                href={Core.settings.traceURL.replace('{{id}}', traceID)}
+              >
+                <T k="lunar.trace.viewDetails" phrase="View trace details" />
+              </MutedButton>
+            )}
+          </ButtonGroup>
         </Spacing>
       )}
     </Alert>

--- a/packages/core/src/components/ErrorMessage/story.tsx
+++ b/packages/core/src/components/ErrorMessage/story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ErrorMessage from '.';
+import { ErrorObject } from '../../types';
 
 export default {
   title: 'Core/ErrorMessage',
@@ -30,4 +31,16 @@ export function fromAnApiEndpointError() {
 
 fromAnApiEndpointError.story = {
   name: 'From an API endpoint error.',
+};
+
+export function fromAnApiEndpointErrorWithTraceID() {
+  // Would be shown for an APIError from airbnb-api-resource.
+  const error = new Error('Oh noes') as ErrorObject;
+  error.trace_id = 'tRaCeId==';
+
+  return <ErrorMessage error={error} />;
+}
+
+fromAnApiEndpointErrorWithTraceID.story = {
+  name: 'From an API endpoint error with Trace ID.',
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export type Settings = {
   defaultTimezone?: TimeZone;
   emojiCDN?: EmojiPath;
   errorURL?: string;
+  traceURL?: string;
   fontFaces?: { [fontFamily: string]: FontFace[] };
   fontFamily?: string;
   logger?: Logger | null;
@@ -41,6 +42,7 @@ class Core {
     defaultTimezone: getTimezoneFromClient() || DEFAULT_TIMEZONE,
     emojiCDN: '',
     errorURL: '',
+    traceURL: '',
     fontFaces: {},
     fontFamily:
       '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,6 +21,7 @@ export type ErrorObject = {
   error_url?: string;
   debug_info?: { [key: string]: string };
   user_message?: string;
+  trace_id?: string;
 };
 
 export type ErrorType = ErrorObject | (Error & ErrorObject);

--- a/packages/core/test/components/ErrorMessage.test.tsx
+++ b/packages/core/test/components/ErrorMessage.test.tsx
@@ -6,8 +6,14 @@ import MutedButton from '../../src/components/MutedButton';
 import ErrorMessage, { getErrorMessage } from '../../src/components/ErrorMessage';
 import StatusText from '../../src/components/StatusText';
 import { ErrorObject } from '../../src/types';
+import Core from '../../src';
 
 describe('getErrorMessage()', () => {
+  beforeAll(() => {
+    Core.settings.errorURL = 'http://error-url-test.com/{{id}}';
+    Core.settings.traceURL = 'http://trace-url-test.com/{{id}}';
+  });
+
   it('returns empty string for no message', () => {
     expect(getErrorMessage({})).toBe('');
   });
@@ -183,7 +189,9 @@ describe('<ErrorMessage />', () => {
         .find(MutedButton)
         .contains(<T k="lunar.error.viewDetails" phrase="View error details" />),
     ).toBe(true);
-    expect(typeof wrapper.find(Alert).find(MutedButton).prop('onClick')).toBe('function');
+    expect(wrapper.find(Alert).find(MutedButton).prop('href')).toBe(
+      'http://error-url-test.com/ABC',
+    );
   });
 
   it('renders a button if an error instance containing an error ID is passed', () => {
@@ -211,6 +219,43 @@ describe('<ErrorMessage />', () => {
         .find(MutedButton)
         .contains(<T k="lunar.error.viewDetails" phrase="View error details" />),
     ).toBe(true);
-    expect(typeof wrapper.find(Alert).find(MutedButton).prop('onClick')).toBe('function');
+    expect(wrapper.find(Alert).find(MutedButton).prop('href')).toBe(
+      'http://error-url-test.com/ABC',
+    );
+  });
+
+  it('renders a button if an trace ID is passed', () => {
+    const error = new Error('Whatever') as ErrorObject; // Satisfy TS.
+
+    const wrapper = shallow(
+      <ErrorMessage
+        error={{
+          error_message: 'Failure',
+        }}
+      />,
+    );
+
+    expect(
+      wrapper
+        .find(Alert)
+        .find(MutedButton)
+        .contains(<T k="lunar.trace.viewDetails" phrase="View trace details" />),
+    ).toBe(false);
+
+    error.trace_id = 'tRaCiD1337==';
+
+    wrapper.setProps({
+      error,
+    });
+
+    expect(
+      wrapper
+        .find(Alert)
+        .find(MutedButton)
+        .contains(<T k="lunar.trace.viewDetails" phrase="View trace details" />),
+    ).toBe(true);
+    expect(wrapper.find(Alert).find(MutedButton).prop('href')).toBe(
+      'http://trace-url-test.com/tRaCiD1337==',
+    );
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

- Add `traceURL` setting
- Use `trace_id` property from `ErrorMessage` for link for more info on that trace ID
- Update the `Button` to a `Link` (no need for it to be a button that I can think of - don't need to generate the URL "on the fly" when the button is clicked, we can use a plain anchor tag)

## Motivation and Context

Allow better debugging when a `trace_id` is present in an `Error` passed to `ErrorMessage` component.

## Testing

Added tests. Ran `sg` locally and verified.

## Screenshots

![image](https://user-images.githubusercontent.com/839082/79928439-d318cc80-83f7-11ea-8546-12de177f31db.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
