### PR TITLE
new(DataTable): Add xLarge row size. Fix forceUpdate logic.

### DIFF
--- a/packages/core/src/components/DataTable/constants.tsx
+++ b/packages/core/src/components/DataTable/constants.tsx
@@ -1,15 +1,15 @@
-import { WidthProperties, RowHeightOptions } from "./types";
+import { WidthProperties, RowHeightOptions } from './types';
 
 export const SELECTION_OPTIONS = {
-  ACTIVE: "ACTIVE",
-  DISABLED: "DISABLED",
-  INACTIVE: "INACTIVE",
-  HAS_ACTIVE_CHILD: "HAS_ACTIVE_CHILD",
+  ACTIVE: 'ACTIVE',
+  DISABLED: 'DISABLED',
+  INACTIVE: 'INACTIVE',
+  HAS_ACTIVE_CHILD: 'HAS_ACTIVE_CHILD',
 };
 
 export const STATUS_OPTIONS = {
-  ALERT: "ALERT",
-  WARNING: "WARNING",
+  ALERT: 'ALERT',
+  WARNING: 'WARNING',
 };
 
 type HeightMap = {

--- a/packages/core/src/components/DataTable/constants.tsx
+++ b/packages/core/src/components/DataTable/constants.tsx
@@ -1,19 +1,19 @@
-import { WidthProperties } from './types';
+import { WidthProperties, RowHeightOptions } from "./types";
 
 export const SELECTION_OPTIONS = {
-  ACTIVE: 'ACTIVE',
-  DISABLED: 'DISABLED',
-  INACTIVE: 'INACTIVE',
-  HAS_ACTIVE_CHILD: 'HAS_ACTIVE_CHILD',
+  ACTIVE: "ACTIVE",
+  DISABLED: "DISABLED",
+  INACTIVE: "INACTIVE",
+  HAS_ACTIVE_CHILD: "HAS_ACTIVE_CHILD",
 };
 
 export const STATUS_OPTIONS = {
-  ALERT: 'ALERT',
-  WARNING: 'WARNING',
+  ALERT: "ALERT",
+  WARNING: "WARNING",
 };
 
 type HeightMap = {
-  [key: string]: number;
+  [key in RowHeightOptions]: number;
 };
 
 export const HEIGHT_TO_PX: HeightMap = {
@@ -21,6 +21,7 @@ export const HEIGHT_TO_PX: HeightMap = {
   small: 48,
   regular: 56,
   large: 64,
+  xLarge: 80,
   jumbo: 108,
 };
 

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -1,19 +1,19 @@
-import React from 'react';
-import { SortDirectionType, Table } from 'react-virtualized';
-import { WithStylesProps } from '../../composers/withStyles';
-import { DataTable } from './DataTable';
+import React from "react";
+import { SortDirectionType, Table } from "react-virtualized";
+import { WithStylesProps } from "../../composers/withStyles";
+import { DataTable } from "./DataTable";
 
 export type DataTableRef = (instance: DataTable) => void;
 export type TableRef = React.RefObject<Table>;
-export type RowHeightOptions = string;
+export type RowHeightOptions = "micro" | "small" | "regular" | "large" | "xLarge" | "jumbo";
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '';
+export type ColumnLabelCase = "sentence" | "title" | "uppercase" | "";
 
 export type DefaultDataTableProps = keyof DataTableProps;
 
 export type SortByValueAccessor<T extends GenericRow = GenericRow> = (
   row: T,
-  columnKey: string,
+  columnKey: string
 ) => unknown;
 
 export interface DataTableProps {
@@ -45,6 +45,8 @@ export interface DataTableProps {
   height?: number;
   /** References row fields to render as columns, infered from data if not specified. */
   keys?: string[];
+  /** If dynamicRowHeight is enabled, this sets the maximum value for measured row height. */
+  maximumDynamicRowHeight?: number;
   /** If dynamicRowHeight is enabled, this sets the minimum value for measured row height. */
   minimumDynamicRowHeight?: number;
   /**
@@ -208,7 +210,7 @@ export type RendererProps<T = RowData> = {
   /** Whether or not zebra mode is enabled. */
   zebra: boolean;
   /** Theme from Lunar. */
-  theme: WithStylesProps['theme'];
+  theme: WithStylesProps["theme"];
 };
 
 export type Renderer<T = RowData> = React.ComponentType<RendererProps<T>>;

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -1,19 +1,19 @@
-import React from "react";
-import { SortDirectionType, Table } from "react-virtualized";
-import { WithStylesProps } from "../../composers/withStyles";
-import { DataTable } from "./DataTable";
+import React from 'react';
+import { SortDirectionType, Table } from 'react-virtualized';
+import { WithStylesProps } from '../../composers/withStyles';
+import { DataTable } from './DataTable';
 
 export type DataTableRef = (instance: DataTable) => void;
 export type TableRef = React.RefObject<Table>;
-export type RowHeightOptions = "micro" | "small" | "regular" | "large" | "xLarge" | "jumbo";
+export type RowHeightOptions = 'micro' | 'small' | 'regular' | 'large' | 'xLarge' | 'jumbo';
 export type HeightOptions = RowHeightOptions | undefined;
-export type ColumnLabelCase = "sentence" | "title" | "uppercase" | "";
+export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '';
 
 export type DefaultDataTableProps = keyof DataTableProps;
 
 export type SortByValueAccessor<T extends GenericRow = GenericRow> = (
   row: T,
-  columnKey: string
+  columnKey: string,
 ) => unknown;
 
 export interface DataTableProps {
@@ -210,7 +210,7 @@ export type RendererProps<T = RowData> = {
   /** Whether or not zebra mode is enabled. */
   zebra: boolean;
   /** Theme from Lunar. */
-  theme: WithStylesProps["theme"];
+  theme: WithStylesProps['theme'];
 };
 
 export type Renderer<T = RowData> = React.ComponentType<RendererProps<T>>;

--- a/packages/core/test/components/DataTable.test.tsx
+++ b/packages/core/test/components/DataTable.test.tsx
@@ -384,14 +384,14 @@ describe('<DataTable /> does not break with weird props', () => {
     width: 500,
     tableHeaderLabel: 'My Table',
     zebra: true,
-    rowHeight: 'regular',
+    rowHeight: 'regular' as const,
     columnMetadata,
     columnToLabel: {
       name: 'CUSTOM NAME',
     },
     expandable: true,
-    columnHeaderHeight: 'micro',
-    tableHeaderHeight: 'large',
+    columnHeaderHeight: 'micro' as const,
+    tableHeaderHeight: 'large' as const,
     keys: ['name'],
     showRowDividers: true,
   };


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf
cc @schillerk 

## Description

This PR
- adds a new row size to `DataTable`: `xLarge`
- improves the `rowHeight` type from `string` to a union of possible `string`
- tries to fix some conditions which lead to infinite re-renders from `forceUpdate` calls in `componentDidUpdate`

## Motivation and Context

I've been trying to upgrade to lunar v3 and some of our tables are pretty broken, especially for dynamic row height. Adding an additional fixed row height will alleviate some of these issues for us, and I'm hoping the `forceUpdate` logic may help. I'm not sure if there have been regressions, but it's pretty easy to generate a stack trace in the storybook now. Go [here](https://airbnb.io/lunar/?path=/story/core-datatable--a-table-with-dynamic-sort-key), expand the row, then sort a column 😱 

I couldn't think of a great way to remove the force updates, but I tried to clean it up a bit. You can still get the stack trace from resizing the window many times, unfortunately the `AutoSizer` doesn't support a `debounce` property 😢 

## Testing

- [x] CI
- [x] functional 
  - [x] `xLarge` row height renders as expected
  - [x] expanding a row + sorting no longer gives a stack trace

## Screenshots

**xLarge** (no story changes)
![image](https://user-images.githubusercontent.com/4496521/80766529-79e92100-8afa-11ea-9da9-057bd0e349d1.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
