### PR TITLE
fix(Forms) Allow defaultValue to override initialValues

### DIFF
--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -342,7 +342,8 @@ export default class Form<Data extends object = {}> extends React.Component<
   ) {
     const field = fields[name];
     const initial = getIn(formState.initialValues!, name);
-    const value = typeof initial === 'undefined' ? config.defaultValue : initial;
+    const newInitialValue = initial ?? config.defaultValue;
+    const value = config.defaultValue ?? initial;
 
     if (!field) {
       return;
@@ -350,14 +351,14 @@ export default class Form<Data extends object = {}> extends React.Component<
 
     field.data.config = config;
     // @ts-ignore
-    field.initial = value;
+    field.initial = newInitialValue;
     // @ts-ignore
     field.value = value;
     field.touched = config.validateDefaultValue || false;
 
     // These are needed for form "reset" to work correctly!
     /* eslint-disable no-param-reassign */
-    formState.initialValues = setIn(formState.initialValues!, name, value);
+    formState.initialValues = setIn(formState.initialValues!, name, newInitialValue);
     formState.values = setIn(formState.values, name, value);
     /* eslint-enable no-param-reassign */
   }

--- a/packages/forms/test/components/Form.test.tsx
+++ b/packages/forms/test/components/Form.test.tsx
@@ -560,6 +560,38 @@ describe('<Form />', () => {
         },
       });
     });
+
+    it('allows intitialValue to be overridden', () => {
+      const config = {
+        name: 'foo',
+        defaultValue: '456',
+        validateDefaultValue: true,
+        validator() {},
+      };
+      const fields = { foo: { data: {} } };
+      const formState = { initialValues: { foo: '123' }, values: {} };
+
+      // @ts-ignore
+      instance.setFieldConfig(['foo', config], { fields, formState });
+
+      expect(fields).toEqual({
+        foo: {
+          data: { config },
+          initial: '123',
+          value: '456',
+          touched: true,
+        },
+      });
+
+      expect(formState).toEqual({
+        initialValues: {
+          foo: '123',
+        },
+        values: {
+          foo: '456',
+        },
+      });
+    });
   });
 
   describe('submitForm()', () => {


### PR DESCRIPTION
to: @milesj @stefhatcher @hayes @alecklandgraf

## Description
Right now, mounting a new field with a default value does nothing if an `initialValues` entry was provided for the field. This PR changes that logic so that field default value is used if present, otherwise it falls back to the initial value.

## Motivation and Context
Imagine an edit form, where you need to set `initialValues` to populate the existing data. Then the user changes the value of a field, which changes the options in a related select. To set the new default value, for that select, we need to be able to override the initial value.

## Testing
I've written a unit test that verifies the new behavior. My bigger concern is whether this is going to break an existing clients. I've been auditing usages of `initialValues` and `defaultValue` in source graph, and I'll report on what I find here.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
