### PR TITLE
update(Forms): Use form values if present on register

### DIFF
--- a/packages/forms/src/components/Form/index.tsx
+++ b/packages/forms/src/components/Form/index.tsx
@@ -342,7 +342,9 @@ export default class Form<Data extends object = {}> extends React.Component<
   ) {
     const field = fields[name];
     const initial = getIn(formState.initialValues!, name);
-    const value = typeof initial === 'undefined' ? config.defaultValue : initial;
+    const value =
+      getIn(formState.values!, name) ??
+      (typeof initial === 'undefined' ? config.defaultValue : initial);
 
     if (!field) {
       return;
@@ -350,14 +352,14 @@ export default class Form<Data extends object = {}> extends React.Component<
 
     field.data.config = config;
     // @ts-ignore
-    field.initial = value;
+    field.initial = initial ?? value;
     // @ts-ignore
     field.value = value;
     field.touched = config.validateDefaultValue || false;
 
     // These are needed for form "reset" to work correctly!
     /* eslint-disable no-param-reassign */
-    formState.initialValues = setIn(formState.initialValues!, name, value);
+    formState.initialValues = setIn(formState.initialValues!, name, initial ?? value);
     formState.values = setIn(formState.values, name, value);
     /* eslint-enable no-param-reassign */
   }

--- a/packages/forms/test/components/Form.test.tsx
+++ b/packages/forms/test/components/Form.test.tsx
@@ -560,6 +560,37 @@ describe('<Form />', () => {
         },
       });
     });
+
+    it('initial value is ignored if a field already has a value', () => {
+      const config = {
+        name: 'foo',
+        validateDefaultValue: true,
+        validator() {},
+      };
+      const fields = { foo: { data: {} } };
+      const formState = { initialValues: { foo: '123' }, values: { foo: '456' } };
+
+      // @ts-ignore
+      instance.setFieldConfig(['foo', config], { fields, formState });
+
+      expect(fields).toEqual({
+        foo: {
+          data: { config },
+          initial: '123',
+          value: '456',
+          touched: true,
+        },
+      });
+
+      expect(formState).toEqual({
+        initialValues: {
+          foo: '123',
+        },
+        values: {
+          foo: '456',
+        },
+      });
+    });
   });
 
   describe('submitForm()', () => {


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf

## Description
This PR checks for an existing field value when a field is registered, and uses that value rather than the form initial value.


## Motivation and Context
Using final form mutators, it's possible to set a field value before the initial mount of the component. I'm working on a form that uses [Final Form Arrays](
https://final-form.org/docs/final-form-arrays/getting-started) to arbitrary numbers of rows to a form. 

## Testing
I've added a unit test that verifies the new behavior

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
