### PR TITLE
new(Copy): Add invertTooltip prop

### DIFF
--- a/packages/core/src/components/Copy/index.tsx
+++ b/packages/core/src/components/Copy/index.tsx
@@ -10,6 +10,8 @@ export type CopyProps = {
   children?: React.ReactElement;
   /** Pass an HTML element attribute id to the Link. */
   id?: string;
+  /** Invert the colors of the tooltip. */
+  invertTooltip?: boolean;
   /** String of text to be copied to the clipboard. */
   text: string;
   /** Callback fired when text is copied. */
@@ -31,6 +33,7 @@ export default function Copy({
   children,
   text,
   id,
+  invertTooltip,
   trackingName,
   underlined,
   prompt,
@@ -64,6 +67,7 @@ export default function Copy({
   return (
     <Tooltip
       remainOnMouseDown
+      inverted={invertTooltip}
       content={
         copied ? (
           <T k="lunar.copy.copied" phrase="Copied!" />

--- a/packages/core/src/components/Copy/story.tsx
+++ b/packages/core/src/components/Copy/story.tsx
@@ -51,7 +51,12 @@ withACustomElementToTriggerTheCopy.story = {
 };
 
 export function withInvertedTooltip() {
-  return <Copy invertTooltip text="Inverted tooltip." prompt="Yo copy me..." />;
+  return (
+    <Text>
+      Check out this inverted tooltip{' '}
+      <Copy invertTooltip text="Inverted tooltip." prompt="Yo copy me..." />.
+    </Text>
+  );
 }
 
 withInvertedTooltip.story = {

--- a/packages/core/src/components/Copy/story.tsx
+++ b/packages/core/src/components/Copy/story.tsx
@@ -49,3 +49,11 @@ export function withACustomElementToTriggerTheCopy() {
 withACustomElementToTriggerTheCopy.story = {
   name: 'With a custom element to trigger the copy.',
 };
+
+export function withInvertedTooltip() {
+  return <Copy invertTooltip text="Inverted tooltip." prompt="Yo copy me..." />;
+}
+
+withInvertedTooltip.story = {
+  name: 'With an inverted tooltip.',
+};

--- a/packages/core/test/components/Copy.test.tsx
+++ b/packages/core/test/components/Copy.test.tsx
@@ -4,6 +4,7 @@ import copy from 'copy-to-clipboard';
 import IconCopy from '@airbnb/lunar-icons/lib/interface/IconCopy';
 import Copy from '../../src/components/Copy';
 import IconButton from '../../src/components/IconButton';
+import { Tooltip } from '../../src/components/Tooltip';
 
 jest.mock('copy-to-clipboard', () => jest.fn(() => true));
 
@@ -49,5 +50,13 @@ describe('<Copy />', () => {
 
     expect(spy).toHaveBeenCalledWith('foo', true);
     expect(copy).toHaveBeenCalledWith('foo');
+  });
+
+  it('inverts the Tooltip if specified', () => {
+    const wrapper = shallow(<Copy invertTooltip={false} text="foo" />);
+
+    expect(wrapper.dive().find(Tooltip).prop('inverted')).toBe(false);
+    wrapper.setProps({ invertTooltip: true });
+    expect(wrapper.dive().find(Tooltip).prop('inverted')).toBe(true);
   });
 });


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf
cc: @etr2460 @kenchendesign 

## Description

This adds a hook to invert the color of the `Copy` tooltip.

## Motivation and Context

We use `black` tooltips throughout our apps when they have instructional content. We can't make this consistent because the `Copy` `Tooltip` cannot currently be inverted.

## Testing

- [x] CI
  - [x] new jest test
- [x] functional
  - [x] new story

## Screenshots
Default
<img src="https://user-images.githubusercontent.com/4496521/83677288-cbb91700-a590-11ea-999d-2a119a766335.png" width="250" />

Inverted
<img src="https://user-images.githubusercontent.com/4496521/83677113-87c61200-a590-11ea-9e9a-5909751f94a6.png" width="300" />

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
