### PR TITLE
new(Forms): Add support for arrays of fields.

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,6 +30,7 @@
     "@types/lodash": "*",
     "airbnb-prop-types": "^2.15.0",
     "final-form": "^4.19.1",
+    "final-form-arrays": "^3.0.2",
     "lodash": "^4.17.15",
     "shallowequal": "^1.1.0",
     "uuid": "^7.0.3"

--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -16,6 +16,7 @@ import {
   FieldValidator,
   MutableState,
 } from 'final-form';
+import arrayMutators, { Mutators as ArrayMutators } from 'final-form-arrays';
 import T from '@airbnb/lunar/lib/components/Translate';
 import { getErrorMessage } from '@airbnb/lunar/lib/components/ErrorMessage';
 import FormErrorMessage from '@airbnb/lunar/lib/components/FormErrorMessage';
@@ -101,6 +102,7 @@ export default class Form<Data extends object = {}> extends React.Component<
       initialValues,
       mutators: {
         setFieldConfig: this.setFieldConfig,
+        ...arrayMutators,
       },
       onSubmit: this.handleSubmit,
       validate: this.handleValidate,
@@ -426,6 +428,8 @@ export default class Form<Data extends object = {}> extends React.Component<
           getFields: this.getFields,
           getState: this.getState,
           register: this.registerField,
+          // Since we have a known list of mutators, we can type it more specifically
+          mutators: (this.form.mutators as unknown) as ArrayMutators,
           submit: this.submitForm,
         }}
       >

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -9,6 +9,18 @@ import {
   FieldValidator,
   Unsubscribe,
 } from 'final-form';
+import { Mutators } from 'final-form-arrays';
+
+export {
+  IsEqual,
+  FormState,
+  FieldState,
+  FieldSubscriber,
+  FieldSubscription,
+  FieldValidator,
+  Unsubscribe,
+  Mutators,
+};
 
 // value:
 // string - Autocomplete, DatePickerInput, DateTimeSelect, FileInput, Input, RadioButton, RadioButtonController, Select, TextArea, ToggleButtonController
@@ -26,6 +38,7 @@ export type Context = {
   getFields: () => FieldState<any>[];
   getState: () => FormState<any>;
   register: (field: Field<any>, onUpdate: FieldSubscriber<any>) => Unsubscribe;
+  mutators: Mutators;
   submit: () => Promise<object | undefined>;
 };
 

--- a/packages/forms/test/index.test.ts
+++ b/packages/forms/test/index.test.ts
@@ -20,6 +20,14 @@ describe('forms', () => {
       'Switch',
       'TextArea',
       'ToggleButtonController',
+      'IsEqual',
+      'FormState',
+      'FieldState',
+      'FieldSubscriber',
+      'FieldSubscription',
+      'FieldValidator',
+      'Unsubscribe',
+      'Mutators',
     ]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7711,6 +7711,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+final-form-arrays@^3.0.2:
+  version "3.0.2"
+  resolved "https://artifactory.d.musta.ch/artifactory/api/npm/npm/final-form-arrays/-/final-form-arrays-3.0.2.tgz#9f3bef778dec61432357744eb6f3abef7e7f3847"
+  integrity sha1-nzvvd43sYUMjV3ROtvOr735/OEc=
+
 final-form@^4.19.1:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.19.1.tgz#1aa1a3bf67f7399b54ed6185d56f9a8d74cfda5a"


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
In order to support dynamic forms in Tower, this PR adds the final form arrays plugin.
https://final-form.org/arrays

## Motivation and Context
My current work requires a form that allows users to dynamically add and remove fields from a form. I've looked at different ways to solve this without modifications to lunar, but wasn't able to find anything that solved all my issues.

## Testing
Looking for feedback here, I'm not sure what sort of testing is appropriate, since this is mostly a configuration change.

## Screenshots
This PR doesn't affect any existing lunar components.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
