### PR TITLE
fix(Loader): remove redundant spacing

### DIFF
--- a/packages/core/src/components/Loader/styles.ts
+++ b/packages/core/src/components/Loader/styles.ts
@@ -38,6 +38,11 @@ export const styleSheetLoader: StyleSheet = ({ color, unit }) => ({
     animationFillMode: 'both',
     verticalAlign: 'middle',
     backgroundColor: color.core.primary[3],
+    '@selectors': {
+      ':last-child': {
+        marginRight: 0,
+      },
+    },
   },
 
   dot_inverted: {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

Remove redundant spacing after the last dot, so loader can be align horizontal center accurately.

## Motivation and Context

As description.

## Testing

Verified it looks correct in storyboard.

## Screenshots

<img width="275" alt="Screen Shot 2020-04-26 at 1 37 41 PM" src="https://user-images.githubusercontent.com/3402429/80298906-33768800-87c3-11ea-97a2-c242cd4bed30.png">
<img width="272" alt="Screen Shot 2020-04-26 at 1 38 11 PM" src="https://user-images.githubusercontent.com/3402429/80298908-35404b80-87c3-11ea-8ac5-1a33dde65cb5.png">

## Checklist

- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
