### PR TITLE
new(Card): Adding two props 'noShadow' and 'selected' for Card

### DIFF
--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -26,7 +26,8 @@ export default function Card({ children, noShadow, overflow, selected, styleShee
 
   return (
     <div
-      className={cx(styles.card,
+      className={cx(
+        styles.card,
         overflow && styles.card_overflow,
         noShadow && styles.card_noShadow,
         selected && styles.card_selected,

--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -26,8 +26,7 @@ export default function Card({ children, noShadow, overflow, selected, styleShee
 
   return (
     <div
-      className={cx(
-        !noShadow && styles.card,
+      className={cx(styles.card,
         overflow && styles.card_overflow,
         noShadow && styles.card_noShadow,
         selected && styles.card_selected,

--- a/packages/core/src/components/Card/index.tsx
+++ b/packages/core/src/components/Card/index.tsx
@@ -8,8 +8,12 @@ export { Content };
 export type CardProps = {
   /** List of `Content`s blocks to contain content. */
   children: NonNullable<React.ReactNode>;
+  /** Hide shadow. */
+  noShadow?: boolean;
   /** Set overflow to be visible. */
   overflow?: boolean;
+  /** Whether the card is selected or not. */
+  selected?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
 };
@@ -17,8 +21,19 @@ export type CardProps = {
 /**
  * An abstract layout to use as a base for cards.
  */
-export default function Card({ children, overflow, styleSheet }: CardProps) {
+export default function Card({ children, noShadow, overflow, selected, styleSheet }: CardProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetCard);
 
-  return <div className={cx(styles.card, overflow && styles.card_overflow)}>{children}</div>;
+  return (
+    <div
+      className={cx(
+        !noShadow && styles.card,
+        overflow && styles.card_overflow,
+        noShadow && styles.card_noShadow,
+        selected && styles.card_selected,
+      )}
+    >
+      {children}
+    </div>
+  );
 }

--- a/packages/core/src/components/Card/story.tsx
+++ b/packages/core/src/components/Card/story.tsx
@@ -326,6 +326,38 @@ asCompact.story = {
   name: 'As compact.',
 };
 
+export function noShadow() {
+  return (
+    <Card noShadow>
+      <Content>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  );
+}
+
+noShadow.story = {
+  name: 'No shadow.',
+};
+
+export function selected() {
+  return (
+    <Card selected>
+      <Content>
+        <Text>
+          <LoremIpsum />
+        </Text>
+      </Content>
+    </Card>
+  );
+}
+
+selected.story = {
+  name: 'Selected.',
+};
+
 export function cardAsAButtonWithMiddleAlignment() {
   return (
     <Card>

--- a/packages/core/src/components/Card/styles.ts
+++ b/packages/core/src/components/Card/styles.ts
@@ -12,11 +12,12 @@ export const styleSheetCard: StyleSheet = ({ color, pattern, ui }) => ({
   },
 
   card_noShadow: {
-    border: ui.border,
+    boxShadow: 'none',
   },
 
   card_selected: {
-    border: `2px solid ${color.core.primary[3]}`,
+    border: ui.borderThick,
+    borderColor: color.core.primary[3],
   },
 });
 

--- a/packages/core/src/components/Card/styles.ts
+++ b/packages/core/src/components/Card/styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from '../../hooks/useStyles';
 
-export const styleSheetCard: StyleSheet = ({ color, pattern }) => ({
+export const styleSheetCard: StyleSheet = ({ color, pattern, ui }) => ({
   card: {
     ...pattern.box,
     background: color.accent.bg,
@@ -9,6 +9,14 @@ export const styleSheetCard: StyleSheet = ({ color, pattern }) => ({
 
   card_overflow: {
     overflow: 'visible',
+  },
+
+  card_noShadow: {
+    border: ui.border,
+  },
+
+  card_selected: {
+    border: `2px solid ${color.core.primary[3]}`,
   },
 });
 

--- a/packages/core/test/components/Card.test.tsx
+++ b/packages/core/test/components/Card.test.tsx
@@ -18,4 +18,36 @@ describe('<Card />', () => {
 
     expect(withoutOverflow.prop('className')).not.toBe(withOverflow.prop('className'));
   });
+
+  it('renders different styles for `noShadow`', () => {
+    const withoutNoShadow = shallow(
+      <Card>
+        <Content>Foo</Content>
+      </Card>,
+    );
+
+    const withNoShadow = shallow(
+      <Card noShadow>
+        <Content>Foo</Content>
+      </Card>,
+    );
+
+    expect(withoutNoShadow.prop('className')).not.toBe(withNoShadow.prop('className'));
+  });
+
+  it('renders different styles for `selected`', () => {
+    const withoutSelected = shallow(
+      <Card>
+        <Content>Foo</Content>
+      </Card>,
+    );
+
+    const withSelected = shallow(
+      <Card selected>
+        <Content>Foo</Content>
+      </Card>,
+    );
+
+    expect(withoutSelected.prop('className')).not.toBe(withSelected.prop('className'));
+  });
 });


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
Add two new props for the `Card` component. 
1.  `noShadow` that hides the shadow of the card.
2. `selected` that shows the border when selected.

<!--- Describe your change in detail. -->

## Motivation and Context
**Background:** 
Some discussions are here https://git.musta.ch/airbnb/solar/issues/978, the design team call out for adding a new variation '`noShadow`' for Card to support some features like the wrapper of checkboxes.

And in the long run, looks like the Lunar team also consider to refactor `clickable button checkboxes` to just being wrapped with `card`, so also adding the `selected` state here in this PR. 

**Design:** [figma](https://www.figma.com/file/JRX1IRigC6oxce2nyFqAZM/Nova-Guides---V2-Features?node-id=1016%3A64864)
![image](https://user-images.githubusercontent.com/27188043/88855327-89364400-d1a7-11ea-9008-16d905d09bd5.png)


<!--- Why is this change required? What problem does it solve? -->

## Testing
Local storybook and unit tests. 
<!--- Please describe in detail how you tested your change. -->

## Screenshots
When there is **noShadow**: 
![image](https://user-images.githubusercontent.com/27188043/88854180-c3064b00-d1a5-11ea-8625-989046dd2812.png)


When **selected**: 
![image](https://user-images.githubusercontent.com/27188043/88854193-c8639580-d1a5-11ea-9b9b-f2404f7c9bdc.png)

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
