### PR TITLE
fix(DataTable): Don't cast undefined to a string

### DIFF
--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -74,7 +74,7 @@ export default function ColumnLabels({
 
       // TODO: The types here are very wrong and confusing.
       const { children } = col.props;
-      const key = String(children[0].props.children);
+      const key = children[0].props.children ? String(children[0].props.children) : '';
       const label = columnToLabel[key]
         ? columnToLabel[key]
         : key && caseColumnLabel(key, columnLabelCase!);
@@ -87,7 +87,7 @@ export default function ColumnLabels({
       const showDivider = showColumnDividers && !!label && !isRightmost;
 
       const sortable =
-        !columnMetadata || !columnMetadata[key] || columnMetadata[key].disableSorting !== 1;
+        !columnMetadata || !columnMetadata?.[key] || columnMetadata[key].disableSorting !== 1;
 
       const newHeader = (
         <Spacing left={indent && !isLeftmost ? 2 : 0}>

--- a/packages/core/src/components/DataTable/ColumnLabels.tsx
+++ b/packages/core/src/components/DataTable/ColumnLabels.tsx
@@ -87,7 +87,7 @@ export default function ColumnLabels({
       const showDivider = showColumnDividers && !!label && !isRightmost;
 
       const sortable =
-        !columnMetadata || !columnMetadata?.[key] || columnMetadata[key].disableSorting !== 1;
+        !columnMetadata || !columnMetadata[key] || columnMetadata[key].disableSorting !== 1;
 
       const newHeader = (
         <Spacing left={indent && !isLeftmost ? 2 : 0}>


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
cc @schillerk 

## Description

Fixes an issue with DataTable where [this commit](https://github.com/airbnb/lunar/commit/1db54a9cd9b6850f2fca7f2d71e6cf174333707b#diff-8cd6767ced5d1ee6e96c679cc4d680f6R77) casts `undefined` to a `string` which `react-virtualized` interprets as needing a sortable column. This breaks styles for any table that is expandable or selectable.

## Motivation and Context

See above.

## Testing

- [x] CI
- [x] functional

## Screenshots

**Before**
(note the sortable `undefined` in the first column)
![image](https://user-images.githubusercontent.com/4496521/80671505-e6aedd80-8a5e-11ea-918b-a598056d6c6e.png)

**After**
![image](https://user-images.githubusercontent.com/4496521/80671472-cda62c80-8a5e-11ea-90d5-1c87c70d63c4.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
