### PR TITLE
update(Link): Add `truncated` prop

### DIFF
--- a/packages/core/src/components/Link/index.tsx
+++ b/packages/core/src/components/Link/index.tsx
@@ -23,12 +23,14 @@ export type LinkProps = ButtonOrLinkProps & {
   muted?: boolean;
   /** Decrease font size to small. */
   small?: boolean;
+  /** Truncate the link text with an ellipsis. */
+  truncated?: boolean;
   /** Bold font. */
   bold?: boolean;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
   /** Pass text props to the underlying text. */
-  textProps?: Omit<TextProps, 'children' | 'styleSheet'>;
+  textProps?: Omit<TextProps, 'children' | 'styleSheet' | 'truncated'>;
 };
 
 /** A standard link for... linking to things. */
@@ -42,6 +44,7 @@ function Link({
   micro,
   muted,
   small,
+  truncated,
   bold,
   styleSheet,
   textProps = {},
@@ -61,6 +64,7 @@ function Link({
           disabled && styles.link_disabled,
           block && styles.link_block,
           baseline && styles.link_baseline,
+          truncated && styles.link_truncated,
         )}
       >
         {children}

--- a/packages/core/src/components/Link/story.tsx
+++ b/packages/core/src/components/Link/story.tsx
@@ -115,3 +115,18 @@ export function boldText() {
 boldText.story = {
   name: 'Bold text.',
 };
+
+export function truncatedText() {
+  return (
+    <Link block truncated>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam leo erat, lacinia nec porttitor
+      sed, mollis sed nibh. Nam porta sit amet risus quis interdum. Sed feugiat lorem vitae augue
+      blandit, sed mollis mi laoreet. Donec auctor, enim eget tempus auctor, est lorem laoreet nisi,
+      a rutrum dolor quam eget mi.
+    </Link>
+  );
+}
+
+truncatedText.story = {
+  name: 'Truncated text.',
+};

--- a/packages/core/src/components/Link/styles.ts
+++ b/packages/core/src/components/Link/styles.ts
@@ -65,4 +65,10 @@ export const linkStyleSheet: StyleSheet = ({ color, pattern, transition }) => ({
       textDecoration: 'none',
     },
   },
+
+  link_truncated: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
 });

--- a/packages/core/test/components/Link.test.tsx
+++ b/packages/core/test/components/Link.test.tsx
@@ -85,6 +85,16 @@ describe('<Link />', () => {
     expect(wrapper.find(ButtonOrLink).prop('className')).toMatch('link_muted');
   });
 
+  it('renders truncated', () => {
+    const wrapper = mountUseStyles(
+      <Link truncated href="/">
+        Truncated
+      </Link>,
+    );
+
+    expect(wrapper.find(ButtonOrLink).prop('className')).toMatch('link_truncated');
+  });
+
   it('renders the child component with an inline=false prop when block prop is passed', () => {
     const wrapper = mountUseStyles(
       <Link block href="/foo">


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description

This adds a `truncated` property to links and a `link_truncated` style, as well as a unit test. It also removes `truncated` from the `textProps` because it doesn't work.

## Motivation and Context

Although Link takes in `textProps` to pass to the Text component, `overflow` and `text-overflow` aren't inherited, so the truncation isn't applied. This removes the ability to define `truncated` in the `textProps` and adds a prop to Link so that truncating a Link with ellipsis is possible.

## Testing

I tested this locally in storyguide and added a unit test.

## Screenshots

<img width="417" alt="Screen Shot 2020-07-30 at 4 43 52 PM" src="https://user-images.githubusercontent.com/69016534/88985301-bd336700-d284-11ea-84d7-eaf8ee7bd069.png">


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
