### PR TITLE
update(ImageViewer): Add `dropdownAbove` prop

### DIFF
--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -46,7 +46,7 @@ export type ZoomControlsProps = {
   iconSize?: number | string;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
-  /** Bottom edge of dropdown menu */
+  /** Place dropdown menu above */
   dropdownAbove?: boolean;
 };
 

--- a/packages/core/src/components/ImageViewer/ZoomControls.tsx
+++ b/packages/core/src/components/ImageViewer/ZoomControls.tsx
@@ -46,13 +46,15 @@ export type ZoomControlsProps = {
   iconSize?: number | string;
   /** Custom style sheet. */
   styleSheet?: StyleSheet;
+  /** Bottom edge of dropdown menu */
+  dropdownAbove?: boolean;
 };
 
 /** Zoom controls that can be used with an image viewer component */
 export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetZoomControls);
   const [visible, setVisible] = useState(false);
-  const { onScale, scale = 1, iconSize = '2em' } = props;
+  const { onScale, scale = 1, iconSize = '2em', dropdownAbove } = props;
 
   const zoomOptions = ZOOM_OPTIONS.map((zoom: { label: string; scale: number }) => ({
     ...zoom,
@@ -89,7 +91,13 @@ export default function ZoomControls({ styleSheet, ...props }: ZoomControlsProps
       </ButtonGroup>
 
       {visible && (
-        <Dropdown visible={visible} left="0" zIndex={5} onClickOutside={toggleZoomMenu}>
+        <Dropdown
+          visible={visible}
+          bottom={dropdownAbove ? '100%' : undefined}
+          left="0"
+          zIndex={5}
+          onClickOutside={toggleZoomMenu}
+        >
           <Menu accessibilityLabel={T.phrase('lunar.image.zoomMenu', 'Zoom dropdown menu')}>
             {zoomOptions.map((zoom) => (
               <Item key={zoom.scale} onClick={zoom.handleOnClick}>

--- a/packages/core/src/components/ImageViewer/story.tsx
+++ b/packages/core/src/components/ImageViewer/story.tsx
@@ -6,13 +6,32 @@ import Row from '../Row';
 type ImageViewerDemoProps = {
   width?: string;
   height?: string;
+  controlsBottom?: boolean;
 };
 
-function ImageViewerDemo({ width, height }: ImageViewerDemoProps) {
+function ImageViewerDemo({ width, height, controlsBottom }: ImageViewerDemoProps) {
   const [scale, setScale] = useState(1);
   const [rotation, setRotation] = useState(0);
 
-  return (
+  return controlsBottom ? (
+    <>
+      <ImageViewer
+        alt="Testing"
+        scale={scale}
+        src={space}
+        rotation={rotation}
+        height={height}
+        width={width}
+      />
+      <Row
+        before={
+          <RotateControls rotation={rotation} onRotation={(value: number) => setRotation(value)} />
+        }
+      >
+        <ZoomControls dropdownAbove scale={scale} onScale={(value: number) => setScale(value)} />
+      </Row>
+    </>
+  ) : (
     <>
       <Row
         before={
@@ -62,4 +81,12 @@ export function withSetWidthAndHeightPortrait() {
 
 withSetWidthAndHeightPortrait.story = {
   name: 'With set width and height, portrait.',
+};
+
+export function withControlsBottom() {
+  return <ImageViewerDemo controlsBottom />;
+}
+
+withControlsBottom.story = {
+  name: 'With dropdownAbove set.',
 };


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
We have a use case in Torch to place the zoom controls at the bottom of the screen which results in the dropdown menu being cut off. Adding a prop to override this.

## Motivation and Context
Above

## Testing
Storybook

## Screenshots
![image](https://user-images.githubusercontent.com/17676991/89681517-f46bce80-d8a9-11ea-8150-ca8722046eb2.png)


## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
