### PR TITLE
fix:[Lightbox] Increase z-index

### DIFF
--- a/packages/core/src/components/Lightbox/index.tsx
+++ b/packages/core/src/components/Lightbox/index.tsx
@@ -148,8 +148,8 @@ export default class Lightbox extends React.PureComponent<LightboxProps, Lightbo
         portal
         visible
         header={header}
-        onClose={onClose}
         styleSheet={styleSheetLightboxSheet}
+        onClose={onClose}
       >
         <LightboxImage
           aside={aside}

--- a/packages/core/src/components/Lightbox/index.tsx
+++ b/packages/core/src/components/Lightbox/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Sheet from '../Sheet';
 import LightboxImage, { LightboxImageProps } from './Image';
 import Header from './Header';
+import { styleSheetLightboxSheet } from './styles';
 
 export type LightboxProps = {
   /** Images to show. */
@@ -140,7 +141,16 @@ export default class Lightbox extends React.PureComponent<LightboxProps, Lightbo
     );
 
     return (
-      <Sheet compact headerShadow noAnimation portal visible header={header} onClose={onClose}>
+      <Sheet
+        compact
+        headerShadow
+        noAnimation
+        portal
+        visible
+        header={header}
+        onClose={onClose}
+        styleSheet={styleSheetLightboxSheet}
+      >
         <LightboxImage
           aside={aside}
           alt={alt}

--- a/packages/core/src/components/Lightbox/styles.ts
+++ b/packages/core/src/components/Lightbox/styles.ts
@@ -1,4 +1,7 @@
+import { ComponentBlock } from 'aesthetic';
+import { Z_INDEX_LIGHTBOX } from '../../constants';
 import { StyleSheet } from '../../hooks/useStyles';
+import { styleSheetSheet } from '../Sheet/styles';
 
 export const styleSheetHeader: StyleSheet = ({ unit }) => ({
   header: {
@@ -49,3 +52,12 @@ export const styleSheetImage: StyleSheet = ({ color, unit }) => ({
     padding: unit * 3,
   },
 });
+
+export const styleSheetLightboxSheet: StyleSheet = (theme) => {
+  const sheetStyle = styleSheetSheet(theme);
+
+  // Override zIndex
+  (sheetStyle.sheet as ComponentBlock).zIndex = Z_INDEX_LIGHTBOX;
+
+  return sheetStyle;
+};

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -102,6 +102,7 @@ export const STATUSES = ['notice', 'info', 'success', 'warning', 'danger', 'mute
 export const BRANDS = ['luxury', 'plus'];
 export const Z_INDEX_MODAL = 2000;
 export const Z_INDEX_PORTAL = 2000; // Same as Modal to fix Tooltip in Modal
+export const Z_INDEX_LIGHTBOX = 2004; // Lightbox is full screen and appears on top of everything else
 export const Z_INDEX_TOAST = 3000;
 
 // EMOJIS


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description
This change increases the z-index of lightbox so that it appears on top of application chrome (headers etc). The lightbox is a full screen image viewer and if things appear on top of it, and block the lightbox controls.

## Motivation and Context
A recent change in a product using lunar caused the lightbox controls to be covered and unusable.

## Testing
- [x] Storybook (looks the same as before, and DOM element has the correct z-index)

## Screenshots
n/a (no visual change)

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
