### PR TITLE
fix(Autocomplete): prefix and suffix style

### DIFF
--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -445,8 +445,8 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
     return items;
   }
 
-  getInputProps(props: AutocompleteProps<T>) {
-    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large, prefix, suffix } = props;
+  getInputProps(props: AutocompleteProps<T> & { hasPrefix: boolean; hasSuffix: boolean }) {
+    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large, hasPrefix, hasSuffix } = props;
     const { id } = this.state;
 
     // Should match the props passed within `Input`
@@ -461,8 +461,8 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
       placeholder: placeholder ?? T.phrase('lunar.common.search', 'Search'),
       small,
       large,
-      hasPrefix: !!prefix,
-      hasSuffix: !!suffix,
+      hasPrefix,
+      hasSuffix,
       type: 'text',
     };
   }
@@ -702,13 +702,13 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
 
   render() {
     const { id, open, value } = this.state;
-    const { children, fieldProps } = partitionFieldProps(this.props);
+    const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
 
     return (
       <FormField {...fieldProps} id={id}>
         <div style={{ display: 'block', position: 'relative' }}>
           <BaseInput
-            {...this.getInputProps(this.props)}
+            {...this.getInputProps(inputProps)}
             role="combobox"
             value={value}
             aria-autocomplete="list"

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -446,7 +446,19 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
   }
 
   getInputProps(props: AutocompleteProps<T> & { hasPrefix: boolean; hasSuffix: boolean }) {
-    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large, hasPrefix, hasSuffix } = props;
+    const {
+      disabled,
+      invalid,
+      name,
+      optional,
+      placeholder,
+      onBlur,
+      onFocus,
+      small,
+      large,
+      hasPrefix,
+      hasSuffix,
+    } = props;
     const { id } = this.state;
 
     // Should match the props passed within `Input`

--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -446,7 +446,7 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
   }
 
   getInputProps(props: AutocompleteProps<T>) {
-    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large } = props;
+    const { disabled, invalid, name, optional, placeholder, onBlur, onFocus, small, large, prefix, suffix } = props;
     const { id } = this.state;
 
     // Should match the props passed within `Input`
@@ -461,6 +461,8 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
       placeholder: placeholder ?? T.phrase('lunar.common.search', 'Search'),
       small,
       large,
+      hasPrefix: !!prefix,
+      hasSuffix: !!suffix,
       type: 'text',
     };
   }
@@ -700,13 +702,13 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
 
   render() {
     const { id, open, value } = this.state;
-    const { children, fieldProps, inputProps } = partitionFieldProps(this.props);
+    const { children, fieldProps } = partitionFieldProps(this.props);
 
     return (
       <FormField {...fieldProps} id={id}>
         <div style={{ display: 'block', position: 'relative' }}>
           <BaseInput
-            {...this.getInputProps(inputProps)}
+            {...this.getInputProps(this.props)}
             role="combobox"
             value={value}
             aria-autocomplete="list"


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description

`BaseInput` in `Autocomplete` doesn't receive `hasPrefix` and `hasSuffix` props before, which would cause style bug with `<Prefix />` and `<Suffix />`.

The `hasPrefix` and `hasSuffix` condition check is copied from `partitionFieldProps()` function.

## Motivation and Context

Fix style bug.

## Testing

Looks good in storybook.

## Screenshots

Before:
<img width="216" alt="Screen Shot 2020-07-17 at 4 00 06 PM" src="https://user-images.githubusercontent.com/3402429/87763371-44291e00-c847-11ea-87d4-fd5b8bfaf896.png">

After:
<img width="272" alt="Screen Shot 2020-07-17 at 3 57 52 PM" src="https://user-images.githubusercontent.com/3402429/87763376-45f2e180-c847-11ea-8a71-3d5e1eb5c05b.png">


## Checklist

- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
