### PR TITLE
new(Overlay): Add `enableMouseInteraction` prop

### DIFF
--- a/packages/core/src/components/Overlay/Portal/index.tsx
+++ b/packages/core/src/components/Overlay/Portal/index.tsx
@@ -109,7 +109,7 @@ export class Portal extends React.Component<PortalProps & WithStylesProps, Porta
               className={cx(
                 styles.content,
                 { paddingTop: y, marginLeft: x, minHeight: height },
-                enableMouseInteraction && styles.hasPointerEvents,
+                enableMouseInteraction && styles.withPointerEvents,
               )}
             >
               {children}

--- a/packages/core/src/components/Overlay/Portal/index.tsx
+++ b/packages/core/src/components/Overlay/Portal/index.tsx
@@ -8,6 +8,8 @@ import { styleSheetPortal } from './styles';
 
 export type PortalProps = {
   children?: React.ReactNode;
+  /** Enable userSelect and pointer events. */
+  enableMouseInteraction?: boolean;
   /** True removes the background. */
   noBackground: boolean;
   /** Callback for when the overlay should be closed. */
@@ -86,7 +88,7 @@ export class Portal extends React.Component<PortalProps & WithStylesProps, Porta
   );
 
   render() {
-    const { cx, children, styles, x, y, noBackground } = this.props;
+    const { cx, children, enableMouseInteraction, styles, x, y, noBackground } = this.props;
     const { height } = this.state;
 
     return (
@@ -94,13 +96,21 @@ export class Portal extends React.Component<PortalProps & WithStylesProps, Porta
         <FocusTrap>
           <div
             ref={this.ref}
-            className={cx(styles.container, noBackground ? styles.noBg : styles.opaque)}
+            className={cx(
+              styles.container,
+              !enableMouseInteraction && styles.noUserSelect,
+              noBackground ? styles.noBg : styles.opaque,
+            )}
             role="presentation"
             onClick={this.handleClick}
             onScroll={this.handleScrollThrottled}
           >
             <div
-              className={cx(styles.content, { paddingTop: y, marginLeft: x, minHeight: height })}
+              className={cx(
+                styles.content,
+                { paddingTop: y, marginLeft: x, minHeight: height },
+                enableMouseInteraction && styles.hasPointerEvents,
+              )}
             >
               {children}
             </div>

--- a/packages/core/src/components/Overlay/Portal/styles.ts
+++ b/packages/core/src/components/Overlay/Portal/styles.ts
@@ -12,7 +12,7 @@ export const styleSheetPortal: StyleSheet = ({ color }) => ({
     overflow: 'auto',
   },
 
-  hasPointerEvents: {
+  withPointerEvents: {
     pointerEvents: 'all',
   },
 

--- a/packages/core/src/components/Overlay/Portal/styles.ts
+++ b/packages/core/src/components/Overlay/Portal/styles.ts
@@ -10,12 +10,19 @@ export const styleSheetPortal: StyleSheet = ({ color }) => ({
     right: 0,
     bottom: 0,
     overflow: 'auto',
-    userSelect: 'none',
+  },
+
+  hasPointerEvents: {
+    pointerEvents: 'all',
   },
 
   noBg: {
     pointerEvents: 'none',
     overflow: 'hidden',
+  },
+
+  noUserSelect: {
+    userSelect: 'none',
   },
 
   opaque: {

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -7,6 +7,8 @@ import Portal from './Portal';
 export type OverlayProps = {
   /** Content to display within the overlay. */
   children?: React.ReactNode;
+  /** Enable userSelect and pointer events. */
+  enableMouseInteraction?: boolean;
   /** True to be visible. */
   open?: boolean;
   /** True for non-modal appearance. */
@@ -24,6 +26,7 @@ export type OverlayState = {
 /** An overlay that masks the entire viewport and displays a chunk of content over it. */
 export default class Overlay extends React.PureComponent<OverlayProps, OverlayState> {
   static defaultProps = {
+    enableMouseInteraction: false,
     noBackground: false,
     open: false,
   };
@@ -98,13 +101,15 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
   private handleScroll = throttle(() => this.props.onClose(), 100);
 
   render() {
-    const { onClose, open, children, noBackground } = this.props as Required<OverlayProps>;
+    const { onClose, enableMouseInteraction, open, children, noBackground } = this
+      .props as Required<OverlayProps>;
     const { x, y, targetRectReady } = this.state;
 
     return (
       <div ref={this.ref}>
         {open && targetRectReady && (
           <Portal
+            enableMouseInteraction={enableMouseInteraction}
             x={x}
             y={y}
             noBackground={noBackground}


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description

This PR adds the `enableMouseInteraction` prop to `Overlay` and `Overlay/Portal` to enable mouse events and mouse interaction in Overlays.  In the Overlay portal stylesheet, we extract the `container` class' `userSelect: 'none'` out into a `noUserSelect` class, and introduce the ~`hasPointerEvents`~ `withPointerEvents` class to explicitly enable pointer events in Overlay. These two classes are composed in such a way that there are no breaking changes. 

## Motivation and Context

Overlay's portal implementation is useful for Tooltip and Popover popups, which need to escape their parent divs. The current Popover implementation renders the popup in a div with a set zIndex, which does not let the popup escape a DataTable row, while a plain Tooltip's `<Overlay></Overlay>` popup is able to escape the DataTable as intended.

To allow Popover to use `<Overlay>` for its Portal rendering and positioning logic, we added the ability to enable pointer events in Overlay so that Popover's mouse event based timeout logic and copy-paste functionality could work when implemented with Overlay.

## Testing

Tested in storybook. 

## Screenshots

An overlay without `enableMouseInteraction` prop:
![overlay-no-prop](https://user-images.githubusercontent.com/17525561/88254431-2ce49900-cc6a-11ea-9d64-d6d9bab5d4ee.gif)


An overlay with `enableMouseInteraction` prop (mouse can interact with content in the overlay):
![overlay-with-prop](https://user-images.githubusercontent.com/17525561/88254512-63221880-cc6a-11ea-8671-f9dd30b3c89e.gif)


## Checklist

- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
