### PR TITLE
release(Apollo): Update to Apollo v3 and GraphQL v15 

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -6,12 +6,6 @@ Provides out of the box support for GraphQL, powered by [Apollo](https://www.apo
 yarn add @airbnb/lunar-apollo
 ```
 
-This package relies on GraphQL related packages to also be installed.
-
-```bash static
-yarn add graphql graphql-tag
-```
-
 ## Setup
 
 Initialize the package to create an Apollo client. The following option settings may be passed to

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -19,29 +19,18 @@
   },
   "peerDependencies": {
     "@airbnb/lunar": "^3.0.0",
-    "graphql": "^14.1.0",
-    "graphql-tag": "^2.10.0",
-    "react": "^16.8.0",
-    "react-apollo": "^3.0.0"
+    "graphql": "^15.5.0",
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@airbnb/lunar-test-utils": "^3.0.2",
-    "@apollo/react-testing": "^3.1.3",
-    "graphql": "^14.6.0",
-    "graphql-tag": "^2.10.3",
+    "graphql": "^15.5.0",
     "react": "^16.13.0",
-    "react-apollo": "^3.1.3",
     "react-test-renderer": "^16.13.1"
   },
   "dependencies": {
+    "@apollo/client": "^3.3.12",
     "@types/lodash": "*",
-    "apollo-cache": "^1.3.4",
-    "apollo-cache-inmemory": "^1.6.5",
-    "apollo-client": "^2.6.8",
-    "apollo-link": "^1.2.13",
-    "apollo-link-error": "^1.1.12",
-    "apollo-link-http": "^1.5.16",
-    "apollo-utilities": "^1.3.3",
     "lodash": "^4.17.15"
   }
 }

--- a/packages/apollo/src/components/Mutation/index.tsx
+++ b/packages/apollo/src/components/Mutation/index.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
+import { MutationResult, MutationFunction, OperationVariables, ApolloError } from '@apollo/client';
 import {
   Mutation as BaseMutation,
   MutationComponentOptions,
-  MutationResult,
-  MutationFunction,
-  OperationVariables,
-} from 'react-apollo';
-import { ApolloError } from 'apollo-client';
+} from '@apollo/client/react/components';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
 import Loader from '@airbnb/lunar/lib/components/Loader';
 import renderElementOrFunction, {

--- a/packages/apollo/src/components/Mutation/story.tsx
+++ b/packages/apollo/src/components/Mutation/story.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import gql from 'graphql-tag';
+import { gql, MutationFunction } from '@apollo/client';
 import Button from '@airbnb/lunar/lib/components/Button';
 import Shimmer from '@airbnb/lunar/lib/components/Shimmer';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
-import { MutationFunction } from 'react-apollo';
-import { MockedProvider } from '@apollo/react-testing';
+import { MockedProvider } from '@apollo/client/testing';
 import Mutation from '.';
 
 const MUTATION = gql`
@@ -109,7 +108,11 @@ customLoadingComponent.story = {
 export function customErrorComponent() {
   return (
     <MockedProvider mocks={[errorMock]} addTypename={false}>
-      <Mutation mutation={MUTATION} error={(error) => <ErrorMessage error={error} />}>
+      <Mutation
+        mutation={MUTATION}
+        variables={variables}
+        error={(error) => <ErrorMessage error={error} />}
+      >
         {(updateUser) => <UpdateButton onUpdate={updateUser} />}
       </Mutation>
     </MockedProvider>

--- a/packages/apollo/src/components/Provider/index.tsx
+++ b/packages/apollo/src/components/Provider/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from '@apollo/client';
 import Apollo from '../..';
 
 export type ProviderProps = {

--- a/packages/apollo/src/components/Query/index.tsx
+++ b/packages/apollo/src/components/Query/index.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  Query as BaseQuery,
-  QueryComponentOptions,
-  QueryResult,
-  OperationVariables,
-} from 'react-apollo';
-import { ApolloError } from 'apollo-client';
+import { QueryResult, OperationVariables, ApolloError } from '@apollo/client';
+import { Query as BaseQuery, QueryComponentOptions } from '@apollo/client/react/components';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
 import Loader from '@airbnb/lunar/lib/components/Loader';
 import renderElementOrFunction, {

--- a/packages/apollo/src/components/Query/story.tsx
+++ b/packages/apollo/src/components/Query/story.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Shimmer from '@airbnb/lunar/lib/components/Shimmer';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
-import { MockedProvider } from '@apollo/react-testing';
-import gql from 'graphql-tag';
+import { MockedProvider } from '@apollo/client/testing';
+import { gql } from '@apollo/client';
 import Query from '.';
 
 const QUERY = gql`

--- a/packages/apollo/src/hooks/useMutation.ts
+++ b/packages/apollo/src/hooks/useMutation.ts
@@ -1,3 +1,3 @@
-import { useMutation } from 'react-apollo';
+import { useMutation } from '@apollo/client';
 
 export default useMutation;

--- a/packages/apollo/src/hooks/useQuery.ts
+++ b/packages/apollo/src/hooks/useQuery.ts
@@ -1,3 +1,3 @@
-import { useQuery } from 'react-apollo';
+import { useQuery } from '@apollo/client';
 
 export default useQuery;

--- a/packages/apollo/src/hooks/useSubscription.ts
+++ b/packages/apollo/src/hooks/useSubscription.ts
@@ -1,3 +1,3 @@
-import { useSubscription } from 'react-apollo';
+import { useSubscription } from '@apollo/client';
 
 export default useSubscription;

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -1,17 +1,20 @@
 import Core from '@airbnb/lunar';
-import { ApolloClient, ApolloClientOptions } from 'apollo-client';
-import { InMemoryCache, InMemoryCacheConfig } from 'apollo-cache-inmemory';
-import { ApolloLink } from 'apollo-link';
-import { onError } from 'apollo-link-error';
-import { HttpLink } from 'apollo-link-http';
+import {
+  ApolloClient,
+  ApolloClientOptions,
+  InMemoryCache,
+  InMemoryCacheConfig,
+  ApolloLink,
+  HttpLink,
+} from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 import Mutation from './components/Mutation';
 import Query from './components/Query';
 import Provider from './components/Provider';
 // @ts-ignore
 import pkg from '../package.json';
 
-export * from 'apollo-client';
-export * from 'apollo-cache-inmemory';
+export * from '@apollo/client';
 
 export { onError, HttpLink, Mutation, Query, Provider };
 

--- a/packages/apollo/src/updaters/removeFromList.ts
+++ b/packages/apollo/src/updaters/removeFromList.ts
@@ -1,22 +1,20 @@
 import { DocumentNode } from 'graphql';
-import get from 'lodash/get';
-import set from 'lodash/set';
-import { DataProxy } from 'apollo-cache';
+import { get, set } from 'lodash/fp';
+import { DataProxy, ApolloCache, StoreObject } from '@apollo/client';
 import prepareQuery from '../utils/prepareQuery';
 import getQueryName from '../utils/getQueryName';
 
 export default function removeFromList<Result, Vars = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<Vars>,
+  docOrQuery: DocumentNode | DataProxy.Query<Vars, Result>,
   listPath: string,
   id: string | number,
   idName: string = 'id',
 ) {
-  const query = prepareQuery<Vars>(docOrQuery);
+  const query = prepareQuery<Result, Vars>(docOrQuery);
 
-  return (cache: DataProxy) => {
+  return (cache: ApolloCache<Result>) => {
     const queryResult = cache.readQuery<Result>(query);
-    const nextResult = { ...queryResult };
-    const list = get(queryResult, listPath);
+    const list = get(listPath, queryResult);
 
     if (typeof list === 'undefined' || !Array.isArray(list)) {
       if (__DEV__) {
@@ -26,10 +24,19 @@ export default function removeFromList<Result, Vars = {}>(
       }
     }
 
-    set(
-      nextResult,
+    const rootItem = listPath.split('.')[0];
+    // @ts-ignore
+    const resultRoot = queryResult[rootItem] as StoreObject;
+    // Evict cache before writeQuery: https://github.com/apollographql/apollo-client/issues/6451
+    cache.evict({
+      id: cache.identify(resultRoot),
+      broadcast: false,
+    });
+
+    const nextResult = set(
       listPath,
       list.filter((item) => (item as { [key: string]: unknown })[idName] !== id),
+      { ...queryResult },
     );
 
     cache.writeQuery({

--- a/packages/apollo/src/utils/prepareQuery.ts
+++ b/packages/apollo/src/utils/prepareQuery.ts
@@ -1,14 +1,14 @@
 import { DocumentNode } from 'graphql';
-import { DataProxy } from 'apollo-cache';
+import { DataProxy } from '@apollo/client';
 
-export default function prepareQuery<Vars = {}>(
-  docOrQuery: DocumentNode | DataProxy.Query<Vars>,
-): DataProxy.Query<Vars> {
+export default function prepareQuery<Result, Vars = {}>(
+  docOrQuery: DocumentNode | DataProxy.Query<Vars, Result>,
+): DataProxy.Query<Vars, Result> {
   const query = docOrQuery;
 
   if ((query as DocumentNode).kind) {
-    return { query } as DataProxy.Query<Vars>;
+    return { query } as DataProxy.Query<Vars, Result>;
   }
 
-  return query as DataProxy.Query<Vars>;
+  return query as DataProxy.Query<Vars, Result>;
 }

--- a/packages/apollo/test/components/Mutation.test.tsx
+++ b/packages/apollo/test/components/Mutation.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { MutationResult, MutationFunction } from 'react-apollo';
+import { gql, MutationResult, MutationFunction } from '@apollo/client';
 import { mount } from 'enzyme';
-import gql from 'graphql-tag';
 import { WrappingComponent } from '@airbnb/lunar-test-utils';
 import Loader from '@airbnb/lunar/lib/components/Loader';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
-import { MockedProvider, MockedResponse, wait } from '@apollo/react-testing';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import Mutation from '../../src/components/Mutation';
+import { wait } from '../utils';
 
 const MUTATION = gql`
   mutation updateSomething($id: Int!, $name: String!) {
@@ -31,8 +31,13 @@ function ApolloComponent({
   );
 }
 
+type Variables = {
+  id: number;
+  name: string;
+};
+
 describe('Mutation', () => {
-  const childHandler = (mutate: MutationFunction<unknown, {}>) => (
+  const childHandler = (mutate: MutationFunction<unknown, Variables>) => (
     <button type="button" onClick={() => mutate({ variables: { id: 123, name: 'Something' } })}>
       Submit
     </button>

--- a/packages/apollo/test/components/Provider.test.tsx
+++ b/packages/apollo/test/components/Provider.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mountWithStyles, WrappingComponent } from '@airbnb/lunar-test-utils';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from '@apollo/client';
 import Apollo from '../../src';
 import Provider from '../../src/components/Provider';
 

--- a/packages/apollo/test/components/Query.test.tsx
+++ b/packages/apollo/test/components/Query.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import { WrappingComponent } from '@airbnb/lunar-test-utils';
 import Loader from '@airbnb/lunar/lib/components/Loader';
 import ErrorMessage from '@airbnb/lunar/lib/components/ErrorMessage';
-import { MockedProvider, MockedResponse, wait } from '@apollo/react-testing';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import Query from '../../src/components/Query';
+import { wait } from '../utils';
 
 const QUERY = gql`
   query getSomething {

--- a/packages/apollo/test/index.test.ts
+++ b/packages/apollo/test/index.test.ts
@@ -1,4 +1,4 @@
-import ApolloClient from 'apollo-client';
+import { ApolloClient } from '@apollo/client';
 import Apollo, { Settings, HttpLink } from '../src';
 
 describe('Apollo', () => {

--- a/packages/apollo/test/updaters/__snapshots__/addToList.test.ts.snap
+++ b/packages/apollo/test/updaters/__snapshots__/addToList.test.ts.snap
@@ -4,13 +4,4 @@ exports[`addToList() errors if mutation data does not exist 1`] = `"Cannot find 
 
 exports[`addToList() errors if property name is not an array 1`] = `"\\"getSomething\\" list \\"something.name\\" is not an array."`;
 
-exports[`addToList() errors if query does not exist in cache 1`] = `
-"Can't find field things on object {
-  \\"something\\": {
-    \\"type\\": \\"id\\",
-    \\"generated\\": false,
-    \\"id\\": \\"something:123\\",
-    \\"typename\\": \\"something\\"
-  }
-}."
-`;
+exports[`addToList() errors if query does not exist in cache 1`] = `"\\"otherQuery\\" list \\"something.things\\" is not an array."`;

--- a/packages/apollo/test/updaters/__snapshots__/removeFromList.test.ts.snap
+++ b/packages/apollo/test/updaters/__snapshots__/removeFromList.test.ts.snap
@@ -2,13 +2,4 @@
 
 exports[`removeFromList() errors if property name is not an array 1`] = `"\\"getSomething\\" list \\"something.name\\" is not an array."`;
 
-exports[`removeFromList() errors if query does not exist in cache 1`] = `
-"Can't find field things on object {
-  \\"something\\": {
-    \\"type\\": \\"id\\",
-    \\"generated\\": false,
-    \\"id\\": \\"something:123\\",
-    \\"typename\\": \\"something\\"
-  }
-}."
-`;
+exports[`removeFromList() errors if query does not exist in cache 1`] = `"\\"otherQuery\\" list \\"things\\" is not an array."`;

--- a/packages/apollo/test/updaters/addToList.test.ts
+++ b/packages/apollo/test/updaters/addToList.test.ts
@@ -1,6 +1,6 @@
-import gql from 'graphql-tag';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { gql, InMemoryCache } from '@apollo/client';
 import addToList from '../../src/updaters/addToList';
+import Apollo from '../../src';
 
 const QUERY = gql`
   query getSomething {
@@ -16,6 +16,16 @@ const QUERY = gql`
 `;
 
 describe('addToList()', () => {
+  Apollo.initialize();
+  Apollo.bootstrapClient();
+
+  const mutationResult = (data?: object) => ({
+    loading: false,
+    called: true,
+    client: Apollo.getClient(),
+    ...data,
+  });
+
   let cache: InMemoryCache;
 
   beforeEach(() => {
@@ -50,20 +60,20 @@ describe('addToList()', () => {
         `,
         'something.things',
         'updateThing',
-      )(cache, {});
+      )(cache, mutationResult());
     }).toThrowErrorMatchingSnapshot();
   });
 
   it('errors if property name is not an array', () => {
     expect(() => {
       // Should be `something.things`
-      addToList(QUERY, 'something.name', 'updateThing')(cache, {});
+      addToList(QUERY, 'something.name', 'updateThing')(cache, mutationResult());
     }).toThrowErrorMatchingSnapshot();
   });
 
   it('errors if mutation data does not exist', () => {
     expect(() => {
-      addToList(QUERY, 'something.things', 'updateThing')(cache, {});
+      addToList(QUERY, 'something.things', 'updateThing')(cache, mutationResult());
     }).toThrowErrorMatchingSnapshot();
   });
 
@@ -72,15 +82,16 @@ describe('addToList()', () => {
       QUERY,
       'something.things',
       'updateThing',
-    )(cache, {
-      data: {
+    )(
+      cache,
+      mutationResult({
         updateThing: {
           id: 3,
           type: 'C',
           __typename: 'thing',
         },
-      },
-    });
+      }),
+    );
 
     expect(cache.readQuery({ query: QUERY })).toEqual({
       something: {

--- a/packages/apollo/test/updaters/removeFromList.test.ts
+++ b/packages/apollo/test/updaters/removeFromList.test.ts
@@ -1,5 +1,4 @@
-import gql from 'graphql-tag';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { gql, InMemoryCache } from '@apollo/client';
 import removeFromList from '../../src/updaters/removeFromList';
 
 const QUERY = gql`
@@ -10,6 +9,12 @@ const QUERY = gql`
       things {
         id
         type
+      }
+      nested {
+        thingies {
+          id
+          type
+        }
       }
     }
   }
@@ -33,6 +38,13 @@ describe('removeFromList()', () => {
             { id: 2, type: 'B', __typename: 'thing' },
             { id: 3, type: 'C', __typename: 'thing' },
           ],
+          nested: {
+            thingies: [
+              { id: 1, type: 'A', __typename: 'thingies' },
+              { id: 2, type: 'B', __typename: 'thingies' },
+            ],
+            __typename: 'nested',
+          },
           __typename: 'something',
         },
       },
@@ -64,6 +76,7 @@ describe('removeFromList()', () => {
 
   it('removes item from list based on ID', () => {
     removeFromList(QUERY, 'something.things', 3)(cache);
+    removeFromList(QUERY, 'something.nested.thingies', 2)(cache);
 
     expect(cache.readQuery({ query: QUERY })).toEqual({
       something: {
@@ -73,6 +86,10 @@ describe('removeFromList()', () => {
           { id: 1, type: 'A', __typename: 'thing' },
           { id: 2, type: 'B', __typename: 'thing' },
         ],
+        nested: {
+          thingies: [{ id: 1, type: 'A', __typename: 'thingies' }],
+          __typename: 'nested',
+        },
         __typename: 'something',
       },
     });

--- a/packages/apollo/test/utils.ts
+++ b/packages/apollo/test/utils.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/apollo/test/utils/getQueryName.test.ts
+++ b/packages/apollo/test/utils/getQueryName.test.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import getQueryName from '../../src/utils/getQueryName';
 
 describe('getQueryName()', () => {

--- a/packages/apollo/test/utils/prepareQuery.test.ts
+++ b/packages/apollo/test/utils/prepareQuery.test.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 import prepareQuery from '../../src/utils/prepareQuery';
 
 describe('prepareQuery()', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,63 +106,24 @@
     enquirer "^2.3.4"
     execa "^4.0.0"
 
-"@apollo/react-common@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
-  integrity sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==
+"@apollo/client@^3.3.12":
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.16.tgz#e4a51b0f86583b18ab81723660e381ef616536c1"
+  integrity sha512-EPTiNpmiU6/vvxpl4lXWQDqS3YddweC1sh/ewCuVP9IK0+xlVGb5vR1yhM/7T3PIJqwz52dGpZyJskmbTfENfQ==
   dependencies:
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-components@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.3.tgz#8f6726847cd9b0eb4b22586b1a038d29aa8b1da4"
-  integrity sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
-    prop-types "^15.7.2"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-hoc@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.3.tgz#5742ee74f57611058f5ea1f966c38fc6429dda7b"
-  integrity sha512-oCPma0uBVPTcYTR5sOvtMbpaWll4xDBvYfKr6YkDorUcQVeNzFu1LK1kmQjJP64bKsaziKYji5ibFaeCnVptmA==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-components" "^3.1.3"
-    hoist-non-react-statics "^3.3.0"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-hooks@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
-  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@wry/equality" "^0.1.9"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-ssr@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.3.tgz#0791280d5b735f42f87dbfe849564e78843045bc"
-  integrity sha512-fUTmEYHxSTX1GA43B8vICxXXplpcEBnDwn0IgdAc3eG0p2YK97ZrJDRFCJ5vD7fyDZsrYhMf+rAI3sd+H2SS+A==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
-    tslib "^1.10.0"
-
-"@apollo/react-testing@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-3.1.3.tgz#d8dd318f58fb6a404976bfa3f8a79e976a5c6562"
-  integrity sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.4.0"
     fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.12.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.15.0"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    ts-invariant "^0.7.0"
     tslib "^1.10.0"
+    zen-observable "^0.8.14"
 
 "@babel/cli@^7.8.4":
   version "7.8.4"
@@ -1490,6 +1451,11 @@
     tar "^4.4.10"
     unique-filename "^1.1.1"
     which "^1.3.1"
+
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
+  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -3297,7 +3263,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=6":
+"@types/node@*", "@types/node@>= 8":
   version "12.12.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.31.tgz#d6b4f9645fee17f11319b508fb1001797425da51"
   integrity sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==
@@ -3663,20 +3629,26 @@
     text-table "^0.2.0"
     webpack-log "^1.1.2"
 
-"@wry/context@^0.4.0":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.4.4.tgz#e50f5fa1d6cfaabf2977d1fda5ae91717f8815f8"
-  integrity sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==
+"@wry/context@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
+  integrity sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==
   dependencies:
-    "@types/node" ">=6"
-    tslib "^1.9.3"
+    tslib "^2.1.0"
 
-"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
-  integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
+"@wry/equality@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.4.0.tgz#474491869a8d0590f4a33fd2a4850a77a0f63408"
+  integrity sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.1.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.0.tgz#3245e74988c4e3033299e479a1bf004430752463"
+  integrity sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==
+  dependencies:
+    tslib "^2.1.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -3977,86 +3949,6 @@ aphrodite@^2.4.0:
     asap "^2.0.3"
     inline-style-prefixer "^5.1.0"
     string-hash "^1.1.3"
-
-apollo-cache-inmemory@^1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.5.tgz#2ccaa3827686f6ed7fb634203dbf2b8d7015856a"
-  integrity sha512-koB76JUDJaycfejHmrXBbWIN9pRKM0Z9CJGQcBzIOtmte1JhEBSuzsOUu7NQgiXKYI4iGoMREcnaWffsosZynA==
-  dependencies:
-    apollo-cache "^1.3.4"
-    apollo-utilities "^1.3.3"
-    optimism "^0.10.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-
-apollo-cache@1.3.4, apollo-cache@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.4.tgz#0c9f63c793e1cd6e34c450f7668e77aff58c9a42"
-  integrity sha512-7X5aGbqaOWYG+SSkCzJNHTz2ZKDcyRwtmvW4mGVLRqdQs+HxfXS4dUS2CcwrAj449se6tZ6NLUMnjko4KMt3KA==
-  dependencies:
-    apollo-utilities "^1.3.3"
-    tslib "^1.10.0"
-
-apollo-client@^2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.8.tgz#01cebc18692abf90c6b3806414e081696b0fa537"
-  integrity sha512-0zvJtAcONiozpa5z5zgou83iEKkBaXhhSSXJebFHRXs100SecDojyUWKjwTtBPn9HbM6o5xrvC5mo9VQ5fgAjw==
-  dependencies:
-    "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.3.4"
-    apollo-link "^1.0.0"
-    apollo-utilities "1.3.3"
-    symbol-observable "^1.0.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.0"
-
-apollo-link-error@^1.1.12:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.12.tgz#e24487bb3c30af0654047611cda87038afbacbf9"
-  integrity sha512-psNmHyuy3valGikt/XHJfe0pKJnRX19tLLs6P6EHRxg+6q6JMXNVLYPaQBkL0FkwdTCB0cbFJAGRYCBviG8TDA==
-  dependencies:
-    apollo-link "^1.2.13"
-    apollo-link-http-common "^0.2.15"
-    tslib "^1.9.3"
-
-apollo-link-http-common@^0.2.15:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz#304e67705122bf69a9abaded4351b10bc5efd6d9"
-  integrity sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==
-  dependencies:
-    apollo-link "^1.2.13"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
-apollo-link-http@^1.5.16:
-  version "1.5.16"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.16.tgz#44fe760bcc2803b8a7f57fc9269173afb00f3814"
-  integrity sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==
-  dependencies:
-    apollo-link "^1.2.13"
-    apollo-link-http-common "^0.2.15"
-    tslib "^1.9.3"
-
-apollo-link@^1.0.0, apollo-link@^1.2.13:
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
-  integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
-  dependencies:
-    apollo-utilities "^1.3.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable-ts "^0.8.20"
-
-apollo-utilities@1.3.3, apollo-utilities@^1.3.0, apollo-utilities@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.3.tgz#f1854715a7be80cd810bc3ac95df085815c0787c"
-  integrity sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==
-  dependencies:
-    "@wry/equality" "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
 
 app-root-dir@^1.0.2:
   version "1.0.2"
@@ -8333,17 +8225,17 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-graphql-tag@^2.10.3:
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
-  integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
-
-graphql@^14.6.0:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
-  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
+graphql-tag@^2.12.0:
+  version "2.12.4"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
+  integrity sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==
   dependencies:
-    iterall "^1.2.2"
+    tslib "^2.1.0"
+
+graphql@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -9464,11 +9356,6 @@ istanbul-reports@^3.0.0:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-iterall@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
-  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 iterate-object@^1.3.2:
   version "1.3.3"
@@ -11511,12 +11398,13 @@ optimal@^4.2.0:
   resolved "https://registry.yarnpkg.com/optimal/-/optimal-4.2.0.tgz#a97d9a12cb543988f2e54b88416b77d9a811ed69"
   integrity sha512-jKFdiBkhJCVMh6oXsGNVFv/huPeFTEdlBtSuwDBYYClFn6lwV0fdRwRhWtpazM1ZMuV+bNNRFMth9SMWvUk3uQ==
 
-optimism@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
-  integrity sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==
+optimism@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.15.0.tgz#c65e694bec7ce439f41e9cb8fc261a72d798125b"
+  integrity sha512-KLKl3Kb7hH++s9ewRcBhmfpXgXF0xQ+JZ3xQFuPjnoT6ib2TDmYyVkKENmGxivsN2G3VRxpXuauCkB4GYOhtPw==
   dependencies:
-    "@wry/context" "^0.4.0"
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -12547,17 +12435,6 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-apollo@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.3.tgz#5d8540b401bba36173b63e6c5e75fa561960c63e"
-  integrity sha512-orCZNoAkgveaK5b75y7fw1MSqSHOU/Wuu9rRFOGmRQBSQVZjvV4DI+hj604rHmuN9+WDABxb5W48wTa0F/xNZQ==
-  dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-components" "^3.1.3"
-    "@apollo/react-hoc" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
-    "@apollo/react-ssr" "^3.1.3"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"
@@ -14440,10 +14317,15 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-symbol-observable@^1.0.2, symbol-observable@^1.2.0:
+symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
+symbol-observable@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
 symbol-tree@^3.2.2:
   version "3.2.4"
@@ -14806,12 +14688,12 @@ ts-dedent@^1.1.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.1.0.tgz#67983940793183dc7c7f820acb66ba02cdc33c6e"
   integrity sha512-CVCvDwMBWZKjDxpN3mU/Dx1v3k+sJgE8nrhXcC9vRopRfoa7vVzilNvHEAUi5jQnmFHpnxDx5jZdI1TpG8ny2g==
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
-  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
+ts-invariant@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.7.3.tgz#13aae22a4a165393aaf5cecdee45ef4128d358b8"
+  integrity sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.1.0"
 
 ts-jest@^24.1.0:
   version "24.1.0"
@@ -14849,6 +14731,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -15818,18 +15705,10 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zen-observable-ts@^0.8.20:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz#44091e335d3fcbc97f6497e63e7f57d5b516b163"
-  integrity sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==
-  dependencies:
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
-
-zen-observable@^0.8.0:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.14.tgz#d33058359d335bc0db1f0af66158b32872af3bf7"
-  integrity sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==
+zen-observable@^0.8.14:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zip-stream@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
to: @williaster @alecklandgraf

## Description

Update Apollo client to v3 and GraphQL v15

## Motivation and Context

Apollo client [v3](https://www.apollographql.com/blog/announcing-the-release-of-apollo-client-3-0/) has been out for quite some time and we want to make sure Lunar is up to date. This release contains quite a few breaking changes so this PR is following the [migration guide](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/) consolidating packages to `@apollo/client` and taking care of breaking changes.

This PR also updates GraphQL to [v15](https://github.com/graphql/graphql-js/releases/tag/v15.0.0) making sure we're up to date.

Also migrated to use `lodash/fp`.

## Testing

Updated unit tests. Tested in Storybook.

## Screenshots

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
