### PR TITLE
new(Tooltip): Add `popover` prop

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -17,7 +17,7 @@ const EMPTY_TARGET_RECT: ClientRect = {
   width: 0,
 };
 
-const MOUSE_LEAVE_DELAY = 100; // 100ms
+const MOUSE_LEAVE_DELAY_MS = 100;
 
 export type TooltipProps = {
   /** Accessibility label. If not specified, all tooltip content is duplicated, rendered in an off-screen element with a separate layer. */
@@ -100,8 +100,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
 
   rafHandle: number = 0;
 
-  // Only used when Popover is enabled
-  delayTimeoutId = 0;
+  popoverDelayTimeoutId = 0;
 
   static getDerivedStateFromProps({ disabled }: TooltipProps) {
     if (disabled) {
@@ -226,7 +225,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   private handleMouseLeave = () => {
     if (!this.props.toggleOnClick) {
       if (this.props.popover) {
-        this.delayedSetPopoverVisible(false, MOUSE_LEAVE_DELAY);
+        this.delayedSetPopoverVisible(false, MOUSE_LEAVE_DELAY_MS);
       } else {
         this.handleClose();
       }
@@ -246,13 +245,13 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   }
 
   clearDelayTimer() {
-    clearTimeout(this.delayTimeoutId);
+    clearTimeout(this.popoverDelayTimeoutId);
   }
 
   delayedSetPopoverVisible(open: boolean, delayMs: number = 0) {
     this.clearDelayTimer();
     if (delayMs) {
-      this.delayTimeoutId = window.setTimeout(() => {
+      this.popoverDelayTimeoutId = window.setTimeout(() => {
         this.setPopoverVisible(open);
       }, delayMs);
     } else {
@@ -265,7 +264,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   };
 
   handlePopoverMouseLeave = () => {
-    this.delayedSetPopoverVisible(false, MOUSE_LEAVE_DELAY);
+    this.delayedSetPopoverVisible(false, MOUSE_LEAVE_DELAY_MS);
   };
 
   private renderPopUp() {
@@ -327,7 +326,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     );
 
     if (popover) {
-      return open && <div style={{ position: 'absolute', zIndex: 1 }}>{popupContent}</div>;
+      return open && <div className={cx(styles.popover)}>{popupContent}</div>;
     }
 
     return (

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -32,7 +32,7 @@ export type TooltipProps = {
   horizontalAlign?: 'center' | 'left' | 'right';
   /** True to use a light background with dark text. */
   inverted?: boolean;
-  /** Callback fired when the tooltip is closed. Not supported when using the popover prop. */
+  /** Callback fired when the tooltip is closed. */
   onClose?: () => void;
   /** Callback fired when the tooltip is shown. */
   onShow?: () => void;

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -17,6 +17,9 @@ const EMPTY_TARGET_RECT: ClientRect = {
   width: 0,
 };
 
+const MOUSE_ENTER_DELAY = 0;
+const MOUSE_LEAVE_DELAY = 0.1;
+
 export type TooltipProps = {
   /** Accessibility label. If not specified, all tooltip content is duplicated, rendered in an off-screen element with a separate layer. */
   accessibilityLabel?: string;
@@ -30,10 +33,12 @@ export type TooltipProps = {
   horizontalAlign?: 'center' | 'left' | 'right';
   /** True to use a light background with dark text. */
   inverted?: boolean;
-  /** Callback fired when the tooltip is closed. */
+  /** Callback fired when the tooltip is closed. Not supported when using the popover prop. */
   onClose?: () => void;
   /** Callback fired when the tooltip is shown. */
   onShow?: () => void;
+  /** True to enable interactive popover functionality */
+  popover?: boolean;
   /** True to prevent dismissmal on mouse down. */
   remainOnMouseDown?: boolean;
   /** True to toggle tooltip display on click.  */
@@ -73,6 +78,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     inverted: false,
     onClose() {},
     onShow() {},
+    popover: false,
     remainOnMouseDown: false,
     toggleOnClick: false,
     underlined: false,
@@ -94,6 +100,9 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
   mounted: boolean = false;
 
   rafHandle: number = 0;
+
+  // Only used when Popover is enabled
+  delayTimer: number | null = null;
 
   static getDerivedStateFromProps({ disabled }: TooltipProps) {
     if (disabled) {
@@ -194,7 +203,11 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
 
   private handleMouseEnter = () => {
     if (!this.props.toggleOnClick) {
-      this.handleOpen();
+      if (this.props.popover) {
+        this.delaySetPopupVisible(true, MOUSE_ENTER_DELAY);
+      } else {
+        this.handleOpen();
+      }
     }
   };
 
@@ -213,8 +226,52 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
 
   private handleMouseLeave = () => {
     if (!this.props.toggleOnClick) {
-      this.handleClose();
+      if (this.props.popover) {
+        this.delaySetPopupVisible(false, MOUSE_LEAVE_DELAY);
+      } else {
+        this.handleClose();
+      }
     }
+  };
+
+  setPopupVisible(open: boolean) {
+    const { open: previousOpen } = this.state;
+    this.clearDelayTimer();
+    if (previousOpen !== open) {
+      if (open) {
+        this.handleOpen();
+      } else {
+        this.handleClose();
+      }
+    }
+  }
+
+  clearDelayTimer() {
+    if (this.delayTimer) {
+      clearTimeout(this.delayTimer);
+      this.delayTimer = null;
+    }
+  }
+
+  delaySetPopupVisible(open: boolean, delayS: number) {
+    const delay = delayS * 1000;
+    this.clearDelayTimer();
+    if (delay) {
+      this.delayTimer = window.setTimeout(() => {
+        this.setPopupVisible(open);
+        this.clearDelayTimer();
+      }, delay);
+    } else {
+      this.setPopupVisible(open);
+    }
+  }
+
+  handlePopupMouseEnter = () => {
+    this.clearDelayTimer();
+  };
+
+  handlePopupMouseLeave = () => {
+    this.delaySetPopupVisible(false, MOUSE_LEAVE_DELAY);
   };
 
   private renderPopUp() {
@@ -227,6 +284,7 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
       content,
       inverted,
       verticalAlign,
+      popover,
     } = this.props;
     const { open, targetRect, tooltipHeight, targetRectReady } = this.state;
 
@@ -250,22 +308,37 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     const distance = unit / 2;
     const invert = inverted || Tooltip.inverted;
 
+    const handleMouseEnter = popover ? this.handlePopupMouseEnter : undefined;
+    const handleMouseLeave = popover ? this.handlePopupMouseLeave : undefined;
+
+    const popupContent = (
+      <div
+        ref={this.handleTooltipRef}
+        role="tooltip"
+        className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
+          width,
+          marginLeft: marginLeft[align as keyof StyleStruct],
+          marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
+          textAlign: align,
+        })}
+      >
+        <div
+          className={cx(styles.content, invert && styles.content_inverted)}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <Text inverted={invert}>{content}</Text>
+        </div>
+      </div>
+    );
+
+    if (popover) {
+      return open && <div style={{ position: 'absolute', zIndex: 1 }}>{popupContent}</div>;
+    }
+
     return (
       <Overlay noBackground open={open} onClose={this.handleClose}>
-        <div
-          ref={this.handleTooltipRef}
-          role="tooltip"
-          className={cx(styles.tooltip, above ? styles.tooltip_above : styles.tooltip_below, {
-            width,
-            marginLeft: marginLeft[align as keyof StyleStruct],
-            marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
-            textAlign: align,
-          })}
-        >
-          <div className={cx(styles.content, invert && styles.content_inverted)}>
-            <Text inverted={invert}>{content}</Text>
-          </div>
-        </div>
+        {popupContent}
       </Overlay>
     );
   }

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
+import { withexpandMultiple } from '../Accordion/story';
 import Button from '../Button';
 import Text from '../Text';
 import Spacing from '../Spacing';
+import Link from '../Link';
 import Tooltip from '.';
 
 class TooltipDemo extends React.Component<{}, { text: string; clicked: boolean }> {
@@ -285,4 +287,105 @@ export function withAccessibilityLabel() {
 
 withAccessibilityLabel.story = {
   name: 'With accessibility label',
+};
+
+export function popoverDisplaysWhenAnElementIsHovered() {
+  const content = (
+    <>
+      <Text>Links inside popovers are clickable!</Text>
+      <Link openInNewWindow href="https://github.com/airbnb/lunar">
+        Click me!
+      </Link>
+    </>
+  );
+  return (
+    <div>
+      <Tooltip popover content={content}>
+        <Button>Hover Me</Button>
+      </Tooltip>
+
+      <Text inline>← Has a popover</Text>
+
+      <Text>
+        <LoremIpsum />
+      </Text>
+
+      <div style={{ textAlign: 'right' }}>
+        <Text inline>Also has a popover →</Text>
+        <Tooltip
+          inverted
+          popover
+          content={
+            <Text inverted>This uncomfortably wide Popover should have left-aligned text.</Text>
+          }
+          width={100}
+        >
+          <Button>Hover Me</Button>
+        </Tooltip>
+      </div>
+
+      <Text>
+        <LoremIpsum />
+      </Text>
+
+      <div style={{ textAlign: 'center' }}>
+        <Tooltip popover content="This Popover should most definitely be centered" width={21}>
+          <Button>
+            Hover Me too
+            <br />
+            please
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+popoverDisplaysWhenAnElementIsHovered.story = {
+  name: 'Popover displays when an element is hovered and popover prop is enabled.',
+};
+
+export function popoverExpandsAndShrinksWithContent() {
+  return (
+    <div>
+      <Tooltip popover content={withexpandMultiple()}>
+        <Button>Hover Me</Button>
+      </Tooltip>
+
+      <Text inline>← Has a popover that can expand and collapse</Text>
+
+      <Text>
+        <LoremIpsum />
+      </Text>
+
+      <Spacing top={10}>
+        <div style={{ textAlign: 'right' }}>
+          <Text inline>Also has a popover that can expand and collapse →</Text>
+          <Tooltip popover content={withexpandMultiple()} width={100}>
+            <Button>Hover Me</Button>
+          </Tooltip>
+        </div>
+      </Spacing>
+
+      <Text>
+        <LoremIpsum />
+      </Text>
+
+      <Spacing top={10}>
+        <div style={{ textAlign: 'center' }}>
+          <Tooltip popover content={withexpandMultiple()} width={100}>
+            <Button>
+              Hover Me too
+              <br />
+              please
+            </Button>
+          </Tooltip>
+        </div>
+      </Spacing>
+    </div>
+  );
+}
+
+popoverExpandsAndShrinksWithContent.story = {
+  name: 'Popover expands and shrinks with content.',
 };

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -57,4 +57,9 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => (
   content_inverted: {
     backgroundColor: color.accent.blackout,
   },
+
+  popover: {
+    position: 'absolute',
+    zIndex: 1,
+  },
 });

--- a/packages/core/test/components/Tooltip.test.tsx
+++ b/packages/core/test/components/Tooltip.test.tsx
@@ -98,6 +98,41 @@ describe('<Tooltip />', () => {
     });
   });
 
+  describe('popover', () => {
+    beforeEach(() => {
+      wrapper.setProps({ popover: true });
+      wrapper.setState({ open: true });
+    });
+
+    it('does not yet close when the mouse left the popup for fewer than 100ms', () => {
+      jest.useFakeTimers();
+
+      childContainer.simulate('mouseleave');
+      // Popover is programmed with a 100ms lag between mouseleave and close
+      // so this shouldn't be closed yet
+      setTimeout(() => {
+        expect(wrapper.state('open')).toBeTruthy();
+      }, 99);
+      jest.runAllTimers();
+    });
+
+    it('closes when child exited for 100ms', () => {
+      jest.useFakeTimers();
+
+      childContainer.simulate('mouseleave');
+      // Popover is programmed with a 100ms lag between mouseleave and close
+      setTimeout(() => {
+        expect(wrapper.state('open')).not.toBeTruthy();
+      }, 100);
+      jest.runAllTimers();
+    });
+
+    it('closes when child mousedowned', () => {
+      childContainer.simulate('mousedown');
+      expect(wrapper.state('open')).not.toBeTruthy();
+    });
+  });
+
   it('unmounts cleanly', () => {
     const instance = wrapper.instance() as BaseTooltip;
     wrapper.unmount();


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf

## Description

A popover is essentially a tooltip component with the ability to persist the popup by mouse-entering the popup portion of the tooltip. 

This functionality is achieved by adding a delay timer and setTimeout (via `delaySetPopupVisible`) to ensure that the popup persists long enough for a mouse to move from tooltip trigger to popup div when the `popover` prop is selected. When a mouse enters the popup div, the timer is cleared, and the popup can persist until the mouse leaves the popup.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Several internal tools at Airbnb now require the ability to click links inside a popup, and copy-and-paste text in the popup. However, without this prop, it is not possible to interact with the contents of a popup in the Lunar tooltip

(`remainOnMouseDown` & `toggleOnClick`) props _can_ be used to persist the popups, but we won't be able to interact with the info in the popup since `renderPopup` previously only rendered everything in an Overlay. Additionally, we can't use these props the way we'd like when wrapping a link component with a Tooltip that has these props -- you'd click the link when triggering these props. The timeout method via `delaySetPopupVisible` solves this problem.


## Testing
Added Jest tests to cover the expected open and closing behavior of a popover. Tested locally in storybook.
## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->
![image](https://user-images.githubusercontent.com/17525561/85666362-354cb280-b671-11ea-9625-a44709eeeb1b.png)

![image](https://user-images.githubusercontent.com/17525561/85666437-4dbccd00-b671-11ea-865a-320f6870a505.png)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
