### PR TITLE
update(tooltip): Make inverted text readable in dark mode

### DIFF
--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from '../../hooks/useStyles';
 
-export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => ({
+export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui, mode }) => ({
   container: {
     display: 'inline-block',
   },
@@ -55,7 +55,7 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => (
   },
 
   content_inverted: {
-    backgroundColor: color.accent.blackout,
+    backgroundColor: mode === "light" ? "#000" : "#FFF",
   },
 
   popover: {

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -55,7 +55,10 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui, mode }
   },
 
   content_inverted: {
-    backgroundColor: mode === 'light' ? '#000' : '#FFF',
+    backgroundColor:
+      mode === 'light'
+        ? '#181818' // Dark mode base color
+        : '#FFF', // Light mode base color
   },
 
   popover: {

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -55,7 +55,7 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui, mode }
   },
 
   content_inverted: {
-    backgroundColor: mode === "light" ? "#000" : "#FFF",
+    backgroundColor: mode === 'light' ? '#000' : '#FFF',
   },
 
   popover: {

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from '../../hooks/useStyles';
 
-export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui, mode }) => ({
+export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => ({
   container: {
     display: 'inline-block',
   },
@@ -55,10 +55,7 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui, mode }
   },
 
   content_inverted: {
-    backgroundColor:
-      mode === 'light'
-        ? '#181818' // Dark mode base color
-        : '#FFF', // Light mode base color
+    backgroundColor: color.baseInverse,
   },
 
   popover: {

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -13,6 +13,7 @@ export type Options = {
   disabledOpacity?: number;
   fontFamily: string;
   transitionTime?: string;
+  mode: 'dark' | 'light';
 };
 
 const borderWidth = 1;
@@ -31,6 +32,7 @@ export default function buildTheme(
     color,
     disabledOpacity = 0.3,
     transitionTime = '300ms',
+    mode
   } = options;
 
   const accent = {
@@ -68,6 +70,7 @@ export default function buildTheme(
   const unit = 8;
 
   return {
+    mode,
     color: {
       accent,
       base,

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -32,7 +32,7 @@ export default function buildTheme(
     color,
     disabledOpacity = 0.3,
     transitionTime = '300ms',
-    mode
+    mode,
   } = options;
 
   const accent = {

--- a/packages/core/src/themes/buildTheme.ts
+++ b/packages/core/src/themes/buildTheme.ts
@@ -5,6 +5,7 @@ import toRGBA from '../utils/toRGBA';
 
 export type Options = {
   base: string;
+  baseInverse: string;
   borderRadius?: number;
   boxShadow?: [number, number];
   boxShadowColor?: string;
@@ -13,7 +14,6 @@ export type Options = {
   disabledOpacity?: number;
   fontFamily: string;
   transitionTime?: string;
-  mode: 'dark' | 'light';
 };
 
 const borderWidth = 1;
@@ -25,6 +25,7 @@ export default function buildTheme(
 ): Theme {
   const {
     base,
+    baseInverse,
     borderRadius = 4,
     boxShadow = [2, 4],
     boxShadowColor = base,
@@ -32,7 +33,6 @@ export default function buildTheme(
     color,
     disabledOpacity = 0.3,
     transitionTime = '300ms',
-    mode,
   } = options;
 
   const accent = {
@@ -70,10 +70,10 @@ export default function buildTheme(
   const unit = 8;
 
   return {
-    mode,
     color: {
       accent,
       base,
+      baseInverse,
       brand,
       core: color,
       clear: 'transparent',

--- a/packages/core/src/themes/dark.ts
+++ b/packages/core/src/themes/dark.ts
@@ -24,10 +24,10 @@ const color: Theme['color']['core'] = {
 export default (fontFamily: string) =>
   buildTheme({
     base: '#181818',
+    baseInverse: '#FFF',
     boxShadowColor: '#000',
     brand,
     color,
     disabledOpacity: 0.2,
     fontFamily,
-    mode: 'dark',
   });

--- a/packages/core/src/themes/dark.ts
+++ b/packages/core/src/themes/dark.ts
@@ -29,4 +29,5 @@ export default (fontFamily: string) =>
     color,
     disabledOpacity: 0.2,
     fontFamily,
+    mode: "dark"
   });

--- a/packages/core/src/themes/dark.ts
+++ b/packages/core/src/themes/dark.ts
@@ -29,5 +29,5 @@ export default (fontFamily: string) =>
     color,
     disabledOpacity: 0.2,
     fontFamily,
-    mode: "dark"
+    mode: 'dark',
   });

--- a/packages/core/src/themes/light.ts
+++ b/packages/core/src/themes/light.ts
@@ -28,4 +28,5 @@ export default (fontFamily: string) =>
     brand,
     color,
     fontFamily,
+    mode: "light"
   });

--- a/packages/core/src/themes/light.ts
+++ b/packages/core/src/themes/light.ts
@@ -28,5 +28,5 @@ export default (fontFamily: string) =>
     brand,
     color,
     fontFamily,
-    mode: "light"
+    mode: 'light',
   });

--- a/packages/core/src/themes/light.ts
+++ b/packages/core/src/themes/light.ts
@@ -24,9 +24,9 @@ const color: Theme['color']['core'] = {
 export default (fontFamily: string) =>
   buildTheme({
     base: '#fff',
+    baseInverse: '#181818',
     boxShadowColor: color.neutral[6],
     brand,
     color,
     fontFamily,
-    mode: 'light',
   });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -98,7 +98,6 @@ export type Hexcode = string;
 export type ColorRange = [Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode];
 
 export type Theme = {
-  mode: 'dark' | 'light';
   color: {
     accent: {
       bg: Hexcode;
@@ -115,6 +114,7 @@ export type Theme = {
       textError: Hexcode;
     };
     base: Hexcode;
+    baseInverse: Hexcode;
     brand: {
       luxury: ColorRange;
       plus: ColorRange;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -98,7 +98,7 @@ export type Hexcode = string;
 export type ColorRange = [Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode];
 
 export type Theme = {
-  mode: 'dark' | 'light',
+  mode: 'dark' | 'light';
   color: {
     accent: {
       bg: Hexcode;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -98,6 +98,7 @@ export type Hexcode = string;
 export type ColorRange = [Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode, Hexcode];
 
 export type Theme = {
+  mode: 'dark' | 'light',
   color: {
     accent: {
       bg: Hexcode;


### PR DESCRIPTION
to: @williaster @hayes @alecklandgraf

## Description
When in dark mode, the inverted tooltip text isn't readable. This change fixes that, and also improves the accessibility of the colors for light mode.

In order to make this fix, ~I needed to have theme mode aware styles or use some other color from the theme; there were no applicable analogs, so I went the route of exposing the current theme mode in the theme.~ I added a new `baseInverse` color value to the theme.

## Motivation and Context
The colors currently used for the inverted tooltip aren't accessible, causing difficulty for viewers of all eyesights

## Testing
- Tested with storybook

## Screenshots
**Light Mode**
Before | After
-|-
![image](https://user-images.githubusercontent.com/3392349/86192304-18dfc880-bafe-11ea-9054-c0484f6432e8.png) | ![image](https://user-images.githubusercontent.com/3392349/86195699-5f392580-bb06-11ea-9dd4-51b07820d2a4.png)
Notice how the transparency decreases the contrast, making it harder to read |

**Dark Mode**
Before | After
-|-
![image](https://user-images.githubusercontent.com/3392349/86192242-f5b51900-bafd-11ea-959c-281a8e3b3a8b.png) | ![image](https://user-images.githubusercontent.com/3392349/86192136-b2f34100-bafd-11ea-9ca6-a7c8202bec01.png)
Notice how the text is almost completely unreadable |

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
