### PR TITLE
update(Tooltip): Render Popover's popup in Overlay component

### DIFF
--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -314,23 +314,17 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
           marginTop: above ? -(tooltipHeight + targetRect.height + distance) : distance,
           textAlign: align,
         })}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
-        <div
-          className={cx(styles.content, invert && styles.content_inverted)}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
+        <div className={cx(styles.content, invert && styles.content_inverted)}>
           <Text inverted={invert}>{content}</Text>
         </div>
       </div>
     );
 
-    if (popover) {
-      return open && <div className={cx(styles.popover)}>{popupContent}</div>;
-    }
-
     return (
-      <Overlay noBackground open={open} onClose={this.handleClose}>
+      <Overlay noBackground enableMouseInteraction={popover} open={open} onClose={this.handleClose}>
         {popupContent}
       </Overlay>
     );

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -28,7 +28,7 @@ export type TooltipProps = {
   content: NonNullable<React.ReactNode>;
   /** True to disable tooltip but still show children. */
   disabled?: boolean;
-  /** Manually override calculated horizontal align */
+  /** Manually override calculated horizontal align. */
   horizontalAlign?: 'center' | 'left' | 'right';
   /** True to use a light background with dark text. */
   inverted?: boolean;
@@ -36,7 +36,7 @@ export type TooltipProps = {
   onClose?: () => void;
   /** Callback fired when the tooltip is shown. */
   onShow?: () => void;
-  /** True to enable interactive popover functionality */
+  /** True to enable interactive popover functionality. */
   popover?: boolean;
   /** True to prevent dismissmal on mouse down. */
   remainOnMouseDown?: boolean;
@@ -44,7 +44,7 @@ export type TooltipProps = {
   toggleOnClick?: boolean;
   /** True to add a dotted bottom border. */
   underlined?: boolean;
-  /** Manually override calculated vertical align */
+  /** Manually override calculated vertical align. */
   verticalAlign?: 'above' | 'below';
   /** Width of the tooltip in units. */
   width?: number;

--- a/packages/core/src/components/Tooltip/story.tsx
+++ b/packages/core/src/components/Tooltip/story.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import LoremIpsum from ':storybook/components/LoremIpsum';
 import { withexpandMultiple } from '../Accordion/story';
 import Button from '../Button';
+import DataTable from '../DataTable';
+import { RendererProps } from '../DataTable/types';
 import Text from '../Text';
 import Spacing from '../Spacing';
 import Link from '../Link';
@@ -388,4 +390,53 @@ export function popoverExpandsAndShrinksWithContent() {
 
 popoverExpandsAndShrinksWithContent.story = {
   name: 'Popover expands and shrinks with content.',
+};
+
+export function popoverEscapesDataTableRow() {
+  return (
+    <DataTable
+      showRowDividers
+      data={[
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+        { data: { name: 'John' } },
+      ]}
+      keys={['name']}
+      renderers={{
+        name: ({ row }: RendererProps<{ name: string }>) => {
+          const { name } = row.rowData.data;
+
+          return (
+            <Tooltip
+              popover
+              content={
+                <>
+                  <Text bold>Certified by {name}</Text>
+                  <div>
+                    <LoremIpsum short />
+                  </div>
+                  <Link openInNewWindow href="https://github.com/airbnb/lunar">
+                    Click me!
+                  </Link>
+                </>
+              }
+            >
+              <Text>{name}</Text>
+            </Tooltip>
+          );
+        },
+      }}
+    />
+  );
+}
+
+popoverEscapesDataTableRow.story = {
+  name: 'Popover can escape a DataTable row.',
 };

--- a/packages/core/src/components/Tooltip/styles.ts
+++ b/packages/core/src/components/Tooltip/styles.ts
@@ -58,9 +58,4 @@ export const styleSheetTooltip: StyleSheet = ({ unit, color, pattern, ui }) => (
     color: color.base,
     backgroundColor: color.baseInverse,
   },
-
-  popover: {
-    position: 'absolute',
-    zIndex: 1,
-  },
 });


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
This PR refactors Popover to render inside an `<Overlay>` component, just like the plain tooltip. It also moves the popup `mouseEnter` and `mouseLeave` handlers up to the popup content's outermost div.

Note: We'll want to land #391 first, and then update the target of this PR to master. I set the base of this PR to the Overlay PR to facilitate code review.

## Motivation and Context
The original Popover component rendered in a simple div with a style of `zIndex:1`. This was naive on my part for several reasons: 
1. The Popover would need a much larger zIndex to escape divs with zIndexes potentially much larger than 1. 
2. In our Popover-inside-DataTable use case, the Popover was unable to escape a DataTable row, while a regular Tooltip, which rendered in Overlay's portal, was able to. 

## Testing

Tested with existing unit tests and new story book story.
## Screenshots
![popover-overlay-works](https://user-images.githubusercontent.com/17525561/88256191-6a97f080-cc6f-11ea-8a02-b7ea8144a4b0.gif)

## Checklist

- [x] My code follows the style guide of this project.
- [x] I have updated or added documentation accordingly.
- [x] I have read the CONTRIBUTING document.
