### PR TITLE
new(DateTime, DateTimeRange, DateTimeSelect, Price, PriceComparison, PriceGroup): Add empty fallback if an invalid value is provided.

### DIFF
--- a/packages/core/src/components/DatePicker/index.tsx
+++ b/packages/core/src/components/DatePicker/index.tsx
@@ -99,7 +99,7 @@ export default function DatePicker(props: DatePickerProps) {
       modifiers={getCustomModifiers(modifiers, styles, cx)}
       month={month}
       months={getMonths()}
-      navbarElement={navProps => (
+      navbarElement={(navProps) => (
         <NavBar
           {...navProps}
           noFooter={!todayButton}

--- a/packages/core/src/components/DatePicker/index.tsx
+++ b/packages/core/src/components/DatePicker/index.tsx
@@ -99,7 +99,7 @@ export default function DatePicker(props: DatePickerProps) {
       modifiers={getCustomModifiers(modifiers, styles, cx)}
       month={month}
       months={getMonths()}
-      navbarElement={(navProps) => (
+      navbarElement={navProps => (
         <NavBar
           {...navProps}
           noFooter={!todayButton}

--- a/packages/core/src/components/DatePicker/story.tsx
+++ b/packages/core/src/components/DatePicker/story.tsx
@@ -74,6 +74,7 @@ class DatePickerResetDemo extends React.Component<{}, ResetState> {
         showResetButton
         initialMonth={new Date(2019, 1, 1)}
         selectedDays={selectedDays}
+        // @ts-ignore valid `at` won't return `null`
         todayButton={DateTime.format({
           at: Date.now(),
           medium: true,
@@ -174,6 +175,7 @@ class DatePickerMouseRangeSelectDemo extends React.Component<{}, RangeState> {
             modifiers={modifiers}
             numberOfMonths={2}
             selectedDays={selectedDays}
+            // @ts-ignore valid `at` won't return `null`
             todayButton={DateTime.format({
               at: Date.now(),
               medium: true,
@@ -209,6 +211,7 @@ export function displayATodayButton() {
   return (
     <DatePicker
       initialMonth={new Date(2019, 1, 1)}
+      // @ts-ignore valid `at` won't return `null`
       todayButton={DateTime.format({
         at: Date.now(),
         medium: true,

--- a/packages/core/src/components/DatePickerInput/index.tsx
+++ b/packages/core/src/components/DatePickerInput/index.tsx
@@ -71,8 +71,7 @@ export default class DatePickerInput extends React.Component<
     // Update the parent form with the selected value.
     // We also don't have a real event object, so fake it.
     this.props.onChange(
-      // @ts-ignore null check happened above
-      this.formatDate(day),
+      this.formatDate(day)!,
       day,
       // @ts-ignore
       {},
@@ -105,7 +104,7 @@ export default class DatePickerInput extends React.Component<
       locale: locale ?? this.props.locale,
       noTime: true,
       noTimezone: true,
-    }) as string;
+    })!;
   };
 
   render() {

--- a/packages/core/src/components/DatePickerInput/index.tsx
+++ b/packages/core/src/components/DatePickerInput/index.tsx
@@ -71,6 +71,7 @@ export default class DatePickerInput extends React.Component<
     // Update the parent form with the selected value.
     // We also don't have a real event object, so fake it.
     this.props.onChange(
+      // @ts-ignore null check happened above
       this.formatDate(day),
       day,
       // @ts-ignore
@@ -84,6 +85,7 @@ export default class DatePickerInput extends React.Component<
 
   parseDate = (value: string, format?: string, locale?: string) => {
     try {
+      // @ts-ignore Allow it to fail
       return createDateTime(value, {
         sourceFormat: format ?? this.getFormat(),
         locale: locale ?? this.props.locale,
@@ -103,7 +105,7 @@ export default class DatePickerInput extends React.Component<
       locale: locale ?? this.props.locale,
       noTime: true,
       noTimezone: true,
-    });
+    }) as string;
   };
 
   render() {

--- a/packages/core/src/components/DateTime/story.tsx
+++ b/packages/core/src/components/DateTime/story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import DateTime from '.';
+import Empty from '../Empty';
 
 const future = new Date();
 future.setDate(future.getDate() + 12);
@@ -76,4 +77,25 @@ export function usingStaticMethod() {
 
 usingStaticMethod.story = {
   name: 'Using static method.',
+};
+
+export function withAnInvalidAtValue() {
+  return (
+    <div>
+      <div>
+        Component fallback: <DateTime at="[Hidden]" />
+      </div>
+
+      <div>Static method with fallback: {DateTime.format({ at: '[Hidden]', long: true })}</div>
+
+      <div>
+        Static method with custom fallback:{' '}
+        {DateTime.format({ at: '[Hidden]', long: true }) || <Empty />}
+      </div>
+    </div>
+  );
+}
+
+withAnInvalidAtValue.story = {
+  name: 'Fallback when an invalid date value is provided.',
 };

--- a/packages/core/src/components/DateTimeRange/index.tsx
+++ b/packages/core/src/components/DateTimeRange/index.tsx
@@ -35,13 +35,24 @@ export default function DateTimeRange({
   const fromTimeStamp = createDateTime(from, { locale, timezone });
   const toTimeStamp = createDateTime(to, { locale, timezone });
 
-  if (__DEV__) {
-    if (!fromTimeStamp.isValid || !toTimeStamp.isValid) {
-      throw new Error('Invalid timestamps passed to `DateTimeRange`.');
+  if (
+    !fromTimeStamp ||
+    !toTimeStamp ||
+    (fromTimeStamp && !fromTimeStamp.isValid) ||
+    (toTimeStamp && !toTimeStamp.isValid)
+  ) {
+    if (__DEV__) {
+      console.error(
+        `Invalid ${!fromTimeStamp ? 'fromTimeStamp' : 'toTimeStamp'} passed to \`DateTimeRange\`.`,
+      );
     }
 
+    return <Empty />;
+  }
+
+  if (__DEV__) {
     if (toTimeStamp < fromTimeStamp) {
-      throw new Error('Invalid chronological order of timestamps passed to `DateTimeRange`.');
+      console.error('Invalid chronological order of timestamps passed to `DateTimeRange`.');
     }
   }
 

--- a/packages/core/src/components/DateTimeRange/story.tsx
+++ b/packages/core/src/components/DateTimeRange/story.tsx
@@ -47,3 +47,25 @@ export function differentYearsRangeWithCustomSeparator() {
 differentYearsRangeWithCustomSeparator.story = {
   name: 'Different years range with custom separator.',
 };
+
+export function withAnInvalidValues() {
+  return (
+    <div>
+      <div>
+        Invalid from: <DateTimeRange from="[Hidden]" to={new Date(2019, 1, 17, 0, 0, 0)} />
+      </div>
+
+      <div>
+        Invalid to: <DateTimeRange from={new Date(2019, 1, 15, 0, 0, 0)} to="[Hidden]" />
+      </div>
+
+      <div>
+        Both invalid: <DateTimeRange from="[Hidden]" to="[Hidden]" />
+      </div>
+    </div>
+  );
+}
+
+withAnInvalidValues.story = {
+  name: 'Fallback when an invalid date values are provided.',
+};

--- a/packages/core/src/components/DateTimeSelect/index.tsx
+++ b/packages/core/src/components/DateTimeSelect/index.tsx
@@ -66,10 +66,15 @@ export class DateTimeSelect extends React.Component<
     yearPastBuffer: 80,
   };
 
-  private date = createDateTime(this.props.value, {
-    locale: this.props.locale,
-    timezone: this.props.timezone,
-  }).set({ minute: 0, second: 0 });
+  private date: DateTime = (
+    createDateTime(this.props.value, {
+      locale: this.props.locale,
+      timezone: this.props.timezone,
+    }) ?? this.getNowDate()
+  ).set({
+    minute: 0,
+    second: 0,
+  });
 
   state = {
     id: uuid(),
@@ -83,16 +88,28 @@ export class DateTimeSelect extends React.Component<
     // Don't set minute/second to 0 here, because when used in conjunction with the form kit,
     // the value is always passed down, causing the numbers to always reset to 0.
     if (value !== prevProps.value) {
-      const date = createDateTime(value, {
-        locale,
-        timezone,
-      });
+      const date =
+        createDateTime(value, {
+          locale,
+          timezone,
+        }) ?? this.getNowDate();
 
       this.setState({
         date,
-        meridiem: date.get('hour') <= 11 ? 'am' : 'pm',
+        meridiem: date && date.get('hour') <= 11 ? 'am' : 'pm',
       });
     }
+  }
+
+  getNowDate() {
+    const { locale, timezone } = this.props;
+    let date = DateTime.utc().setLocale(locale!);
+
+    if (timezone && timezone !== 'UTC') {
+      date = date.setZone(timezone as string);
+    }
+
+    return date;
   }
 
   getDayRange(): Range {
@@ -140,7 +157,7 @@ export class DateTimeSelect extends React.Component<
   }
 
   getYearRange(): Range {
-    const now = createDateTime();
+    const now = createDateTime() ?? this.getNowDate();
 
     return createRange(
       now.year - this.props.yearPastBuffer!,

--- a/packages/core/src/components/DateTimeSelect/index.tsx
+++ b/packages/core/src/components/DateTimeSelect/index.tsx
@@ -96,7 +96,7 @@ export class DateTimeSelect extends React.Component<
 
       this.setState({
         date,
-        meridiem: date && date.get('hour') <= 11 ? 'am' : 'pm',
+        meridiem: date?.get('hour') <= 11 ? 'am' : 'pm',
       });
     }
   }

--- a/packages/core/src/components/DateTimeSelect/story.tsx
+++ b/packages/core/src/components/DateTimeSelect/story.tsx
@@ -169,3 +169,18 @@ export function withInlineLabel() {
 withInlineLabel.story = {
   name: 'With inline label.',
 };
+
+export function withInvalidDate() {
+  return (
+    <DateTimeSelect
+      name="dts-basic"
+      label="Label"
+      value="[Hidden]"
+      onChange={() => console.log('onChange')}
+    />
+  );
+}
+
+withInvalidDate.story = {
+  name: "Fallback to today's date if value is invalid",
+};

--- a/packages/core/src/components/Price/index.tsx
+++ b/packages/core/src/components/Price/index.tsx
@@ -23,7 +23,7 @@ export type CommonProps = {
 
 export type PriceProps = CommonProps & {
   /** The amount as a number. */
-  amount?: Amount | number | null;
+  amount?: Amount | number | null | string;
   /** Native currency of the amount. */
   currency?: Currency;
 };
@@ -43,7 +43,11 @@ function Price({
   let currency = baseCurrency;
   let micros = baseMicros;
 
-  if (baseAmount === undefined || baseAmount === null) {
+  if (
+    baseAmount === undefined ||
+    baseAmount === null ||
+    (typeof baseAmount === 'string' && isNaN(Number(baseAmount)))
+  ) {
     return <Empty />;
   }
 
@@ -51,6 +55,8 @@ function Price({
     currency = baseAmount.currency;
     micros = baseAmount.is_micros_accuracy;
     amount = micros ? baseAmount.amount_micros : baseAmount.amount;
+  } else if (typeof baseAmount === 'string') {
+    amount = Number(baseAmount);
   } else if (typeof baseAmount === 'number') {
     amount = baseAmount;
   }
@@ -73,7 +79,7 @@ function Price({
 }
 
 Price.propTypes = {
-  amount: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+  amount: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.string]),
   display: PropTypes.oneOf(['symbol', 'code', 'name']),
 };
 

--- a/packages/core/src/components/Price/story.tsx
+++ b/packages/core/src/components/Price/story.tsx
@@ -31,3 +31,12 @@ export function roundedAmountInJpy() {
 roundedAmountInJpy.story = {
   name: 'Rounded amount in JPY.',
 };
+
+export function withAnInvalidAmount() {
+  // @ts-ignore invalid amount type on purprose to demonstrate the fallback
+  return <Price amount="[Hidden]" currency="USD" />;
+}
+
+withAnInvalidAmount.story = {
+  name: 'Fallback when an invalid amount is provided.',
+};

--- a/packages/core/src/components/PriceComparison/index.tsx
+++ b/packages/core/src/components/PriceComparison/index.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DEFAULT_CURRENCY } from '../../constants';
+import Empty from '../Empty';
 import PriceGroup from '../PriceGroup';
 import { Amount } from '../../types';
 import { CommonProps } from '../Price';
 
 export type PriceComparisonProps = CommonProps & {
   /** The amount as a number. */
-  amount?: Amount | number | null;
+  amount?: Amount | number | null | string;
   /** The amount in USD. */
-  amountUSD?: Amount | number | null;
+  amountUSD?: Amount | number | null | string;
   /** Native currency of the amount. */
   currency?: string;
 };
@@ -26,22 +27,29 @@ function PriceComparison({
   const hasPriceUSD = amountUSD !== null && amountUSD !== undefined;
   const targetCurrency = amount && typeof amount === 'object' ? amount.currency : currency!;
 
+  if (
+    (typeof amount === 'string' && isNaN(Number(amount))) ||
+    (typeof amountUSD === 'string' && isNaN(Number(amountUSD)))
+  ) {
+    return <Empty />;
+  }
+
   // Sometimes the native price could be empty
   if (hasPrice) {
-    amounts[targetCurrency] = amount!;
+    amounts[targetCurrency] = typeof amount === 'string' ? Number(amount) : amount!;
   }
 
   // Show the USD price if the native price is empty, or if the currencies don't match
   if (hasPriceUSD && (!hasPrice || targetCurrency !== DEFAULT_CURRENCY)) {
-    amounts[DEFAULT_CURRENCY] = amountUSD!;
+    amounts[DEFAULT_CURRENCY] = typeof amountUSD === 'string' ? Number(amountUSD) : amountUSD!;
   }
 
   return <PriceGroup {...restProps} amounts={amounts} />;
 }
 
 PriceComparison.propTypes = {
-  amount: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
-  amountUSD: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+  amount: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.string]),
+  amountUSD: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.string]),
 };
 
 export default PriceComparison;

--- a/packages/core/src/components/PriceComparison/story.tsx
+++ b/packages/core/src/components/PriceComparison/story.tsx
@@ -31,3 +31,25 @@ export function onlyUsdAmounts() {
 onlyUsdAmounts.story = {
   name: 'Only USD amounts.',
 };
+
+export function withAnInvalidAmount() {
+  return (
+    <div>
+      {/* invalid amount type on purprose to demonstrate the fallback
+      // @ts-ignore */}
+      <PriceComparison amount="[Hidden]" amountUSD="[Hidden]" currency="EUR" />
+      <br />
+      {/* invalid amount type on purprose to demonstrate the fallback
+      // @ts-ignore */}
+      <PriceComparison amount="[Hidden]" currency="EUR" />
+      <br />
+      {/* invalid amount type on purprose to demonstrate the fallback
+      // @ts-ignore */}
+      <PriceComparison amountUSD="[Hidden]" currency="EUR" />
+    </div>
+  );
+}
+
+withAnInvalidAmount.story = {
+  name: 'Fallback when invalid amounts are provided.',
+};

--- a/packages/core/src/components/PriceGroup/index.tsx
+++ b/packages/core/src/components/PriceGroup/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { DEFAULT_CURRENCY } from '../../constants';
+import Empty from '../Empty';
 import Price, { CommonProps } from '../Price';
 import { Amount } from '../../types';
 
 export type PriceAmountDefinition = {
-  [currency: string]: number | Amount;
+  [currency: string]: Amount | number | string;
 };
 
 export type PriceGroupProps = CommonProps & {
@@ -29,6 +30,19 @@ export default function PriceGroup({ amounts, divider = ', ', ...restProps }: Pr
 
   // Loop through and generate the prices
   const output: JSX.Element[] = [];
+
+  let invalidAmounts = 0;
+  currencies.forEach(currency => {
+    const amount = amounts[currency];
+
+    if (typeof amount === 'string' && isNaN(Number(amount))) {
+      invalidAmounts += 1;
+    }
+  });
+
+  if (invalidAmounts === currencies.length) {
+    return <Empty />;
+  }
 
   currencies.forEach((currency, i) => {
     if (i > 0) {

--- a/packages/core/src/components/PriceGroup/index.tsx
+++ b/packages/core/src/components/PriceGroup/index.tsx
@@ -32,7 +32,7 @@ export default function PriceGroup({ amounts, divider = ', ', ...restProps }: Pr
   const output: JSX.Element[] = [];
 
   let invalidAmounts = 0;
-  currencies.forEach(currency => {
+  currencies.forEach((currency) => {
     const amount = amounts[currency];
 
     if (typeof amount === 'string' && isNaN(Number(amount))) {

--- a/packages/core/src/components/PriceGroup/story.tsx
+++ b/packages/core/src/components/PriceGroup/story.tsx
@@ -24,3 +24,43 @@ export function multipleCurrencyAmounts() {
 multipleCurrencyAmounts.story = {
   name: 'Multiple currency amounts.',
 };
+
+export function withAnInvalidAmount() {
+  return (
+    <div>
+      <div>
+        If all amounts are invalid, one empty:{' '}
+        <PriceGroup
+          amounts={{
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            USD: '[Hidden]',
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            EUR: '[Hidden]',
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            GBP: '[Hidden]',
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            JPY: '[Hidden]',
+          }}
+        />
+      </div>
+
+      <div>
+        If some amounts are invalid:{' '}
+        <PriceGroup
+          amounts={{
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            USD: '[Hidden]',
+            EUR: 345.67,
+            // @ts-ignore amount type on purprose to demonstrate the fallback
+            GBP: '[Hidden]',
+            JPY: 12345,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+withAnInvalidAmount.story = {
+  name: 'Fallback when invalid amounts are provided.',
+};

--- a/packages/core/src/utils/createDateTime.ts
+++ b/packages/core/src/utils/createDateTime.ts
@@ -17,10 +17,10 @@ export { DateTime };
 export default function createDateTime(
   value?: DateTimeType,
   { locale, sourceFormat, timezone }: Options = {},
-): DateTime {
+): DateTime | undefined {
   const options: BaseOptions = { locale: locale || clientLocale };
-  let date;
 
+  let date;
   if (timezone === false) {
     options.zone = utcZone;
   } else if (timezone === true) {
@@ -39,24 +39,32 @@ export default function createDateTime(
     return DateTime.fromISO(moment.toISOString(), options);
   }
 
-  // Parse in different formats
-  if (value instanceof DateTime) {
-    date = value.setLocale(options.locale!).setZone(options.zone);
-  } else if (value instanceof Date) {
-    date = DateTime.fromJSDate(value, options);
-  } else if (typeof value === 'string' && value) {
-    date = sourceFormat
-      ? DateTime.fromFormat(value, sourceFormat, options)
-      : DateTime.fromISO(value, options);
-  } else if (typeof value === 'number') {
-    date = DateTime.fromMillis(value, options);
-  } else {
-    date = DateTime.utc().setLocale(options.locale!);
+  try {
+    // Parse in different formats
+    if (value instanceof DateTime) {
+      date = value.setLocale(options.locale!).setZone(options.zone);
+    } else if (value instanceof Date) {
+      date = DateTime.fromJSDate(value, options);
+    } else if (typeof value === 'string' && value) {
+      date = sourceFormat
+        ? DateTime.fromFormat(value, sourceFormat, options)
+        : DateTime.fromISO(value, options);
+    } else if (typeof value === 'number') {
+      date = DateTime.fromMillis(value, options);
+    } else {
+      date = DateTime.utc().setLocale(options.locale!);
 
-    if (options.zone !== 'UTC') {
-      date = date.setZone(options.zone);
+      if (options.zone !== 'UTC') {
+        date = date.setZone(options.zone);
+      }
     }
-  }
 
-  return date;
+    return date;
+  } catch (error) {
+    if (__DEV__) {
+      console.error(error);
+    }
+
+    return undefined;
+  }
 }

--- a/packages/core/test/components/DateTime.test.tsx
+++ b/packages/core/test/components/DateTime.test.tsx
@@ -227,7 +227,7 @@ describe('<DateTime />', () => {
     describe('rendered output', () => {
       it('formats to relative time in the future', () => {
         const wrapper = shallow(
-          <DateTime relative at={createDateTime().plus({ years: 70 })} timezone="UTC" />,
+          <DateTime relative at={createDateTime()?.plus({ years: 70 })} timezone="UTC" />,
         ).dive();
 
         expect(wrapper.text()).toBe('in 69 years');
@@ -243,9 +243,13 @@ describe('<DateTime />', () => {
 
       it('uses the provided time when noFuture is set and the time is in the past', () => {
         const wrapper = shallow(
-          <DateTime relative noFuture at={createDateTime().minus({ seconds: 5 })} timezone="UTC" />,
+          <DateTime
+            relative
+            noFuture
+            at={createDateTime()?.minus({ seconds: 5 })}
+            timezone="UTC"
+          />,
         ).dive();
-
         expect(wrapper.text()).toBe('a few seconds ago');
       });
     });
@@ -255,6 +259,7 @@ describe('<DateTime />', () => {
     let base: LuxonDateTime;
 
     beforeEach(() => {
+      // @ts-ignore can't be undefined with the date being set...
       base = createDateTime(new Date(Date.UTC(2019, 1, 1)));
     });
 

--- a/packages/core/test/components/DateTimeRange.test.tsx
+++ b/packages/core/test/components/DateTimeRange.test.tsx
@@ -58,12 +58,10 @@ describe('<DateTimeRange />', () => {
 
   it('errors for an invalid time', () => {
     expect(() => shallow(<DateTimeRange from="2016-02-33" to={dateA} timezone="UTC" />)).toThrow(
-      'Invalid DateTime: unit out of range: you specified 33 (of type number) as a day, which is invalid',
+      'Invalid Date',
     );
 
-    expect(() => shallow(<DateTimeRange from={dateA} to="2016-02-33" />)).toThrow(
-      'Invalid DateTime: unit out of range: you specified 33 (of type number) as a day, which is invalid',
-    );
+    expect(() => shallow(<DateTimeRange from={dateA} to="2016-02-33" />)).toThrow('Invalid Date');
   });
 
   it('errors for inproperly ordered times', () => {

--- a/packages/core/test/components/Price.test.tsx
+++ b/packages/core/test/components/Price.test.tsx
@@ -11,6 +11,12 @@ describe('<Price />', () => {
       expect(wrapper.find(Empty)).toHaveLength(1);
     });
 
+    it('renders empty if invalid amount', () => {
+      const wrapper = shallow(<Price amount="[Hidden]" currency="USD" />);
+
+      expect(wrapper.find(Empty)).toHaveLength(1);
+    });
+
     it('render the amount in the currency', () => {
       const wrapper = shallow(<Price amount={12300} currency="JPY" />);
 

--- a/packages/core/test/components/PriceComparison.test.tsx
+++ b/packages/core/test/components/PriceComparison.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import PriceComparison from '../../src/components/PriceComparison';
+import Empty from '../../src/components/Empty';
 
 describe('<PriceComparison />', () => {
   it('render the amount in the currency', () => {
@@ -9,16 +10,36 @@ describe('<PriceComparison />', () => {
     expect(wrapper.text()).toBe('¥12,300');
   });
 
+  it('renders empty if invalid amount', () => {
+    const wrapper = mount(<PriceComparison amount="[Hidden]" currency="JPY" />);
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
+  });
+
   it('render the USD amount if no native amount passed', () => {
     const wrapper = mount(<PriceComparison amountUSD={123} currency="JPY" />);
 
     expect(wrapper.text()).toBe('$123.00');
   });
 
+  it('renders empty if invalid amountUSD', () => {
+    const wrapper = mount(<PriceComparison amountUSD="[Hidden]" currency="JPY" />);
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
+  });
+
   it('render both native and USD amounts', () => {
     const wrapper = mount(<PriceComparison amount={12300} amountUSD={123} currency="JPY" />);
 
     expect(wrapper.text()).toBe('¥12,300, $123.00');
+  });
+
+  it('renders empty if invalid amount and amountUSD', () => {
+    const wrapper = mount(
+      <PriceComparison amount="[Hidden]" amountUSD="[Hidden]" currency="JPY" />,
+    );
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
   });
 
   it('handles zeros accordingly', () => {

--- a/packages/core/test/components/PriceGroup.test.tsx
+++ b/packages/core/test/components/PriceGroup.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import PriceGroup from '../../src/components/PriceGroup';
+import Empty from '../../src/components/Empty';
 
 describe('<PriceGroup />', () => {
   it('render a single amount', () => {
@@ -9,10 +10,29 @@ describe('<PriceGroup />', () => {
     expect(wrapper.text()).toBe('£123.00');
   });
 
+  it('renders empty if invalid amount', () => {
+    const wrapper = mount(<PriceGroup amounts={{ GBP: '[Hidden]' }} />);
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
+  });
+
   it('render multiple amounts', () => {
     const wrapper = mount(<PriceGroup amounts={{ GBP: 123, JPY: 456 }} />);
 
     expect(wrapper.text()).toBe('£123.00, ¥456');
+  });
+
+  it('renders empty if all amounts are invalid', () => {
+    const wrapper = mount(<PriceGroup amounts={{ GBP: '[Hidden]', JPY: '[Hidden]' }} />);
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
+  });
+
+  it('renders empty if an amount is invalid in multiple amounts', () => {
+    const wrapper = mount(<PriceGroup amounts={{ GBP: 123, JPY: '[Hidden]' }} />);
+
+    expect(wrapper.find(Empty)).toHaveLength(1);
+    expect(wrapper.text()).toBe('£123.00, —');
   });
 
   it('render multiple amounts but place USD last', () => {

--- a/packages/core/test/utils/createDateTime.test.ts
+++ b/packages/core/test/utils/createDateTime.test.ts
@@ -13,6 +13,7 @@ describe('createDateTime()', () => {
     const utc = DateTime.utc();
     const time = createDateTime(null, { timezone: 'America/New_York' });
 
+    // @ts-ignore wont be undefined
     expect(utc.toISO()).not.toBe(time.toISO());
   });
 
@@ -20,6 +21,7 @@ describe('createDateTime()', () => {
     const utc = DateTime.utc();
     const time = createDateTime(null, { timezone: 'UTC' });
 
+    // @ts-ignore wont be undefined
     expect(parseISO(utc.toISO())).toBe(parseISO(time.toISO()));
   });
 
@@ -28,6 +30,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(luxon, { timezone: 'UTC' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toISO()).toBe(luxon.toISO());
 
     // Test immutability
@@ -39,7 +42,9 @@ describe('createDateTime()', () => {
     const time = createDateTime(luxon, { timezone: 'Europe/Paris' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.valueOf()).toBe(luxon.valueOf());
+    // @ts-ignore wont be undefined
     expect(time.zoneName).toBe('Europe/Paris');
   });
 
@@ -48,6 +53,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(date, { timezone: 'UTC' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toISO()).toBe(date.toISOString());
   });
 
@@ -56,6 +62,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(date, { timezone: 'UTC' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toISO()).toBe('1988-02-26T00:00:00.000Z');
   });
 
@@ -64,6 +71,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(date, { timezone: 'UTC', sourceFormat: 'MMMM d, yyyy' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toISO()).toBe('1988-02-26T00:00:00.000Z');
   });
 
@@ -72,6 +80,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(date);
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toMillis()).toBe(date);
   });
 
@@ -87,6 +96,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(0);
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toMillis()).toBe(0);
   });
 
@@ -94,6 +104,7 @@ describe('createDateTime()', () => {
     const time = createDateTime(-123);
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toMillis()).toBe(-123);
   });
 
@@ -102,6 +113,7 @@ describe('createDateTime()', () => {
     const time = createDateTime('');
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(time.toMillis()).toBeGreaterThanOrEqual(date);
   });
 
@@ -111,6 +123,13 @@ describe('createDateTime()', () => {
     const time = createDateTime(date, { timezone: 'UTC' });
 
     expect(time).toBeInstanceOf(DateTime);
+    // @ts-ignore wont be undefined
     expect(parseISO(time.toISO())).toBe(parseISO(date.toISOString()));
+  });
+
+  it('throws an error if date is invalid', () => {
+    expect(() => createDateTime('[Hidden]')).toThrow(
+      'Error: Invalid DateTime: unparsable: the input "[Hidden]" can\'t be parsed as ISO 8601',
+    );
   });
 });


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

handle bad values like `"[Hidden]"` being added to things expected timestamps or numbers representing an amount.

## Motivation and Context

caused components to crash

## Testing

- storybook
- new tests
- old tests passing

## Screenshots

<img width="970" alt="Core : DateTime - Fallback when an invalid date value is provided   ⋅ Storybook 2020-04-30 12-39-34" src="https://user-images.githubusercontent.com/306275/80752494-70eb5600-8ae0-11ea-9fb4-5c9580f102a8.png">
<img width="970" alt="Core : DateTimeRange - Fallback when an invalid date values are provided   ⋅ Storybook 2020-04-30 12-40-05" src="https://user-images.githubusercontent.com/306275/80752501-734db000-8ae0-11ea-9173-60682f9dbc32.png">
<img width="970" alt="Core : DateTimeSelect - Fallback to today ' s date if value is invalid ⋅ Storybook 2020-04-30 12-40-29" src="https://user-images.githubusercontent.com/306275/80752506-73e64680-8ae0-11ea-859c-066e5cb2120b.png">
<img width="970" alt="Core : Price - Fallback when an invalid amount is provided   ⋅ Storybook 2020-04-30 12-41-09" src="https://user-images.githubusercontent.com/306275/80752509-747edd00-8ae0-11ea-8211-e791ab1a4959.png">
<img width="971" alt="Core : PriceComparison - Fallback when invalid amounts are provided   ⋅ Storybook 2020-04-30 12-41-27" src="https://user-images.githubusercontent.com/306275/80752511-747edd00-8ae0-11ea-8f6a-817390a2d79d.png">
<img width="970" alt="Core : PriceGroup - Fallback when invalid amounts are provided   ⋅ Storybook 2020-04-30 12-42-00" src="https://user-images.githubusercontent.com/306275/80752513-75177380-8ae0-11ea-80e4-207f26cbde26.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
