### PR TITLE
fix(DataTable): rowHeight xLarge => xlarge

### DIFF
--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -149,6 +149,10 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
     }
   }
 
+  componentWillUnmount() {
+    if (this.timeoutId) window.clearTimeout(this.timeoutId);
+  }
+
   private getTableHeight = (expandedDataList: ExpandedRow[]): number => {
     const { height, rowHeight, showAllRows, dynamicRowHeight } = this.props;
     // @ts-ignore _rowHeightCache is missing from DataTable types

--- a/packages/core/src/components/DataTable/DataTable.tsx
+++ b/packages/core/src/components/DataTable/DataTable.tsx
@@ -141,11 +141,13 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
       });
     } else if (dynamicRowHeight && (filteredDataChanged || dimensionsChanged || sortChanged)) {
       // We need to make sure the cache is cleared before React tries to re-render.
-      if (this.timeoutId) window.clearTimeout(this.timeoutId);
-      this.timeoutId = window.setTimeout(() => {
-        this.cache.clearAll();
-        this.forceUpdate();
-      });
+      if (!this.timeoutId) {
+        this.timeoutId = window.setTimeout(() => {
+          this.cache.clearAll();
+          this.forceUpdate();
+          this.timeoutId = 0;
+        });
+      }
     }
   }
 
@@ -226,11 +228,13 @@ export class DataTable extends React.Component<DataTableProps & WithStylesProps,
 
     if (dynamicRowHeight) {
       // We need to make sure the cache is cleared before React tries to re-render.
-      if (this.timeoutId) window.clearTimeout(this.timeoutId);
-      this.timeoutId = window.setTimeout(() => {
-        this.cache.clearAll();
-        this.forceUpdate();
-      });
+      if (!this.timeoutId) {
+        this.timeoutId = window.setTimeout(() => {
+          this.cache.clearAll();
+          this.forceUpdate();
+          this.timeoutId = 0;
+        });
+      }
     }
   };
 

--- a/packages/core/src/components/DataTable/constants.tsx
+++ b/packages/core/src/components/DataTable/constants.tsx
@@ -21,7 +21,7 @@ export const HEIGHT_TO_PX: HeightMap = {
   small: 48,
   regular: 56,
   large: 64,
-  xLarge: 80,
+  xlarge: 80,
   jumbo: 108,
 };
 

--- a/packages/core/src/components/DataTable/types.ts
+++ b/packages/core/src/components/DataTable/types.ts
@@ -5,7 +5,7 @@ import { DataTable } from './DataTable';
 
 export type DataTableRef = (instance: DataTable) => void;
 export type TableRef = React.RefObject<Table>;
-export type RowHeightOptions = 'micro' | 'small' | 'regular' | 'large' | 'xLarge' | 'jumbo';
+export type RowHeightOptions = 'micro' | 'small' | 'regular' | 'large' | 'xlarge' | 'jumbo';
 export type HeightOptions = RowHeightOptions | undefined;
 export type ColumnLabelCase = 'sentence' | 'title' | 'uppercase' | '';
 


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description

This fixes a remaining comment from #367, and updates `xLarge` => `xlarge` for consistency in `DataTable`s `rowHeight` options.

~I tried removing the logic to create a new `timeout` if one existed, just letting the existing one run, but it broke the dynamic updating so I think we should keep it as is.~ EDIT: got this to work. 

I also added a `clearTimeout` call on unmount.

## Motivation and Context

See #367.

## Testing

- [x] CI
- [x] functional – `xlarge` prop gives correct height

## Screenshots

NA

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
