### PR TITLE
update(Modal): Add optional zIndex to props

### DIFF
--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -46,16 +46,8 @@ export default function Modal({
   return (
     <Portal>
       <div className={cx(containerZIndex, styles.container)}>
-        <div
-          role='presentation'
-          className={cx(styles.wrapper)}
-          onKeyUp={handleKeyUp}
-        >
-          <ModalInner
-            {...props}
-            styleSheet={innerStyleSheet}
-            onClose={onClose}
-          />
+        <div role="presentation" className={cx(styles.wrapper)} onKeyUp={handleKeyUp}>
+          <ModalInner {...props} styleSheet={innerStyleSheet} onClose={onClose} />
         </div>
       </div>
     </Portal>

--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -4,14 +4,23 @@ import Portal from '../Portal';
 import ModalInner, { ModalInnerProps } from './private/Inner';
 import { ESCAPE } from '../../keys';
 import { styleSheetModal } from './styles';
+import { Z_INDEX_MODAL } from '../../constants';
 
 export type ModalProps = ModalInnerProps & {
   /** Custom style sheet. */
   innerStyleSheet?: StyleSheet;
+  /** Z-index of the modal. */
+  zIndex?: number | 'auto';
 };
 
 /** A modal component with a backdrop and a standardized layout. */
-export default function Modal({ onClose, styleSheet, innerStyleSheet, ...props }: ModalProps) {
+export default function Modal({
+  onClose,
+  styleSheet,
+  innerStyleSheet,
+  zIndex,
+  ...props
+}: ModalProps) {
   const [styles, cx] = useStyles(styleSheet ?? styleSheetModal);
 
   const handleClose = (event: React.MouseEvent | React.KeyboardEvent) => {
@@ -32,11 +41,21 @@ export default function Modal({ onClose, styleSheet, innerStyleSheet, ...props }
     };
   }, []);
 
+  const containerZIndex = { zIndex: zIndex ?? Z_INDEX_MODAL };
+
   return (
     <Portal>
-      <div className={cx(styles.container)}>
-        <div role="presentation" className={cx(styles.wrapper)} onKeyUp={handleKeyUp}>
-          <ModalInner {...props} styleSheet={innerStyleSheet} onClose={onClose} />
+      <div className={cx(containerZIndex, styles.container)}>
+        <div
+          role='presentation'
+          className={cx(styles.wrapper)}
+          onKeyUp={handleKeyUp}
+        >
+          <ModalInner
+            {...props}
+            styleSheet={innerStyleSheet}
+            onClose={onClose}
+          />
         </div>
       </div>
     </Portal>

--- a/packages/core/src/components/Modal/styles.ts
+++ b/packages/core/src/components/Modal/styles.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from '../../hooks/useStyles';
-import { Z_INDEX_MODAL } from '../../constants';
 import toRGBA from '../../utils/toRGBA';
 
 export const MODAL_MAX_WIDTH_SMALL = 400;
@@ -14,7 +13,6 @@ export const styleSheetModal: StyleSheet = ({ unit, color }) => ({
     position: 'fixed',
     right: 0,
     top: 0,
-    zIndex: Z_INDEX_MODAL,
   },
 
   wrapper: {


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description

Allow for optional `zIndex` to be passed to Modal.

## Motivation and Context

We want to override z-index for Modals that are in a Lighbox component where a recent change increased the z-index https://github.com/airbnb/lunar/pull/411. This allows to bring such Modals to the front.

## Testing

Tested in storybook

## Screenshots

<img width="1157" alt="Screen Shot 2021-03-15 at 10 16 20 AM" src="https://user-images.githubusercontent.com/4018818/111193629-986fd380-8577-11eb-9eb4-6bb88909bc36.png">

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
