### PR TITLE
fix(Autocomplete): Set items only for valid promise

### DIFF
--- a/packages/core/src/components/Autocomplete/index.tsx
+++ b/packages/core/src/components/Autocomplete/index.tsx
@@ -536,6 +536,10 @@ export default class Autocomplete<T extends Item = Item> extends React.Component
           loading: false,
         };
 
+        if (input !== this.state.value) {
+          delete nextState['items'];
+        }
+
         if (callback) {
           this.setState(nextState, callback);
         } else {

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -204,7 +204,7 @@ describe('<Autocomplete />', () => {
 
       wrapper.find(BaseInput).simulate('keydown', { key: 'ArrowDown', preventDefault: jest.fn() });
 
-      setTimeout(() => expect(wrapper.state('highlightedIndex')).toBe(0), 0);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
     });
 
     it('supports `ArrowDown` event and does not set state if no items', () => {
@@ -215,8 +215,7 @@ describe('<Autocomplete />', () => {
 
       wrapper.find(BaseInput).simulate('keydown', { key: 'ArrowDown', preventDefault: jest.fn() });
 
-      // @ts-ignore
-      setTimeout(() => expect(wrapper.state('highlightedIndex')).toBeNull(), 0);
+      expect(wrapper.state('highlightedIndex')).toBeNull();
     });
 
     it('supports `ArrowUp` event and sets state', () => {
@@ -230,8 +229,7 @@ describe('<Autocomplete />', () => {
 
       wrapper.find(BaseInput).simulate('keydown', { key: 'ArrowUp', preventDefault: jest.fn() });
 
-      // @ts-ignore
-      setTimeout(() => expect(wrapper.state('highlightedIndex')).toBe(2), 0);
+      expect(wrapper.state('highlightedIndex')).toBe(1);
     });
 
     it('supports `ArrowUp` event and does not set state if no items', () => {
@@ -242,8 +240,7 @@ describe('<Autocomplete />', () => {
 
       wrapper.find(BaseInput).simulate('keydown', { key: 'ArrowUp', preventDefault: jest.fn() });
 
-      // @ts-ignore
-      setTimeout(() => expect(wrapper.state('highlightedIndex')).toBeNull(), 0);
+      expect(wrapper.state('highlightedIndex')).toBeNull();
     });
 
     it('supports `Escape` event', () => {
@@ -257,11 +254,8 @@ describe('<Autocomplete />', () => {
       wrapper.find(BaseInput).simulate('keydown', { key: 'Escape' });
 
       expect(instance.ignoreBlur).toBe(false);
-
-      setTimeout(() => {
-        expect(wrapper.state('highlightedIndex')).toBeNull();
-        expect(wrapper.state('open')).toBe(false);
-      }, 0);
+      expect(wrapper.state('highlightedIndex')).toBeNull();
+      expect(wrapper.state('open')).toBe(false);
     });
 
     it('supports `Tab` event', () => {
@@ -339,9 +333,7 @@ describe('<Autocomplete />', () => {
     });
 
     it('supports `Enter` event - text entered + menu item has been highlighted + enter is hit', () => {
-      const spy = jest.fn();
       const input = document.createElement('input');
-      input.focus = spy;
       instance.inputRef = { current: input };
       instance.ignoreBlur = true;
 
@@ -359,18 +351,16 @@ describe('<Autocomplete />', () => {
         .find(BaseInput)
         .simulate('keydown', { key: 'Enter', keyCode: 13, preventDefault: jest.fn() });
 
-      setTimeout(() => {
-        expect(instance.ignoreBlur).toBe(false);
-        expect(wrapper.state('open')).toBe(false);
-        expect(wrapper.state('highlightedIndex')).toBeNull();
-        expect(spy).toHaveBeenCalled();
-      }, 0);
+      expect(instance.ignoreBlur).toBe(false);
+      expect(wrapper.state('open')).toBe(false);
+      expect(wrapper.state('highlightedIndex')).toBeNull();
     });
   });
 
   describe('handleSelect()', () => {
     it('calls `onSelectItem` prop with found item', () => {
       const spy = jest.fn();
+      const pdSpy = jest.fn();
 
       wrapper.setProps({
         onSelectItem: spy,
@@ -382,11 +372,18 @@ describe('<Autocomplete />', () => {
           { value: 'foo', name: 'Foo' },
         ],
         highlightedIndex: 1,
+        open: true,
       });
 
-      wrapper.find(BaseInput).simulate('keydown', { key: 'Enter' });
+      wrapper
+        .find(BaseInput)
+        .simulate('keydown', { key: 'Enter', keyCode: 13, preventDefault: pdSpy });
 
-      setTimeout(() => expect(spy).toHaveBeenCalledWith({ value: 'foo', name: 'Foo' }), 0);
+      expect(spy).toHaveBeenCalledWith(
+        'foo',
+        { value: 'foo', name: 'Foo' },
+        { key: 'Enter', keyCode: 13, preventDefault: pdSpy },
+      );
     });
 
     it('clears the value when selected', () => {
@@ -401,13 +398,14 @@ describe('<Autocomplete />', () => {
         ],
         highlightedIndex: 1,
         value: 'foo',
+        open: true,
       });
 
-      wrapper.find(BaseInput).simulate('keydown', { key: 'Enter' });
+      wrapper
+        .find(BaseInput)
+        .simulate('keydown', { key: 'Enter', keyCode: 13, preventDefault: jest.fn() });
 
-      setTimeout(() => {
-        expect(wrapper.state('value')).toBe('');
-      }, 0);
+      expect(wrapper.state('value')).toBe('');
     });
   });
 

--- a/packages/core/test/components/Autocomplete.test.tsx
+++ b/packages/core/test/components/Autocomplete.test.tsx
@@ -617,6 +617,94 @@ describe('<Autocomplete />', () => {
       );
     });
 
+    it('handles success with multiple promises, first promise resolves first', async () => {
+      jest.spyOn(instance, 'loadItemsDebounced').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({
+                input: 'foo',
+                response: { results: [{ id: 7 }, { id: 8 }, { id: 9 }] },
+              });
+            }, 50);
+          }),
+      );
+      wrapper.setState({
+        value: 'foo',
+      });
+      const firstPromise = instance.loadItems('foo');
+
+      jest.spyOn(instance, 'loadItemsDebounced').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({
+                input: 'bar',
+                response: { results: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+              });
+            }, 100);
+          }),
+      );
+      wrapper.setState({
+        value: 'bar',
+      });
+      const secondPromise = instance.loadItems('bar');
+
+      await firstPromise;
+      await secondPromise;
+
+      expect(wrapper.state()).toEqual(
+        expect.objectContaining({
+          items: [{ id: 10 }, { id: 11 }, { id: 12 }],
+          loading: false,
+        }),
+      );
+    });
+
+    it('handles success with multiple promises, second promise resolves first', async () => {
+      jest.spyOn(instance, 'loadItemsDebounced').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({
+                input: 'foo',
+                response: { results: [{ id: 7 }, { id: 8 }, { id: 9 }] },
+              });
+            }, 100);
+          }),
+      );
+      wrapper.setState({
+        value: 'foo',
+      });
+      const firstPromise = instance.loadItems('foo');
+
+      jest.spyOn(instance, 'loadItemsDebounced').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({
+                input: 'bar',
+                response: { results: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+              });
+            }, 50);
+          }),
+      );
+      wrapper.setState({
+        value: 'bar',
+      });
+      const secondPromise = instance.loadItems('bar');
+
+      await firstPromise;
+      await secondPromise;
+
+      expect(wrapper.state()).toEqual(
+        expect.objectContaining({
+          items: [{ id: 10 }, { id: 11 }, { id: 12 }],
+          loading: false,
+        }),
+      );
+    });
+
     it('handles error', async () => {
       jest
         .spyOn(instance, 'loadItemsDebounced')


### PR DESCRIPTION
to: @alecklandgraf

## Description

<!--- Describe your change in detail. -->

Set items only for valid promise.
If these are multiple promises, the last promise would set items. This could confuse user.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

If user inputs `a`, and the first promise is in pending.
And then user inputs more character `abc`, and the second promise is in pending.
If the second promise resolves first, the `items` would be set to the result of the first promise. It would confuse user.

## Testing

<!--- Please describe in detail how you tested your change. -->

Unit tests.

## Screenshots

<!--- Please provide some screenshots, e.g. before & after or new states. --->

N/A

## Checklist

- My code follows the style guide of this project.
- I have updated or added documentation accordingly.
- I have read the CONTRIBUTING document.
