### PR TITLE
update(FormField): Update compact spacing in styles

### DIFF
--- a/packages/core/src/components/FormField/styles.ts
+++ b/packages/core/src/components/FormField/styles.ts
@@ -12,7 +12,7 @@ export const styleSheetFormField: StyleSheet = ({ unit }) => ({
   },
 
   field_compactSpacing: {
-    marginBottom: unit * 2,
+    marginBottom: unit * 1.5,
   },
 
   field_noSpacing: {


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
This PR updates `compactSpacing` of the FormField styles from 16px to 12px, which is used for `CheckboxController` and `RadioButtonController` default spacing.

<!--- Describe your change in detail. -->

## Motivation and Context


For `Checkboxes` and `RadioButtons`,  **16px** between each options looks good when there are subtitles, but is too spacious when there are no subtitles, and **12px** is just right and provides a nice compromise that works regardless of whether there are subtitles. 

And these changes are approved by the Lunar committee earlier this year. 

<!--- Why is this change required? What problem does it solve? -->

## Testing

Tested with local storybook. 

<!--- Please describe in detail how you tested your change. -->

## Screenshots

**Before (16px):**
![image](https://user-images.githubusercontent.com/27188043/88608729-553c1100-d037-11ea-80d7-8cba11ee91c3.png)

**After (12px):**
![image](https://user-images.githubusercontent.com/27188043/88608744-5bca8880-d037-11ea-8069-3077ca675bd0.png)

**Before (16px with subtitles):**
![image](https://user-images.githubusercontent.com/27188043/88608818-7b61b100-d037-11ea-83cd-4b741e2cb172.png)

**After (12px with subtitles):**
![image](https://user-images.githubusercontent.com/27188043/88608824-7ef53800-d037-11ea-8c96-ff1a6069e95a.png)

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
