### PR TITLE
Enable style changes for inner modal

### DIFF
--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import useStyles, { StyleSheet } from '..././../hooks/useStyles';
-import withStyles, { WithStylesProps } from '../../../composers/withStyles';
+import useStyles, { StyleSheet } from '../../../hooks/useStyles';
 import FocusTrap from '../../FocusTrap';
 import focusFirstFocusableChild from '../../../utils/focus/focusFirstFocusableChild';
 import ModalImageLayout, { ModalImageConfig } from './ImageLayout';
@@ -21,10 +20,11 @@ export type ModalInnerProps = ModalInnerContentProps & {
   fluid?: boolean;
   /** Keep modal open when clicking outside of the modal (in the blackout). */
   persistOnOutsideClick?: boolean;
+  styleSheet: StyleSheet;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */
-export class ModalInner extends React.Component<ModalInnerProps & WithStylesProps> {
+export class ModalInner extends React.Component<ModalInnerProps> {
   dialogRef = React.createRef<HTMLDivElement>();
 
   lastActiveElement: HTMLElement | null = null;

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import useStyles, { StyleSheet } from '..././../hooks/useStyles';
 import withStyles, { WithStylesProps } from '../../../composers/withStyles';
 import FocusTrap from '../../FocusTrap';
 import focusFirstFocusableChild from '../../../utils/focus/focusFirstFocusableChild';
 import ModalImageLayout, { ModalImageConfig } from './ImageLayout';
 import ModalInnerContent, { ModalInnerContentProps } from './InnerContent';
 import {
-  styleSheetInner as styleSheet,
+  styleSheetInner,
   MODAL_MAX_WIDTH_SMALL,
   MODAL_MAX_WIDTH_MEDIUM,
   MODAL_MAX_WIDTH_LARGE,
@@ -78,7 +79,6 @@ export class ModalInner extends React.Component<ModalInnerProps & WithStylesProp
 
   render() {
     const {
-      cx,
       children,
       footer,
       image,
@@ -86,12 +86,14 @@ export class ModalInner extends React.Component<ModalInnerProps & WithStylesProp
       small,
       fluid,
       scrollable,
-      styles,
       subtitle,
       title,
       topBar,
       topBarCentered,
+      styleSheet,
     } = this.props;
+    
+    const [styles, cx] = useStyles(styleSheet ?? styleSheetInner);
 
     const showLargeContent = large || !!image;
 
@@ -131,4 +133,4 @@ export class ModalInner extends React.Component<ModalInnerProps & WithStylesProp
   }
 }
 
-export default withStyles(styleSheet)(ModalInner);
+export default ModalInner;

--- a/packages/core/src/components/Modal/private/Inner.tsx
+++ b/packages/core/src/components/Modal/private/Inner.tsx
@@ -20,7 +20,7 @@ export type ModalInnerProps = ModalInnerContentProps & {
   fluid?: boolean;
   /** Keep modal open when clicking outside of the modal (in the blackout). */
   persistOnOutsideClick?: boolean;
-  styleSheet: StyleSheet;
+  styleSheet?: StyleSheet;
 };
 
 /** A Dialog component with a backdrop and a standardized layout. */


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf

## Description

stylesheet prop is [passed](https://github.com/airbnb/lunar/blob/master/packages/core/src/components/Modal/index.tsx#L39) from the parent component but is currently not being used here

## Motivation and Context

This enables customization of styles for the inner modal component

