### PR TITLE
update(RotateControls, ZoomControls): Add icon size prop

### DIFF
--- a/packages/core/src/components/ImageViewer/RotateControls.tsx
+++ b/packages/core/src/components/ImageViewer/RotateControls.tsx
@@ -11,12 +11,12 @@ export type RotateControlsProps = {
   /** Callback when rotation changes */
   onRotation: (rotation: number) => void;
   /** Size of the icons. */
-  size?: number | string;
+  iconSize?: number | string;
 };
 
 /** Rotate controls that can be used with an image viewer component */
 export default function RotateControls(props: RotateControlsProps) {
-  const { onRotation, rotation = 0, size = '2em' } = props;
+  const { onRotation, rotation = 0, iconSize = '2em' } = props;
 
   const handleRotateLeft = useCallback(() => onRotation(rotation - 90 < 0 ? 270 : rotation - 90), [
     onRotation,
@@ -35,14 +35,14 @@ export default function RotateControls(props: RotateControlsProps) {
             'lunar.image.rotateCounterClockwise',
             'Rotate counter clockwise',
           )}
-          size={size}
+          size={iconSize}
         />
       </IconButton>
 
       <IconButton onClick={handleRotateRight}>
         <IconRotateRight
           accessibilityLabel={T.phrase('lunar.image.rotateClockwise', 'Rotate clockwise')}
-          size={size}
+          size={iconSize}
         />
       </IconButton>
     </ButtonGroup>

--- a/packages/core/src/components/ImageViewer/RotateControls.tsx
+++ b/packages/core/src/components/ImageViewer/RotateControls.tsx
@@ -10,11 +10,13 @@ export type RotateControlsProps = {
   rotation?: number;
   /** Callback when rotation changes */
   onRotation: (rotation: number) => void;
+  /** Size of the icons. */
+  size?: number | string;
 };
 
 /** Rotate controls that can be used with an image viewer component */
 export default function RotateControls(props: RotateControlsProps) {
-  const { onRotation, rotation = 0 } = props;
+  const { onRotation, rotation = 0, size = '2em' } = props;
 
   const handleRotateLeft = useCallback(() => onRotation(rotation - 90 < 0 ? 270 : rotation - 90), [
     onRotation,
@@ -33,14 +35,14 @@ export default function RotateControls(props: RotateControlsProps) {
             'lunar.image.rotateCounterClockwise',
             'Rotate counter clockwise',
           )}
-          size="2em"
+          size={size}
         />
       </IconButton>
 
       <IconButton onClick={handleRotateRight}>
         <IconRotateRight
           accessibilityLabel={T.phrase('lunar.image.rotateClockwise', 'Rotate clockwise')}
-          size="2em"
+          size={size}
         />
       </IconButton>
     </ButtonGroup>

--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -42,6 +42,8 @@ export type ZoomControlsProps = {
   scale?: number;
   /** Callback when scale / zoom changes */
   onScale: (scale: number) => void;
+  /** Size of the icons. */
+  size?: number | string;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
@@ -50,7 +52,7 @@ export type ZoomControlsProps = {
 export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetZoomControls);
   const [visible, setVisible] = useState(false);
-  const { onScale, scale = 1 } = props;
+  const { onScale, scale = 1, size = '2em' } = props;
 
   const zoomOptions = ZOOM_OPTIONS.map((zoom: { label: string; scale: number }) => ({
     ...zoom,
@@ -71,7 +73,10 @@ export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps
     <div className={cx(styles.controls)}>
       <ButtonGroup>
         <IconButton disabled={scale === 1} onClick={handleZoomOut}>
-          <IconRemove accessibilityLabel={T.phrase('lunar.image.zoomOut', 'Zoom out')} size="2em" />
+          <IconRemove
+            accessibilityLabel={T.phrase('lunar.image.zoomOut', 'Zoom out')}
+            size={size}
+          />
         </IconButton>
 
         <Button borderless onClick={toggleZoomMenu}>
@@ -79,7 +84,7 @@ export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps
         </Button>
 
         <IconButton onClick={handleZoomIn}>
-          <IconAdd accessibilityLabel={T.phrase('lunar.image.zoomIn', 'Zoom in')} size="2em" />
+          <IconAdd accessibilityLabel={T.phrase('lunar.image.zoomIn', 'Zoom in')} size={size} />
         </IconButton>
       </ButtonGroup>
 

--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -43,7 +43,7 @@ export type ZoomControlsProps = {
   /** Callback when scale / zoom changes */
   onScale: (scale: number) => void;
   /** Size of the icons. */
-  size?: number | string;
+  iconSize?: number | string;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
@@ -52,7 +52,7 @@ export type ZoomControlsProps = {
 export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetZoomControls);
   const [visible, setVisible] = useState(false);
-  const { onScale, scale = 1, size = '2em' } = props;
+  const { onScale, scale = 1, iconSize = '2em' } = props;
 
   const zoomOptions = ZOOM_OPTIONS.map((zoom: { label: string; scale: number }) => ({
     ...zoom,
@@ -75,7 +75,7 @@ export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps
         <IconButton disabled={scale === 1} onClick={handleZoomOut}>
           <IconRemove
             accessibilityLabel={T.phrase('lunar.image.zoomOut', 'Zoom out')}
-            size={size}
+            size={iconSize}
           />
         </IconButton>
 
@@ -84,7 +84,7 @@ export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps
         </Button>
 
         <IconButton onClick={handleZoomIn}>
-          <IconAdd accessibilityLabel={T.phrase('lunar.image.zoomIn', 'Zoom in')} size={size} />
+          <IconAdd accessibilityLabel={T.phrase('lunar.image.zoomIn', 'Zoom in')} size={iconSize} />
         </IconButton>
       </ButtonGroup>
 

--- a/packages/core/test/components/ImageViewer/RotateControls.test.tsx
+++ b/packages/core/test/components/ImageViewer/RotateControls.test.tsx
@@ -9,7 +9,7 @@ describe('<RotateControls />', () => {
   const rotateSpy = jest.fn();
   const props = {
     onRotation: rotateSpy,
-    size: '1em',
+    iconSize: '1em',
   };
   let wrapper: Enzyme.ShallowWrapper<RotateControlsProps>;
 

--- a/packages/core/test/components/ImageViewer/RotateControls.test.tsx
+++ b/packages/core/test/components/ImageViewer/RotateControls.test.tsx
@@ -9,6 +9,7 @@ describe('<RotateControls />', () => {
   const rotateSpy = jest.fn();
   const props = {
     onRotation: rotateSpy,
+    size: '1em',
   };
   let wrapper: Enzyme.ShallowWrapper<RotateControlsProps>;
 

--- a/packages/core/test/components/ImageViewer/ZoomControls.test.tsx
+++ b/packages/core/test/components/ImageViewer/ZoomControls.test.tsx
@@ -13,6 +13,7 @@ describe('<ZoomControls />', () => {
   const props = {
     onScale: setScaleSpy,
     scale: 1,
+    size: '1em',
   };
 
   describe('zoom buttons', () => {

--- a/packages/core/test/components/ImageViewer/ZoomControls.test.tsx
+++ b/packages/core/test/components/ImageViewer/ZoomControls.test.tsx
@@ -13,7 +13,7 @@ describe('<ZoomControls />', () => {
   const props = {
     onScale: setScaleSpy,
     scale: 1,
-    size: '1em',
+    iconSize: '1em',
   };
 
   describe('zoom buttons', () => {


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf

## Description

title and diff should be explanatory

## Motivation and Context

Design calls for icon sizes to be modifiable - the `<RotateControls />` and `<ZoomControls />` components almost always accompany `<ImageViewer />`, and if `<ImageViewer />` height/width can be changed via props, then naturally the controls should be too for extensibility. 

## Testing

Updated tests to include size prop. 

## Screenshots

n/a

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
