### PR TITLE
fix(tooltip): Set font color for inverted tooltip

### DIFF
--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -55,6 +55,7 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => (
   },
 
   content_inverted: {
+    color: color.base,
     backgroundColor: color.baseInverse,
   },
 


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
Turns out when I made my previous change #386, I didnt account for the fact that the text would always be the default color (which works well against `color.base`, but not so well for `color.baseInverted`).

Since the background will be `baseInverted`, this change sets the foreground color to `base` which, by definition will be contrasting

## Motivation and Context
See above

## Testing
- [x] Storybook

## Screenshots
No visual change for this project, it seems that the colors work well in lunar's storybook, but not for other projects like Nova.

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
