### PR TITLE
fix(ImageViewer): Only call document.preventDefault() when dragging

### DIFF
--- a/packages/core/src/components/ImageViewer/index.tsx
+++ b/packages/core/src/components/ImageViewer/index.tsx
@@ -66,11 +66,11 @@ export default function ImageViewer({
   };
 
   const handleMouseMove = (event: MouseEvent) => {
-    event.preventDefault();
-
     if (!dragging) {
       return;
     }
+
+    event.preventDefault();
 
     const xDiff = lastMouseLocation.x - event.pageX;
     const yDiff = lastMouseLocation.y - event.pageY;


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
`document.preventDefault` should only be called when `dragging` is `true`, otherwise it's impossible to highlight text and in the document

## Motivation and Context
Running into this error in Torch

<!--- Why is this change required? What problem does it solve? -->

## Testing
Tested locally in Storybook, added a text component above `<ImageViewer />`, tried to highlight and it didn't work. After this change, highlighting worked.

<!--- Please describe in detail how you tested your change. -->

## Screenshots
No visual diff

<!--- Please provide some screenshots, e.g. before & after or new states. --->

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
